### PR TITLE
[bug] fix frontend lint errors

### DIFF
--- a/frontend/src/components/Query/DebugPanel.tsx
+++ b/frontend/src/components/Query/DebugPanel.tsx
@@ -4,7 +4,20 @@ import { BookOpen, Clock, Database, ChevronRight } from 'lucide-react';
 interface DebugPanelProps {
     isOpen: boolean;
     onClose: () => void;
-    metadata: any; // Using any for flexibility with untyped RAG extensions
+    metadata: DebugMetadata | null;
+}
+
+interface RagDocument {
+    source?: string;
+    content?: string;
+    score?: number;
+}
+
+interface DebugMetadata {
+    duration_ms?: number;
+    row_count?: number;
+    confidence?: number;
+    rag_documents?: RagDocument[];
 }
 
 export const DebugPanel: React.FC<DebugPanelProps> = ({ isOpen, onClose, metadata }) => {
@@ -39,7 +52,11 @@ export const DebugPanel: React.FC<DebugPanelProps> = ({ isOpen, onClose, metadat
                         </div>
                         <div className="flex justify-between">
                             <span className="text-gray-500">Confidence:</span>
-                            <span className="font-mono text-gray-900">{(metadata?.confidence * 100).toFixed(1)}%</span>
+                            <span className="font-mono text-gray-900">
+                                {typeof metadata?.confidence === 'number'
+                                    ? `${(metadata.confidence * 100).toFixed(1)}%`
+                                    : '-'}
+                            </span>
                         </div>
                     </div>
                 </div>
@@ -52,11 +69,13 @@ export const DebugPanel: React.FC<DebugPanelProps> = ({ isOpen, onClose, metadat
                     </h4>
                     {metadata?.rag_documents ? (
                         <ul className="space-y-2">
-                            {metadata.rag_documents.map((doc: any, idx: number) => (
+                            {metadata.rag_documents.map((doc: RagDocument, idx: number) => (
                                 <li key={idx} className="bg-blue-50 p-2 rounded border border-blue-100 text-xs">
                                     <div className="font-medium text-blue-800 mb-1 truncate">{doc.source || 'Unknown Source'}</div>
                                     <p className="text-gray-600 line-clamp-3">{doc.content}</p>
-                                    <div className="mt-1 text-blue-400 text-[10px] text-right">Score: {doc.score?.toFixed(3)}</div>
+                                    <div className="mt-1 text-blue-400 text-[10px] text-right">
+                                        Score: {typeof doc.score === 'number' ? doc.score.toFixed(3) : '-'}
+                                    </div>
                                 </li>
                             ))}
                         </ul>

--- a/frontend/src/components/Query/ExportBar.tsx
+++ b/frontend/src/components/Query/ExportBar.tsx
@@ -59,9 +59,10 @@ export const ExportBar: React.FC<ExportBarProps> = ({ sessionId, hasResults }) =
             document.body.removeChild(a);
 
             toast.success(`Exported as ${format.toUpperCase()}`);
-        } catch (err: any) {
-            console.error('Export error:', err);
-            toast.error(err.message || "Failed to export results");
+        } catch (error) {
+            console.error('Export error:', error);
+            const message = error instanceof Error ? error.message : 'Failed to export results';
+            toast.error(message);
         } finally {
             setIsExporting(false);
         }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -19,7 +19,7 @@ client.use({
                 if (data && typeof data === 'object' && 'message' in data) {
                     errorMessage = data.message;
                 }
-            } catch (e) {
+            } catch {
                 // ignore JSON parse errors
             }
 

--- a/frontend/src/pages/LLMProviders.tsx
+++ b/frontend/src/pages/LLMProviders.tsx
@@ -81,7 +81,8 @@ export const LLMProviders: React.FC = () => {
                 toast.success(`${PROVIDER_DISPLAY_NAMES[p.provider] || p.provider} ${!p.enabled ? 'enabled' : 'disabled'}`);
                 fetchProviders();
             }
-        } catch (err) {
+        } catch (error) {
+            console.error("Failed to toggle provider", error);
             toast.error("An error occurred");
         } finally {
             setTogglingIds(prev => {

--- a/frontend/src/pages/Observability.tsx
+++ b/frontend/src/pages/Observability.tsx
@@ -192,7 +192,7 @@ export const Observability: React.FC = () => {
 
                 const normalized = normalizeMetricsPayload(data);
                 setMetrics(normalized || MOCK_DATA);
-            } catch (_error) {
+            } catch {
                 setMetrics(MOCK_DATA);
             } finally {
                 setLoading(false);

--- a/frontend/src/pages/QueryWorkspace.tsx
+++ b/frontend/src/pages/QueryWorkspace.tsx
@@ -24,6 +24,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 };
 
 type TabType = 'results' | 'metadata' | 'citations' | 'query-plan';
+type ExportFormat = 'json' | 'csv' | 'xlsx' | 'tsv' | 'parquet';
 
 export const QueryWorkspace: React.FC = () => {
     // --- State ---
@@ -49,7 +50,7 @@ export const QueryWorkspace: React.FC = () => {
     const [isReadOnly, setIsReadOnly] = useState(false);
 
     // Export controls
-    const [exportFormat, setExportFormat] = useState<'json' | 'csv' | 'xlsx' | 'tsv' | 'parquet'>('csv');
+    const [exportFormat, setExportFormat] = useState<ExportFormat>('csv');
     const [isExporting, setIsExporting] = useState(false);
 
     // --- Effects ---
@@ -140,7 +141,7 @@ export const QueryWorkspace: React.FC = () => {
         try {
             await navigator.clipboard.writeText(generatedSql);
             toast.success('SQL copied to clipboard');
-        } catch (err) {
+        } catch {
             toast.error('Failed to copy');
         }
     };
@@ -182,8 +183,9 @@ export const QueryWorkspace: React.FC = () => {
             document.body.removeChild(a);
 
             toast.success(`Exported as ${exportFormat.toUpperCase()}`);
-        } catch (err: any) {
-            toast.error(err.message || "Failed to export");
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to export';
+            toast.error(message);
         } finally {
             setIsExporting(false);
         }
@@ -500,7 +502,7 @@ export const QueryWorkspace: React.FC = () => {
                                 <span className="text-xs font-semibold text-gray-600">Export Format:</span>
                                 <select
                                     value={exportFormat}
-                                    onChange={(e) => setExportFormat(e.target.value as any)}
+                                    onChange={(e) => setExportFormat(e.target.value as ExportFormat)}
                                     className="px-3 py-1.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
                                 >
                                     <option value="json">JSON</option>

--- a/frontend/src/pages/ReleaseGates.tsx
+++ b/frontend/src/pages/ReleaseGates.tsx
@@ -217,7 +217,7 @@ export const ReleaseGates: React.FC = () => {
                 const { data: apiData } = await client.GET('/v1/observability/release-gates');
                 const normalized = normalizeReleaseGatesPayload(apiData);
                 setData(normalized || MOCK_GATES);
-            } catch (_error) {
+            } catch {
                 setData(MOCK_GATES);
             } finally {
                 setLoading(false);

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -65,7 +65,11 @@ export const Settings: React.FC = () => {
         fetchData();
     }, []);
 
-    const handleRoutingChange = (dsId: string, field: keyof RoutingRule, value: any) => {
+    const handleRoutingChange = <K extends keyof RoutingRule>(
+        dsId: string,
+        field: K,
+        value: RoutingRule[K]
+    ) => {
         setRoutingRules(prev => ({
             ...prev,
             [dsId]: { ...prev[dsId], [field]: value }


### PR DESCRIPTION
## Summary
This PR resolves frontend lint failures caused by `@typescript-eslint/no-explicit-any` and `@typescript-eslint/no-unused-vars` violations.

Closes #68.

## User Impact
Before this change, frontend linting failed, which blocks clean CI checks and makes it harder to trust incremental UI changes. After this change, lint passes with no errors, keeping the project in a releasable state for frontend work.

## Root Cause
Several files used `any` in component props/state handlers and had catch parameters that were never used. The configured ESLint rules treat both as errors.

## Fix Details
- Replaced `any` with concrete types in the query/debug UI.
- Replaced `any` casts in query export format handling with a dedicated `ExportFormat` union.
- Updated generic routing-rule field updates in settings to use typed key/value pairs.
- Removed or used unused catch variables where appropriate.
- Kept runtime behavior unchanged while tightening types.

### Files Updated
- `frontend/src/components/Query/DebugPanel.tsx`
- `frontend/src/components/Query/ExportBar.tsx`
- `frontend/src/lib/api/client.ts`
- `frontend/src/pages/LLMProviders.tsx`
- `frontend/src/pages/Observability.tsx`
- `frontend/src/pages/QueryWorkspace.tsx`
- `frontend/src/pages/ReleaseGates.tsx`
- `frontend/src/pages/Settings.tsx`

## Validation
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
