### PR TITLE
feat(backend): enable CORS support

### DIFF
--- a/PLAN/TICKETS.md
+++ b/PLAN/TICKETS.md
@@ -69,6 +69,8 @@ Build a production-ready internal UI that lets an analyst:
 - New data source appears in list without full page refresh.
 - Validation errors are shown inline.
 
+## Ticket BE-003: Enable CORS support for Frontend (Issue #53) [DONE]
+
 ## Ticket UI-004: Introspection Flow and Status UX [DONE]
 
 - Objective: Trigger introspection and provide status feedback.

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -1195,6 +1195,17 @@ function startServer() {
     req.requestId = requestId;
     res.setHeader("x-request-id", requestId);
 
+    // CORS
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, x-user-id");
+
+    if (req.method === "OPTIONS") {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
     res.on("finish", () => {
       logEvent("http_request", {
         request_id: requestId,


### PR DESCRIPTION
Fixes #53 
Enabled CORS in the backend to allow frontend communication.
- Added CORS headers
- Handled OPTIONS preflight requests