### PR TITLE
feat: Remove data source endpoint and UI action (BE-003)

### DIFF
--- a/PLAN/TICKETS.md
+++ b/PLAN/TICKETS.md
@@ -313,6 +313,21 @@ Build a production-ready internal UI that lets an analyst:
 - Failed deliveries surface actionable status and error reason.
 - Delivery events are auditable.
 
+## Ticket BE-003: Remove Data Source API and UI Action [DONE]
+
+- Objective: Allow users to delete a data source and its dependent data (schema objects, semantic entities, etc.).
+- Scope:
+- `DELETE /v1/data-sources/{id}` backend endpoint with cascading cleanup.
+- Trash icon action button in the Data Sources list UI with confirmation dialog.
+- APIs:
+- `DELETE /v1/data-sources/{id}`
+- Acceptance Criteria:
+- User can remove a data source from the list via an action button.
+- Confirmation dialog prevents accidental deletion.
+- Backend cascades deletion to dependent schema objects, semantic entities, metric definitions, join policies, and RAG documents.
+- Success toast confirms removal and list refreshes without full page reload.
+- Attempting to delete a non-existent data source returns 404.
+
 ---
 
 ## Suggested Delivery Sequence

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -132,6 +132,19 @@ async function handleListDataSources(_req, res) {
   return json(res, 200, { items: result.rows });
 }
 
+async function handleDeleteDataSource(_req, res, dataSourceId) {
+  const result = await appDb.query(
+    "DELETE FROM data_sources WHERE id = $1 RETURNING id",
+    [dataSourceId]
+  );
+
+  if (result.rowCount === 0) {
+    return json(res, 404, { error: "not_found", message: "Data source not found" });
+  }
+
+  return json(res, 200, { ok: true, id: dataSourceId });
+}
+
 async function runIntrospectionJob(jobId, dataSource) {
   try {
     await appDb.query(
@@ -1179,6 +1192,11 @@ async function routeRequest(req, res) {
 
   if (req.method === "GET" && pathname === "/v1/data-sources") {
     return handleListDataSources(req, res);
+  }
+
+  const deleteDataSourceMatch = pathname.match(/^\/v1\/data-sources\/([^/]+)$/);
+  if (req.method === "DELETE" && deleteDataSourceMatch) {
+    return handleDeleteDataSource(req, res, deleteDataSourceMatch[1]);
   }
 
   const introspectMatch = pathname.match(/^\/v1\/data-sources\/([^/]+)\/introspect$/);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -155,6 +155,31 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DataSourceResponse"
+  /v1/data-sources/{dataSourceId}:
+    delete:
+      tags: [Admin]
+      summary: Delete a data source and its dependent data
+      parameters:
+        - $ref: "#/components/parameters/DataSourceId"
+      responses:
+        "200":
+          description: Data source deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "404":
+          description: Data source not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required: [error, message]
   /v1/data-sources/{dataSourceId}/introspect:
     post:
       tags: [Admin]

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -188,6 +188,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/data-sources/{dataSourceId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a data source and its dependent data */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    dataSourceId: components["parameters"]["DataSourceId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Data source deleted */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OkResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/data-sources/{dataSourceId}/introspect": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Summary
- Add `DELETE /v1/data-sources/{id}` backend endpoint — cascading cleanup handled by existing `ON DELETE CASCADE` foreign keys on all dependent tables (schema_objects, semantic_entities, join_policies, query_sessions, rag_documents, etc.)
- Add trash icon button with inline confirm/cancel to the Data Sources list Actions column
- Update OpenAPI spec and frontend API types for the new endpoint

## Test plan
- [ ] Delete a data source via the UI trash button — confirm dialog appears
- [ ] Click "Confirm" — data source removed, toast shown, list refreshes
- [ ] Click "Cancel" — no deletion, confirmation dismissed
- [ ] Verify dependent data (schema objects, semantic entities) is cascade-deleted
- [ ] `DELETE /v1/data-sources/{nonexistent-uuid}` returns 404

Closes #60