### PR TITLE
fix: refresh dvdrental dates around yesterday without future earnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ BENCHMARK_ORACLE_CONN=postgresql://postgres:postgres@localhost:5440/dvdrental \
 npm run benchmark:mvp
 ```
 
-Note: on first initialization of `test-data`, the restore script shifts all `date`/`timestamp` fields by a dynamic offset so the latest rental lands around yesterday (relative to system time).
+Note: on first initialization of `test-data`, the restore script shifts all `date`/`timestamp` fields by dynamic offsets so the latest rental and latest payment land around yesterday (relative to system time), then caps shifted values at current system date/time to avoid future-dated rows.
 
 Report outputs:
 

--- a/test-data/init/01-restore-dvdrental.sh
+++ b/test-data/init/01-restore-dvdrental.sh
@@ -24,18 +24,22 @@ psql --username="$POSTGRES_USER" --dbname="$POSTGRES_DB" -v ON_ERROR_STOP=1 <<'S
 DO $$
 DECLARE
   v_anchor_ts timestamp without time zone;
+  v_payment_anchor_ts timestamp without time zone;
   v_target_ts timestamp without time zone;
   v_target_tstz timestamp with time zone;
   v_target_date date;
   v_shift_interval interval;
+  v_payment_shift_interval interval;
   v_shift_days integer;
   v_rowcount bigint;
   v_updated_cells bigint := 0;
+  v_effective_interval interval;
   v_col record;
 BEGIN
   -- Anchor on the most recent rental and shift everything by the same offset
   -- to keep relative spacing between rows while making rentals feel fresh.
   SELECT MAX(rental_date) INTO v_anchor_ts FROM public.rental;
+  SELECT MAX(payment_date) INTO v_payment_anchor_ts FROM public.payment;
 
   IF v_anchor_ts IS NULL THEN
     RAISE NOTICE 'Skipping temporal shift: no rental rows found.';
@@ -48,8 +52,13 @@ BEGIN
 
   v_shift_interval := v_target_ts - v_anchor_ts;
   v_shift_days := v_target_date - v_anchor_ts::date;
+  v_payment_shift_interval := CASE
+    WHEN v_payment_anchor_ts IS NULL THEN v_shift_interval
+    ELSE v_target_ts - v_payment_anchor_ts
+  END;
 
-  RAISE NOTICE 'Applying temporal shift from rental max=% to target=%. Interval=% (days=%).', v_anchor_ts, v_target_ts, v_shift_interval, v_shift_days;
+  RAISE NOTICE 'Applying temporal shift from rental max=% to target=%. Rental interval=% (days=%), payment interval=%.',
+    v_anchor_ts, v_target_ts, v_shift_interval, v_shift_days, v_payment_shift_interval;
 
   FOR v_col IN
     SELECT c.table_schema, c.table_name, c.column_name, c.data_type
@@ -65,23 +74,35 @@ BEGIN
     IF v_col.data_type = 'date' THEN
       EXECUTE format(
         'UPDATE %I.%I
-         SET %I = %I + %s
+         SET %I = LEAST(%I + %s, CURRENT_DATE)
          WHERE %I IS NOT NULL',
         v_col.table_schema, v_col.table_name, v_col.column_name, v_col.column_name, v_shift_days, v_col.column_name
       );
     ELSIF v_col.data_type = 'timestamp without time zone' THEN
+      v_effective_interval := CASE
+        WHEN v_col.table_name = 'payment' AND v_col.column_name = 'payment_date'
+          THEN v_payment_shift_interval
+        ELSE v_shift_interval
+      END;
+
       EXECUTE format(
         'UPDATE %I.%I
-         SET %I = %I + %L::interval
+         SET %I = LEAST(%I + %L::interval, CURRENT_TIMESTAMP::timestamp)
          WHERE %I IS NOT NULL',
-        v_col.table_schema, v_col.table_name, v_col.column_name, v_col.column_name, v_shift_interval, v_col.column_name
+        v_col.table_schema, v_col.table_name, v_col.column_name, v_col.column_name, v_effective_interval, v_col.column_name
       );
     ELSE
+      v_effective_interval := CASE
+        WHEN v_col.table_name = 'payment' AND v_col.column_name = 'payment_date'
+          THEN v_payment_shift_interval
+        ELSE v_shift_interval
+      END;
+
       EXECUTE format(
         'UPDATE %I.%I
-         SET %I = %I + %L::interval
+         SET %I = LEAST(%I + %L::interval, CURRENT_TIMESTAMP)
          WHERE %I IS NOT NULL',
-        v_col.table_schema, v_col.table_name, v_col.column_name, v_col.column_name, v_shift_interval, v_col.column_name
+        v_col.table_schema, v_col.table_name, v_col.column_name, v_col.column_name, v_effective_interval, v_col.column_name
       );
     END IF;
 


### PR DESCRIPTION
## Summary
- update `test-data` restore flow to shift fixture timestamps relative to system time
- anchor rental freshness to the latest rental so recent rentals land around yesterday
- apply a dedicated payment-date shift so revenue also lands around yesterday
- cap shifted values at current system date/time to avoid future-dated rows (for example 2027)
- document the behavior in README

## Verification
- reinitialized test data with `docker compose -f test-data/docker-compose.yml down -v && docker compose -f test-data/docker-compose.yml up -d`
- verified latest rental rows are around yesterday (relative to current system date)
- verified payment dates no longer spill into the future
