### PR TITLE
feat: Export Delivery API - download + email (BE-002)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,11 @@ RAG_EMBED_MODEL_GEMINI=text-embedding-004
 OPENAI_API_KEY=
 GEMINI_API_KEY=
 DEEPSEEK_API_KEY=
+
+# SMTP config for email delivery (BE-002)
+SMTP_HOST=localhost
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=AI-DB Reports <noreply@ai-db.local>

--- a/app/src/services/deliveryService.js
+++ b/app/src/services/deliveryService.js
@@ -1,0 +1,173 @@
+const appDb = require("../lib/appDb");
+const { exportQueryResult, SUPPORTED_FORMATS } = require("./exportService");
+const { sendExportEmail } = require("./emailService");
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Validate an array of email addresses.
+ * @param {string[]} emails
+ * @returns {{ok: boolean, invalid: string[]}}
+ */
+function validateRecipients(emails) {
+  const invalid = emails.filter((e) => !EMAIL_REGEX.test(e));
+  return { ok: invalid.length === 0, invalid };
+}
+
+/**
+ * Create a delivery record and, for email mode, kick off async delivery.
+ *
+ * @param {Object} opts
+ * @param {string} opts.sessionId
+ * @param {string} opts.deliveryMode  'download' | 'email'
+ * @param {string} opts.format        'json' | 'csv' | 'xlsx'
+ * @param {string[]} [opts.recipients]
+ * @param {string} opts.requestedBy
+ * @returns {Promise<Object>} delivery record (for download mode includes buffer)
+ */
+async function createDelivery({ sessionId, deliveryMode, format, recipients, requestedBy }) {
+  if (!SUPPORTED_FORMATS.has(format)) {
+    throw Object.assign(new Error(`Unsupported format: ${format}`), { statusCode: 400 });
+  }
+
+  if (deliveryMode === "email") {
+    if (!recipients || recipients.length === 0) {
+      throw Object.assign(new Error("recipients are required for email delivery"), { statusCode: 400 });
+    }
+    const validation = validateRecipients(recipients);
+    if (!validation.ok) {
+      throw Object.assign(
+        new Error(`Invalid recipient email(s): ${validation.invalid.join(", ")}`),
+        { statusCode: 400 }
+      );
+    }
+  }
+
+  // Insert delivery record
+  const insertResult = await appDb.query(
+    `
+      INSERT INTO export_deliveries (session_id, delivery_mode, format, recipients, status, requested_by)
+      VALUES ($1, $2, $3, $4, 'pending', $5)
+      RETURNING id, status, created_at
+    `,
+    [sessionId, deliveryMode, format, recipients || null, requestedBy]
+  );
+
+  const delivery = insertResult.rows[0];
+
+  if (deliveryMode === "download") {
+    // Synchronous: generate export and return file
+    try {
+      const { buffer, contentType, filename } = await exportQueryResult(sessionId, format);
+
+      await appDb.query(
+        `
+          UPDATE export_deliveries
+          SET status = 'completed', file_name = $2, file_size_bytes = $3, completed_at = NOW()
+          WHERE id = $1
+        `,
+        [delivery.id, filename, buffer.length]
+      );
+
+      return {
+        id: delivery.id,
+        status: "completed",
+        delivery_mode: "download",
+        buffer,
+        contentType,
+        filename
+      };
+    } catch (err) {
+      await appDb.query(
+        `
+          UPDATE export_deliveries
+          SET status = 'failed', error_message = $2, completed_at = NOW()
+          WHERE id = $1
+        `,
+        [delivery.id, err.message]
+      );
+      throw err;
+    }
+  }
+
+  // Email mode: run async
+  processEmailDelivery(delivery.id, sessionId, format, recipients).catch((err) => {
+    console.error(`[delivery] Email delivery ${delivery.id} failed: ${err.message}`);
+  });
+
+  return {
+    id: delivery.id,
+    status: "processing",
+    delivery_mode: "email"
+  };
+}
+
+/**
+ * Process email delivery asynchronously.
+ */
+async function processEmailDelivery(deliveryId, sessionId, format, recipients) {
+  await appDb.query(
+    "UPDATE export_deliveries SET status = 'processing' WHERE id = $1",
+    [deliveryId]
+  );
+
+  try {
+    const { buffer, contentType, filename } = await exportQueryResult(sessionId, format);
+
+    // Fetch session question for email subject
+    const sessionResult = await appDb.query(
+      "SELECT question FROM query_sessions WHERE id = $1",
+      [sessionId]
+    );
+    const question = sessionResult.rows[0]?.question || "Query Export";
+
+    await sendExportEmail({
+      recipients,
+      subject: `AI-DB Export: ${question.substring(0, 80)}`,
+      textBody: `Your requested export for the query "${question}" is attached.\n\nFormat: ${format.toUpperCase()}\nFile: ${filename}`,
+      fileBuffer: buffer,
+      fileName: filename,
+      contentType
+    });
+
+    await appDb.query(
+      `
+        UPDATE export_deliveries
+        SET status = 'completed', file_name = $2, file_size_bytes = $3, completed_at = NOW()
+        WHERE id = $1
+      `,
+      [deliveryId, filename, buffer.length]
+    );
+  } catch (err) {
+    await appDb.query(
+      `
+        UPDATE export_deliveries
+        SET status = 'failed', error_message = $2, completed_at = NOW()
+        WHERE id = $1
+      `,
+      [deliveryId, err.message]
+    );
+    throw err;
+  }
+}
+
+/**
+ * Fetch a delivery record by ID.
+ * @param {string} exportId
+ * @returns {Promise<Object|null>}
+ */
+async function getDeliveryStatus(exportId) {
+  const result = await appDb.query(
+    `
+      SELECT id, session_id, delivery_mode, format, recipients, status, error_message,
+             file_name, file_size_bytes, requested_by, created_at, completed_at
+      FROM export_deliveries
+      WHERE id = $1
+    `,
+    [exportId]
+  );
+
+  return result.rows[0] || null;
+}
+
+module.exports = { createDelivery, getDeliveryStatus };

