### PR TITLE
[codex] fix dashboard/query routing and dashboard nav target

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
       <Toaster position="top-right" richColors />
       <Routes>
         <Route element={<AppShell />}>
-          <Route path="/" element={<QueryWorkspace />} />
+          <Route path="/" element={<Dashboard />} />
           <Route path="/query" element={<QueryWorkspace />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/data-sources" element={<DataSources />} />

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -15,7 +15,7 @@ import styles from './AppShell.module.css';
 import { useDataSource } from '../../hooks/useDataSource';
 
 const NAV_ITEMS = [
-    { path: '/', label: 'Dasbhoard', icon: LayoutDashboard },
+    { path: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { path: '/data-sources', label: 'Data Sources', icon: Database },
     { path: '/llm-providers', label: 'LLM Providers', icon: Server },
     { path: '/schema', label: 'Schema Explorer', icon: Layers },

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -6,7 +6,7 @@ export const NotFound: React.FC = () => {
         <div className="flex flex-col items-center justify-center h-screen bg-gray-100">
             <h1 className="text-4xl font-bold mb-4">404 - Page Not Found</h1>
             <p className="mb-6">The page you are looking for does not exist.</p>
-            <Link to="/" className="text-blue-600 hover:underline">
+            <Link to="/dashboard" className="text-blue-600 hover:underline">
                 Go back to Dashboard
             </Link>
         </div>


### PR DESCRIPTION
## Summary
This PR fixes navigation/routing inconsistencies between Dashboard and Query Workspace so they are clearly separate destinations in the UI.

Closes #66.

## User Impact
Before this change, selecting "Dashboard" in the sidebar sent users to `/`, which rendered the Query Workspace. At the same time, a dedicated `/dashboard` route existed but was not reachable from sidebar navigation. This made the information architecture confusing and made the Dashboard page appear broken or missing.

After this change, Dashboard and Query Workspace are distinct and predictable:
- Dashboard is rendered at `/` and `/dashboard`.
- Query Workspace is rendered at `/query`.
- Sidebar "Dashboard" now links to `/dashboard` directly.

## Root Cause
Two route/nav mismatches were present:
1. `frontend/src/App.tsx` mapped both `/` and `/query` to `QueryWorkspace`.
2. `frontend/src/components/Layout/AppShell.tsx` mapped the sidebar Dashboard item to `/` rather than `/dashboard`.

## Fix
- Updated `frontend/src/App.tsx` so `/` renders `Dashboard`.
- Kept `/dashboard` rendering `Dashboard` as explicit dashboard route.
- Kept `/query` rendering `QueryWorkspace`.
- Updated sidebar Dashboard nav path to `/dashboard` and corrected the label typo (`Dasbhoard` -> `Dashboard`).
- Updated `frontend/src/pages/NotFound.tsx` "Go back to Dashboard" link to `/dashboard` for consistency with explicit dashboard navigation.

## Validation
- Ran `npm --prefix frontend run build` successfully.
