### PR TITLE
[feat] dashboard tabs for observability and release gates

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>Report Pilot</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,10 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Navigate, Routes, Route } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { AppShell } from './components/Layout/AppShell';
 import { Dashboard } from './pages/Dashboard';
 import { DataSources } from './pages/DataSources';
 import { SchemaExplorer } from './pages/SchemaExplorer';
 import { QueryWorkspace } from './pages/QueryWorkspace';
-import { Observability } from './pages/Observability';
-import { ReleaseGates } from './pages/ReleaseGates';
 import { NotFound } from './pages/NotFound';
 import { Settings } from './pages/Settings';
 import { LLMProviders } from './pages/LLMProviders';
@@ -22,8 +20,8 @@ function App() {
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/data-sources" element={<DataSources />} />
           <Route path="/schema" element={<SchemaExplorer />} />
-          <Route path="/observability" element={<Observability />} />
-          <Route path="/release-gates" element={<ReleaseGates />} />
+          <Route path="/observability" element={<Navigate to="/dashboard?tab=observability" replace />} />
+          <Route path="/release-gates" element={<Navigate to="/dashboard?tab=release-gates" replace />} />
           <Route path="/llm-providers" element={<LLMProviders />} />
           <Route path="/settings" element={<Settings />} />
         </Route>

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -4,8 +4,6 @@ import {
     LayoutDashboard,
     Database,
     Search,
-    Activity,
-    ShieldCheck,
     Settings,
     Layers,
     Server,
@@ -20,8 +18,6 @@ const NAV_ITEMS = [
     { path: '/llm-providers', label: 'LLM Providers', icon: Server },
     { path: '/schema', label: 'Schema Explorer', icon: Layers },
     { path: '/query', label: 'Query Workspace', icon: Search },
-    { path: '/observability', label: 'Observability', icon: Activity },
-    { path: '/release-gates', label: 'Release Gates', icon: ShieldCheck },
 ];
 
 export const AppShell: React.FC = () => {
@@ -37,7 +33,7 @@ export const AppShell: React.FC = () => {
             <aside className={styles.sidebar}>
                 <div className={styles.sidebarHeader}>
                     <LayoutDashboard className="mr-2" size={24} />
-                    <span>Report Pilot Console</span>
+                    <span>Report Pilot</span>
                 </div>
 
                 <div className={styles.sidebarContent}>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,10 +1,48 @@
 import React from 'react';
+import { Activity, ShieldCheck } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
+import { Observability } from './Observability';
+import { ReleaseGates } from './ReleaseGates';
 
 export const Dashboard: React.FC = () => {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const tab = searchParams.get('tab') === 'release-gates' ? 'release-gates' : 'observability';
+
+    const setTab = (nextTab: 'observability' | 'release-gates') => {
+        setSearchParams({ tab: nextTab });
+    };
+
     return (
         <div className="p-6 h-full overflow-y-auto">
-            <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
-            <p>Welcome to Report Pilot Console.</p>
+            <h1 className="text-2xl font-bold text-gray-900 mb-1">Dashboard</h1>
+            <p className="text-sm text-gray-500 mb-6">Operational visibility for query quality, reliability, and release readiness.</p>
+
+            <div className="inline-flex items-center rounded-lg border border-gray-200 bg-white p-1 mb-6">
+                <button
+                    onClick={() => setTab('observability')}
+                    className={`inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                        tab === 'observability'
+                            ? 'bg-blue-600 text-white shadow-sm'
+                            : 'text-gray-600 hover:bg-gray-100'
+                    }`}
+                >
+                    <Activity size={16} />
+                    Observability
+                </button>
+                <button
+                    onClick={() => setTab('release-gates')}
+                    className={`inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                        tab === 'release-gates'
+                            ? 'bg-blue-600 text-white shadow-sm'
+                            : 'text-gray-600 hover:bg-gray-100'
+                    }`}
+                >
+                    <ShieldCheck size={16} />
+                    Release Gates
+                </button>
+            </div>
+
+            {tab === 'observability' ? <Observability embedded /> : <ReleaseGates embedded />}
         </div>
     );
 };

--- a/frontend/src/pages/Observability.tsx
+++ b/frontend/src/pages/Observability.tsx
@@ -179,7 +179,11 @@ function normalizeMetricsPayload(payload: unknown): MetricsData | null {
     return normalizeLegacyShape(payload) || normalizeBackendShape(payload);
 }
 
-export const Observability: React.FC = () => {
+interface ObservabilityProps {
+    embedded?: boolean;
+}
+
+export const Observability: React.FC<ObservabilityProps> = ({ embedded = false }) => {
     const [metrics, setMetrics] = useState<MetricsData | null>(null);
     const [loading, setLoading] = useState(true);
 
@@ -202,17 +206,19 @@ export const Observability: React.FC = () => {
         fetchMetrics();
     }, []);
 
-    if (loading) return <div className="p-8 text-center text-gray-500">Loading metrics...</div>;
-    if (!metrics) return <div className="p-8 text-center text-gray-500">No metrics available.</div>;
+    if (loading) return <div className={embedded ? 'py-10 text-center text-gray-500' : 'p-8 text-center text-gray-500'}>Loading metrics...</div>;
+    if (!metrics) return <div className={embedded ? 'py-10 text-center text-gray-500' : 'p-8 text-center text-gray-500'}>No metrics available.</div>;
 
     const { summary, history, recent_failures } = metrics;
 
     return (
-        <div className="p-8 max-w-7xl mx-auto space-y-8 h-full overflow-y-auto">
-            <div className="flex items-center gap-3 mb-2">
-                <Activity className="w-8 h-8 text-blue-600" />
-                <h1 className="text-2xl font-bold text-gray-900">Observability</h1>
-            </div>
+        <div className={embedded ? 'space-y-8 h-full overflow-y-auto' : 'p-8 max-w-7xl mx-auto space-y-8 h-full overflow-y-auto'}>
+            {!embedded && (
+                <div className="flex items-center gap-3 mb-2">
+                    <Activity className="w-8 h-8 text-blue-600" />
+                    <h1 className="text-2xl font-bold text-gray-900">Observability</h1>
+                </div>
+            )}
 
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
                 <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">

--- a/frontend/src/pages/ReleaseGates.tsx
+++ b/frontend/src/pages/ReleaseGates.tsx
@@ -207,7 +207,11 @@ function normalizeReleaseGatesPayload(payload: unknown): ReleaseGateData | null 
     return normalizeUiShape(payload) || normalizeBackendShape(payload);
 }
 
-export const ReleaseGates: React.FC = () => {
+interface ReleaseGatesProps {
+    embedded?: boolean;
+}
+
+export const ReleaseGates: React.FC<ReleaseGatesProps> = ({ embedded = false }) => {
     const [data, setData] = useState<ReleaseGateData | null>(null);
     const [loading, setLoading] = useState(true);
 
@@ -231,16 +235,16 @@ export const ReleaseGates: React.FC = () => {
         // In real app, POST to /v1/observability/benchmarks/run
     };
 
-    if (loading) return <div className="p-8 text-center text-gray-500">Loading release status...</div>;
-    if (!data) return <div className="p-8 text-center text-gray-500">No release data found.</div>;
+    if (loading) return <div className={embedded ? 'py-10 text-center text-gray-500' : 'p-8 text-center text-gray-500'}>Loading release status...</div>;
+    if (!data) return <div className={embedded ? 'py-10 text-center text-gray-500' : 'p-8 text-center text-gray-500'}>No release data found.</div>;
 
     return (
-        <div className="p-8 max-w-5xl mx-auto space-y-8 h-full overflow-y-auto">
+        <div className={embedded ? 'space-y-8 h-full overflow-y-auto' : 'p-8 max-w-5xl mx-auto space-y-8 h-full overflow-y-auto'}>
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                     <ShieldCheck className={`w-8 h-8 ${data.status === 'PASS' ? 'text-green-600' : 'text-amber-500'}`} />
                     <div>
-                        <h1 className="text-2xl font-bold text-gray-900">Release Gates</h1>
+                        {!embedded && <h1 className="text-2xl font-bold text-gray-900">Release Gates</h1>}
                         <p className="text-sm text-gray-500">
                             Last Checked: {safeFormatTimestamp(data.run_date, 'MMM d, yyyy HH:mm')} • Dataset: {data.dataset_version}
                         </p>


### PR DESCRIPTION
## Summary
This change consolidates operational monitoring into a single dashboard experience by moving Observability and Release Gates into tabs on `/dashboard`.

## Problem
Operational views were split across separate routes (`/observability` and `/release-gates`), while the main `/dashboard` page was still a placeholder. That made the navigation feel fragmented and did not match the intended product direction of using dashboard as the operational hub.

## User Impact Before
Users had to leave dashboard and switch between separate pages to see reliability metrics and release readiness signals.

## Root Cause
The UI-014 (Observability Dashboard) and UI-015 (Release Gates View) implementations were shipped as standalone pages, but the dashboard route itself was never promoted from placeholder into the composed operations home.

## Fix
- Replaced the placeholder dashboard with a tabbed dashboard containing:
  - `Observability` tab
  - `Release Gates` tab
- Removed standalone sidebar entries for Observability and Release Gates.
- Kept backward compatibility for old links by redirecting:
  - `/observability` -> `/dashboard?tab=observability`
  - `/release-gates` -> `/dashboard?tab=release-gates`
- Added an `embedded` mode to both views so they render cleanly inside dashboard tabs without duplicate page framing.
- Preserved branding update in shell and document title (`Report Pilot`).

## Ticket Linkage
- UI-014: Observability Dashboard
- UI-015: Release Gates View
- Source: `PLAN/TICKETS.md`

## Validation
- `npm --prefix frontend run build`
- `npm --prefix frontend run lint`

## Notes
This PR intentionally keeps existing feature logic and API calls unchanged; it only changes routing/navigation composition and dashboard presentation.