--- a/app/src/services/emailService.js
+++ b/app/src/services/emailService.js
@@ -1,0 +1,56 @@
+const nodemailer = require("nodemailer");
+
+const SMTP_HOST = process.env.SMTP_HOST || "localhost";
+const SMTP_PORT = Number(process.env.SMTP_PORT || 587);
+const SMTP_SECURE = String(process.env.SMTP_SECURE || "false") === "true";
+const SMTP_USER = process.env.SMTP_USER || "";
+const SMTP_PASS = process.env.SMTP_PASS || "";
+const SMTP_FROM = process.env.SMTP_FROM || "AI-DB Reports <noreply@ai-db.local>";
+
+let transporter = null;
+
+function getTransporter() {
+  if (!transporter) {
+    transporter = nodemailer.createTransport({
+      host: SMTP_HOST,
+      port: SMTP_PORT,
+      secure: SMTP_SECURE,
+      auth: SMTP_USER ? { user: SMTP_USER, pass: SMTP_PASS } : undefined
+    });
+  }
+  return transporter;
+}
+
+/**
+ * Send an email with an export file attached.
+ *
+ * @param {Object} opts
+ * @param {string[]} opts.recipients
+ * @param {string} opts.subject
+ * @param {string} opts.textBody
+ * @param {Buffer} opts.fileBuffer
+ * @param {string} opts.fileName
+ * @param {string} opts.contentType
+ * @returns {Promise<{messageId: string}>}
+ */
+async function sendExportEmail({ recipients, subject, textBody, fileBuffer, fileName, contentType }) {
+  const transport = getTransporter();
+
+  const info = await transport.sendMail({
+    from: SMTP_FROM,
+    to: recipients.join(", "),
+    subject,
+    text: textBody,
+    attachments: [
+      {
+        filename: fileName,
+        content: fileBuffer,
+        contentType
+      }
+    ]
+  });
+
+  return { messageId: info.messageId };
+}
+
+module.exports = { sendExportEmail };

