### PR TITLE
feat: make release gates button actionable

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Observability:
 
 - `GET /v1/observability/metrics?window_hours=24`
 - `GET /v1/observability/release-gates`
+- `GET /v1/observability/benchmark-command`
 - `POST /v1/observability/release-gates/report`
 
 RAG:

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -10,7 +10,11 @@ const { evaluateExplainBudget } = require("./services/queryBudget");
 const { buildCitations, computeConfidence } = require("./services/queryResponse");
 const { reindexRagDocuments } = require("./services/ragService");
 const { retrieveRagContext } = require("./services/ragRetrieval");
-const { buildObservabilityMetrics, loadLatestBenchmarkReleaseGates } = require("./services/observabilityService");
+const {
+  buildObservabilityMetrics,
+  loadLatestBenchmarkReleaseGates,
+  buildBenchmarkCommand
+} = require("./services/observabilityService");
 const { exportQueryResult, SUPPORTED_FORMATS } = require("./services/exportService");
 const { createDelivery, getDeliveryStatus } = require("./services/deliveryService");
 const { OpenAiAdapter } = require("./adapters/llm/openAiAdapter");
@@ -1079,6 +1083,11 @@ async function handleReleaseGates(_req, res) {
   return json(res, 200, payload);
 }
 
+async function handleBenchmarkCommand(_req, res) {
+  const payload = buildBenchmarkCommand();
+  return json(res, 200, payload);
+}
+
 async function handleCreateBenchmarkReport(req, res) {
   const body = await readJsonBody(req);
   const {
@@ -1271,6 +1280,10 @@ async function routeRequest(req, res) {
 
   if (req.method === "GET" && pathname === "/v1/observability/release-gates") {
     return handleReleaseGates(req, res);
+  }
+
+  if (req.method === "GET" && pathname === "/v1/observability/benchmark-command") {
+    return handleBenchmarkCommand(req, res);
   }
 
   if (req.method === "POST" && pathname === "/v1/observability/release-gates/report") {

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -441,6 +441,17 @@ paths:
                   message:
                     type: string
                 required: [error, message]
+  /v1/observability/benchmark-command:
+    get:
+      tags: [Observability]
+      summary: Benchmark CLI command derived from runtime configuration
+      responses:
+        "200":
+          description: Shell command and environment values for running the benchmark
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BenchmarkCommandResponse"
   /v1/observability/release-gates/report:
     post:
       tags: [Observability]
@@ -757,6 +768,16 @@ components:
     ObservabilityMetricsResponse:
       type: object
       additionalProperties: true
+    BenchmarkCommandResponse:
+      type: object
+      properties:
+        command:
+          type: string
+        env:
+          type: object
+          additionalProperties:
+            type: string
+      required: [command, env]
     ReleaseGatesResponse:
       type: object
       additionalProperties: true

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -873,6 +873,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/observability/benchmark-command": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Benchmark CLI command derived from runtime configuration */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Shell command and environment values for running the benchmark */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BenchmarkCommandResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/observability/release-gates/report": {
         parameters: {
             query?: never;
@@ -1060,6 +1096,12 @@ export interface components {
         };
         ObservabilityMetricsResponse: {
             [key: string]: unknown;
+        };
+        BenchmarkCommandResponse: {
+            command: string;
+            env: {
+                [key: string]: string;
+            };
         };
         ReleaseGatesResponse: {
             [key: string]: unknown;


### PR DESCRIPTION
## Summary
This PR makes the Release Gates action button useful with current APIs and improves the empty-state flow when no benchmark report exists.

It now also introduces an API endpoint that returns a benchmark CLI command derived from backend runtime environment, so frontend no longer hardcodes this command.

This branch also contains the dashboard tab consolidation from its parent branch so Observability and Release Gates are accessed under `/dashboard`.

## Linked Issue
Closes #77

## What Changed
- Replaced mock "Run Benchmark" button behavior with real `Refresh Status` behavior in `ReleaseGates`.
- Added `Copy CLI Command` action so users can run benchmark immediately from terminal.
- Added explicit no-report (`404`) empty state with benchmark command panel and CTA actions.
- Added backend endpoint: `GET /v1/observability/benchmark-command`.
- Backend command payload is built from runtime env with safe defaults and returned as a ready shell command.
- Frontend now fetches benchmark command from API and uses fallback command only if request fails.
- Updated OpenAPI spec and regenerated frontend API types.
- Updated README observability endpoint list.

## Validation
- `npm test`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`

## Notes
- This PR does **not** introduce a backend endpoint for starting benchmark runs from UI.
- It intentionally uses existing benchmark workflow and adds API-based command discovery for better runtime consistency.
