### PR TITLE
fix(test-data): accept connections from all networks

### DIFF
--- a/test-data/docker-compose.yml
+++ b/test-data/docker-compose.yml
@@ -3,12 +3,13 @@ services:
     image: postgres:16-alpine
     container_name: report-pilot-dvdrental-postgres
     restart: unless-stopped
+    command: [ "postgres", "-c", "listen_addresses=*" ]
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-dvdrental}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
-      - "${POSTGRES_PORT:-5440}:5432"
+      - "0.0.0.0:${POSTGRES_PORT:-5440}:5432"
     volumes:
       - dvdrental_postgres_data:/var/lib/postgresql/data
       - ./dvdrental.tar:/docker-entrypoint-initdb.d/dvdrental.tar:ro
@@ -32,8 +33,9 @@ services:
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
       PGADMIN_REPLACE_SERVERS_ON_STARTUP: "True"
       PGADMIN_LISTEN_PORT: 80
+      PGADMIN_LISTEN_ADDRESS: 0.0.0.0
     ports:
-      - "${PGADMIN_PORT:-5050}:80"
+      - "0.0.0.0:${PGADMIN_PORT:-5050}:80"
     volumes:
       - dvdrental_pgadmin_data:/var/lib/pgadmin
       - ./pgadmin/servers.json:/pgadmin4/servers.json:ro


### PR DESCRIPTION
## Summary
- configure Postgres to listen on all interfaces with `listen_addresses=*`
- bind Postgres published port explicitly to `0.0.0.0`
- configure pgAdmin to listen on `0.0.0.0`
- bind pgAdmin published port explicitly to `0.0.0.0`

## Validation
- docker compose -f test-data/docker-compose.yml config