--- a/db/migrations/0004_export_deliveries.sql
+++ b/db/migrations/0004_export_deliveries.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS export_deliveries (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  session_id UUID NOT NULL REFERENCES query_sessions(id),
+  delivery_mode TEXT NOT NULL CHECK (delivery_mode IN ('download', 'email')),
+  format TEXT NOT NULL CHECK (format IN ('json', 'csv', 'xlsx')),
+  recipients TEXT[],
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+  error_message TEXT,
+  file_name TEXT,
+  file_size_bytes BIGINT,
+  requested_by TEXT NOT NULL DEFAULT 'anonymous',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_export_deliveries_session_id ON export_deliveries(session_id);
+CREATE INDEX IF NOT EXISTS idx_export_deliveries_status ON export_deliveries(status);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -8,6 +8,7 @@ servers:
     description: Local runtime (same origin)
 tags:
   - name: Query
+  - name: Export
   - name: Admin
   - name: Providers
   - name: Observability
@@ -67,6 +68,66 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OkResponse"
+  /v1/query/sessions/{sessionId}/export/deliver:
+    post:
+      tags: [Export]
+      summary: Deliver an export via download or email
+      parameters:
+        - $ref: "#/components/parameters/SessionId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExportDeliverRequest"
+      responses:
+        "200":
+          description: Download file (when delivery_mode is download)
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          headers:
+            x-export-id:
+              schema:
+                type: string
+              description: Export delivery tracking ID
+        "202":
+          description: Email delivery accepted (async)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExportDeliverAccepted"
+  /v1/exports/{exportId}/status:
+    get:
+      tags: [Export]
+      summary: Check export delivery status
+      parameters:
+        - in: path
+          name: exportId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Delivery status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExportDeliveryStatus"
+        "404":
+          description: Export delivery not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required: [error, message]
   /v1/data-sources:
     get:
       tags: [Admin]
@@ -613,3 +674,71 @@ components:
           type: object
           additionalProperties: true
       required: [run_date, dataset_file, summary]
+    ExportDeliverRequest:
+      type: object
+      properties:
+        delivery_mode:
+          type: string
+          enum: [download, email]
+        format:
+          type: string
+          enum: [json, csv, xlsx]
+          default: json
+        recipients:
+          type: array
+          items:
+            type: string
+            format: email
+          description: Required when delivery_mode is email
+      required: [delivery_mode]
+    ExportDeliverAccepted:
+      type: object
+      properties:
+        export_id:
+          type: string
+        status:
+          type: string
+          enum: [processing]
+        delivery_mode:
+          type: string
+          enum: [email]
+      required: [export_id, status, delivery_mode]
+    ExportDeliveryStatus:
+      type: object
+      properties:
+        id:
+          type: string
+        session_id:
+          type: string
+        delivery_mode:
+          type: string
+          enum: [download, email]
+        format:
+          type: string
+          enum: [json, csv, xlsx]
+        recipients:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          enum: [pending, processing, completed, failed]
+        error_message:
+          type: string
+          nullable: true
+        file_name:
+          type: string
+          nullable: true
+        file_size_bytes:
+          type: integer
+          nullable: true
+        requested_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+      required: [id, session_id, delivery_mode, format, status, requested_by, created_at]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "csv-stringify": "^6.6.0",
         "node-sql-parser": "^5.3.8",
+        "nodemailer": "^8.0.1",
         "pg": "^8.13.1",
         "xlsx": "^0.18.5"
       },
@@ -104,12 +105,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/pg": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "csv-stringify": "^6.6.0",
     "node-sql-parser": "^5.3.8",
+    "nodemailer": "^8.0.1",
     "pg": "^8.13.1",
     "xlsx": "^0.18.5"
   }


### PR DESCRIPTION
## Summary
- Add `POST /v1/query/sessions/{id}/export/deliver` endpoint with two delivery modes: `download` (synchronous file response) and `email` (async with nodemailer)
- Add `GET /v1/exports/{export_id}/status` endpoint for tracking email delivery progress
- Add `export_deliveries` table (migration 0004) for auditable delivery tracking with status lifecycle (pending → processing → completed/failed)
- Email delivery validates recipients, attaches export file, and tracks completion/failure asynchronously
- SMTP config via environment variables (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`)

## Test plan
- [ ] Run migration and verify `export_deliveries` table is created
- [ ] Test download delivery: `POST /v1/query/sessions/{id}/export/deliver` with `{"delivery_mode": "download", "format": "csv"}` returns file
- [ ] Test email delivery: same endpoint with `{"delivery_mode": "email", "format": "xlsx", "recipients": ["test@example.com"]}` returns 202 with `export_id`
- [ ] Test status tracking: `GET /v1/exports/{export_id}/status` shows delivery progress
- [ ] Test validation: invalid emails rejected, missing recipients for email mode rejected
- [ ] Test error states: non-existent session returns 404, unsupported format returns 400

Closes #20