### PR TITLE
Add repository workflow guidance

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: commit
+description: Create a clean commit for the current staged or unstaged changes, optionally using a provided ticket or ticket summary for context
+---
+
+Create a git commit for the current repo changes.
+
+Read `AGENTS.md` first. It is the canonical project guide for this repository.
+
+Inputs:
+
+- Optional ticket identifier such as `#123` or `ABC-123`
+- Optional short ticket summary or description
+
+Workflow:
+
+1. Run `git status --short` and inspect the relevant diff before staging anything
+2. If there are unrelated changes, stage only the files that belong in this commit
+3. If there are no changes to commit, stop and say so
+4. Write a single clear commit message for the actual change
+5. Commit without adding extra trailers or AI attribution
+
+Commit message rules:
+
+- Use Conventional Commits format: `<type>[optional scope]: <description>`
+- Keep the subject imperative, lowercase after the prefix, and without a trailing period
+- Prefer a concise single-line message unless the user explicitly asks for a body
+- Use the optional ticket context to inform the message
+- Do not invent ticket IDs or details that were not provided
+
+Examples:
+
+- `feat(query): add saved query rename action`
+- `fix(rag): reindex notes after schema import`
+- `docs: update local runtime instructions`
+
+Hard rules:
+
+- Do not include `codex`, `claude`, `chatgpt`, or similar agent branding in the branch name or commit message
+- Do not add `Co-authored-by`
+- Do not add `Signed-off-by`
+- Do not add AI-generated disclaimers, attribution, or signature text
+- Do not amend existing commits unless the user explicitly asks
+- Do not use `git add -A` unless the full working tree is intentionally part of the commit
+
+If the current branch name contains agent branding, warn the user before committing and recommend renaming the branch first.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: create-pr
+description: Create a pull request for the current branch, optionally linking it to a provided ticket, and commit first if the branch still has uncommitted changes
+---
+
+Create a pull request for the current branch.
+
+Read `AGENTS.md` first. It is the canonical project guide for this repository.
+
+Inputs:
+
+- Optional ticket identifier such as `#123`, `ABC-123`, or a ticket URL
+- Optional short ticket summary or context
+
+Workflow:
+
+1. Check `git status --short`
+2. If there are staged or unstaged code changes that belong in the PR, use the `commit` skill first
+3. Get the current branch with `git rev-parse --abbrev-ref HEAD`
+4. If the branch name contains `codex`, `claude`, `chatgpt`, or similar agent branding, stop and ask the user to rename the branch before creating the PR
+5. Review the branch diff against its base and write a concise human PR title and body
+6. Open the PR using the normal repo workflow
+
+PR title rules:
+
+- Keep it short, specific, and written by topic rather than by tool
+- Do not include agent branding
+- Do not copy a noisy stack of commit subjects into the title
+
+PR body rules:
+
+- Summarize what changed and how to verify it
+- If a ticket is provided, link it explicitly
+- For GitHub issues, prefer a closing reference such as `Closes #123`
+- For external tickets such as `ABC-123`, include a plain ticket line such as `Ticket: ABC-123`
+- Do not invent ticket IDs, links, or status text
+- Do not add `Co-authored-by`
+- Do not add `Signed-off-by`
+- Do not add AI-generated disclaimers, attribution, or signature text
+
+If there are no commits on the branch yet, stop and use the `commit` skill first.

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 docker-compose.override.yml
 server.log
 server_verified.log
+.claude/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,251 @@
+# AGENTS.md — Report Pilot
+
+## Project Overview
+
+Report Pilot is a local-first NL-to-SQL runtime for reporting workflows.
+
+It combines:
+
+- A Node.js backend API for schema ingestion, query orchestration, provider routing, and audit storage
+- A PostgreSQL metadata database managed by SQL migrations
+- A React frontend for data source setup, schema exploration, query authoring, provider management, and observability
+- A retrieval + LLM pipeline that turns natural-language reporting questions into validated read-only SQL
+
+The core design principle is a layered architecture:
+
+1. Adapter layer for database and LLM providers
+2. Service layer for orchestration and policy enforcement
+3. API layer for HTTP endpoints
+4. UI layer for admin and analyst workflows
+
+Keep responsibilities in those layers. Avoid scattering SQL safety or provider logic directly into route handlers or frontend components.
+
+## Build And Run
+
+```bash
+# Install root and frontend dependencies
+npm run setup
+
+# Run backend + frontend locally
+npm run dev
+
+# Run backend only
+npm run dev:be
+
+# Run frontend only
+npm run dev:fe
+
+# Apply DB migrations
+npm run migrate
+
+# Run backend tests
+npm test
+
+# Build everything
+npm run build
+
+# Build frontend only
+npm run build:fe
+
+# Run the benchmark suite
+npm run benchmark:mvp
+
+# Frontend lint
+npm --prefix frontend run lint
+```
+
+Docker local stack:
+
+```bash
+cp .env.example .env
+docker compose up --build
+```
+
+Default app port: `8080`
+
+## High-Level Architecture
+
+```text
+React UI (/frontend)
+  -> HTTP API (/app/src/server.js)
+      -> Service layer (/app/src/services)
+          -> LLM adapters (/app/src/adapters/llm)
+          -> DB adapters (/app/src/adapters)
+          -> Metadata DB (/db/migrations, app DB tables)
+          -> Target reporting databases (Postgres first, MSSQL supported)
+```
+
+### 1. Backend API (`/app/src`)
+
+The backend exposes health, data source, schema, query, provider, RAG, export, and observability endpoints.
+
+Key entry points:
+
+- `app/src/start.js` boots the service
+- `app/src/server.js` defines the HTTP API
+- `app/src/migrate.js` applies SQL migrations
+
+The backend owns:
+
+- Data source registration and introspection
+- Query session lifecycle
+- NL-to-SQL generation and retries
+- SQL validation and read-only enforcement
+- RAG indexing and retrieval
+- Provider health and routing
+- Observability, exports, and delivery flows
+
+### 2. Database Layer
+
+Application metadata lives in PostgreSQL and is defined by ordered SQL migrations in `/db/migrations`.
+
+Rules:
+
+- Add schema changes as new numbered migration files, never by editing applied migrations
+- Keep migration names descriptive
+- If a feature needs persisted state, update migrations first and then wire service logic to the new schema
+
+### 3. Database Adapters (`/app/src/adapters`)
+
+Database-specific execution and introspection belongs in adapters.
+
+Current adapters:
+
+- `postgresAdapter.js`
+- `mssqlAdapter.js`
+- `dbAdapterFactory.js`
+
+Keep dialect-specific quoting, validation, introspection, and execution in adapters rather than service code.
+
+### 4. LLM Provider Adapters (`/app/src/adapters/llm`)
+
+Provider-specific HTTP calls, health checks, and embedding generation belong here.
+
+Current providers:
+
+- OpenAI
+- Gemini
+- DeepSeek
+- OpenRouter
+- Custom adapter support
+
+Routing policy belongs in shared services such as `providerConfigService.js`, `llmSqlService.js`, and `embeddingRouter.js`, not inside individual provider adapters.
+
+### 5. Service Layer (`/app/src/services`)
+
+This is the core of the system.
+
+Important modules include:
+
+- `llmSqlService.js` and `sqlGenerator.js` for generation orchestration
+- `sqlAstValidator.js`, `sqlSafety.js`, and `queryBudget.js` for guardrails
+- `introspectionService.js` and `ddlImportService.js` for schema ingestion
+- `ragService.js` and `ragRetrieval.js` for indexing and retrieval
+- `providerConfigService.js` for provider config and routing
+- `observabilityService.js`, `exportService.js`, and `deliveryService.js` for operational workflows
+
+Prefer putting business rules here rather than in routes or UI code.
+
+### 6. Frontend (`/frontend/src`)
+
+The React frontend is organized by pages plus focused components.
+
+Primary areas:
+
+- `pages/QueryWorkspace.tsx` for the main analyst query flow
+- `pages/DataSources.tsx` and related dialogs for source setup and RAG notes
+- `pages/SchemaExplorer.tsx` for metadata browsing
+- `pages/LLMProviders.tsx` for provider configuration
+- `pages/Observability.tsx` and `pages/ReleaseGates.tsx` for operational visibility
+
+API client code lives under `frontend/src/lib/api`.
+
+If backend request or response shapes change, update:
+
+- `docs/api/openapi.yaml`
+- `frontend/src/lib/api/types.ts`
+- Any affected client calls or UI flows
+
+## Core Product Invariants
+
+These rules matter more than local implementation preference.
+
+### Read-Only SQL Only
+
+This project is for reporting queries. Do not introduce paths that allow writes, DDL, or unsafe escape hatches.
+
+- Preserve AST-based validation
+- Preserve read-only execution constraints
+- Preserve budget and plan checks unless there is a deliberate, reviewed design change
+
+### Ground SQL In Known Metadata
+
+Generated SQL should be grounded in introspected schema, semantic definitions, RAG notes, and validated examples.
+
+- Do not silently bypass retrieval or validation
+- Keep citations and confidence behavior aligned with the actual generation flow
+- Reindex RAG when schema or semantic inputs change
+
+### Keep Adapter Boundaries Clean
+
+- DB-specific logic stays in DB adapters
+- Provider-specific logic stays in LLM adapters
+- Cross-provider routing and policy stays in services
+
+If a change cuts across providers or databases, implement the shared behavior in the service layer and keep adapters thin.
+
+### Preserve Auditability And Operability
+
+When changing query execution, provider routing, exports, or observability:
+
+- Keep structured operational signals intact
+- Preserve release-gate and benchmark behavior where applicable
+- Avoid hiding failures that should surface in metrics, feedback, or logs
+
+## Change Guidance
+
+### When Changing API Behavior
+
+- Update the route implementation
+- Update `docs/api/openapi.yaml`
+- Update generated or handwritten frontend API types and affected UI code
+- Add or adjust backend tests when behavior changes
+
+### When Changing Query Generation Or Safety
+
+- Review `llmSqlService.js`, `sqlGenerator.js`, `sqlAstValidator.js`, `sqlSafety.js`, and `queryBudget.js` together
+- Test both valid reporting queries and rejection paths
+- Preserve confidence, citations, and feedback capture unless the change explicitly redesigns them
+
+### When Changing Schema Introspection Or RAG
+
+- Keep schema metadata and indexed documents consistent
+- Ensure reindex triggers still happen after introspection, semantic edits, or feedback examples
+- Verify provider-embedding fallback behavior remains coherent
+
+### When Changing Frontend UX
+
+- Keep desktop and mobile behavior reasonable
+- Preserve existing route structure unless there is a concrete navigation reason to change it
+- Prefer focused component updates over page-level sprawl
+
+## Testing Expectations
+
+At minimum, run the narrowest commands that exercise the changed surface.
+
+Common choices:
+
+- `npm test`
+- `npm run build`
+- `npm --prefix frontend run build`
+- `npm --prefix frontend run lint`
+
+For benchmark or release-gate work, also run the relevant benchmark flow.
+
+## Practical Notes
+
+- Environment variables live in `.env`; keep `.env.example` in sync when adding required config
+- Local test database fixtures and connection setup live under `/test-data`
+- Benchmark assets live under `/docs/evals`
+- Repo-local agent skills live under `.agents/skills/`
+- Planning docs in `/PLAN` and `IMPLEMENTATION_PLAN.md` describe feature intent, but the source of truth for runtime behavior is the code plus migrations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,251 +1,55 @@
-# AGENTS.md — Report Pilot
+# AGENTS.md - Report Pilot
 
-## Project Overview
+Report Pilot is a local-first NL-to-SQL reporting runtime. This file is canonical.
 
-Report Pilot is a local-first NL-to-SQL runtime for reporting workflows.
+## Commands
 
-It combines:
-
-- A Node.js backend API for schema ingestion, query orchestration, provider routing, and audit storage
-- A PostgreSQL metadata database managed by SQL migrations
-- A React frontend for data source setup, schema exploration, query authoring, provider management, and observability
-- A retrieval + LLM pipeline that turns natural-language reporting questions into validated read-only SQL
-
-The core design principle is a layered architecture:
-
-1. Adapter layer for database and LLM providers
-2. Service layer for orchestration and policy enforcement
-3. API layer for HTTP endpoints
-4. UI layer for admin and analyst workflows
-
-Keep responsibilities in those layers. Avoid scattering SQL safety or provider logic directly into route handlers or frontend components.
-
-## Build And Run
-
-```bash
-# Install root and frontend dependencies
-npm run setup
-
-# Run backend + frontend locally
-npm run dev
-
-# Run backend only
-npm run dev:be
-
-# Run frontend only
-npm run dev:fe
-
-# Apply DB migrations
-npm run migrate
-
-# Run backend tests
-npm test
-
-# Build everything
-npm run build
-
-# Build frontend only
-npm run build:fe
-
-# Run the benchmark suite
-npm run benchmark:mvp
-
-# Frontend lint
-npm --prefix frontend run lint
-```
-
-Docker local stack:
-
-```bash
-cp .env.example .env
-docker compose up --build
-```
-
-Default app port: `8080`
-
-## High-Level Architecture
-
-```text
-React UI (/frontend)
-  -> HTTP API (/app/src/server.js)
-      -> Service layer (/app/src/services)
-          -> LLM adapters (/app/src/adapters/llm)
-          -> DB adapters (/app/src/adapters)
-          -> Metadata DB (/db/migrations, app DB tables)
-          -> Target reporting databases (Postgres first, MSSQL supported)
-```
-
-### 1. Backend API (`/app/src`)
-
-The backend exposes health, data source, schema, query, provider, RAG, export, and observability endpoints.
-
-Key entry points:
-
-- `app/src/start.js` boots the service
-- `app/src/server.js` defines the HTTP API
-- `app/src/migrate.js` applies SQL migrations
-
-The backend owns:
-
-- Data source registration and introspection
-- Query session lifecycle
-- NL-to-SQL generation and retries
-- SQL validation and read-only enforcement
-- RAG indexing and retrieval
-- Provider health and routing
-- Observability, exports, and delivery flows
-
-### 2. Database Layer
-
-Application metadata lives in PostgreSQL and is defined by ordered SQL migrations in `/db/migrations`.
-
-Rules:
-
-- Add schema changes as new numbered migration files, never by editing applied migrations
-- Keep migration names descriptive
-- If a feature needs persisted state, update migrations first and then wire service logic to the new schema
-
-### 3. Database Adapters (`/app/src/adapters`)
-
-Database-specific execution and introspection belongs in adapters.
-
-Current adapters:
-
-- `postgresAdapter.js`
-- `mssqlAdapter.js`
-- `dbAdapterFactory.js`
-
-Keep dialect-specific quoting, validation, introspection, and execution in adapters rather than service code.
-
-### 4. LLM Provider Adapters (`/app/src/adapters/llm`)
-
-Provider-specific HTTP calls, health checks, and embedding generation belong here.
-
-Current providers:
-
-- OpenAI
-- Gemini
-- DeepSeek
-- OpenRouter
-- Custom adapter support
-
-Routing policy belongs in shared services such as `providerConfigService.js`, `llmSqlService.js`, and `embeddingRouter.js`, not inside individual provider adapters.
-
-### 5. Service Layer (`/app/src/services`)
-
-This is the core of the system.
-
-Important modules include:
-
-- `llmSqlService.js` and `sqlGenerator.js` for generation orchestration
-- `sqlAstValidator.js`, `sqlSafety.js`, and `queryBudget.js` for guardrails
-- `introspectionService.js` and `ddlImportService.js` for schema ingestion
-- `ragService.js` and `ragRetrieval.js` for indexing and retrieval
-- `providerConfigService.js` for provider config and routing
-- `observabilityService.js`, `exportService.js`, and `deliveryService.js` for operational workflows
-
-Prefer putting business rules here rather than in routes or UI code.
-
-### 6. Frontend (`/frontend/src`)
-
-The React frontend is organized by pages plus focused components.
-
-Primary areas:
-
-- `pages/QueryWorkspace.tsx` for the main analyst query flow
-- `pages/DataSources.tsx` and related dialogs for source setup and RAG notes
-- `pages/SchemaExplorer.tsx` for metadata browsing
-- `pages/LLMProviders.tsx` for provider configuration
-- `pages/Observability.tsx` and `pages/ReleaseGates.tsx` for operational visibility
-
-API client code lives under `frontend/src/lib/api`.
-
-If backend request or response shapes change, update:
-
-- `docs/api/openapi.yaml`
-- `frontend/src/lib/api/types.ts`
-- Any affected client calls or UI flows
-
-## Core Product Invariants
-
-These rules matter more than local implementation preference.
-
-### Read-Only SQL Only
-
-This project is for reporting queries. Do not introduce paths that allow writes, DDL, or unsafe escape hatches.
-
-- Preserve AST-based validation
-- Preserve read-only execution constraints
-- Preserve budget and plan checks unless there is a deliberate, reviewed design change
-
-### Ground SQL In Known Metadata
-
-Generated SQL should be grounded in introspected schema, semantic definitions, RAG notes, and validated examples.
-
-- Do not silently bypass retrieval or validation
-- Keep citations and confidence behavior aligned with the actual generation flow
-- Reindex RAG when schema or semantic inputs change
-
-### Keep Adapter Boundaries Clean
-
-- DB-specific logic stays in DB adapters
-- Provider-specific logic stays in LLM adapters
-- Cross-provider routing and policy stays in services
-
-If a change cuts across providers or databases, implement the shared behavior in the service layer and keep adapters thin.
-
-### Preserve Auditability And Operability
-
-When changing query execution, provider routing, exports, or observability:
-
-- Keep structured operational signals intact
-- Preserve release-gate and benchmark behavior where applicable
-- Avoid hiding failures that should surface in metrics, feedback, or logs
-
-## Change Guidance
-
-### When Changing API Behavior
-
-- Update the route implementation
-- Update `docs/api/openapi.yaml`
-- Update generated or handwritten frontend API types and affected UI code
-- Add or adjust backend tests when behavior changes
-
-### When Changing Query Generation Or Safety
-
-- Review `llmSqlService.js`, `sqlGenerator.js`, `sqlAstValidator.js`, `sqlSafety.js`, and `queryBudget.js` together
-- Test both valid reporting queries and rejection paths
-- Preserve confidence, citations, and feedback capture unless the change explicitly redesigns them
-
-### When Changing Schema Introspection Or RAG
-
-- Keep schema metadata and indexed documents consistent
-- Ensure reindex triggers still happen after introspection, semantic edits, or feedback examples
-- Verify provider-embedding fallback behavior remains coherent
-
-### When Changing Frontend UX
-
-- Keep desktop and mobile behavior reasonable
-- Preserve existing route structure unless there is a concrete navigation reason to change it
-- Prefer focused component updates over page-level sprawl
-
-## Testing Expectations
-
-At minimum, run the narrowest commands that exercise the changed surface.
-
-Common choices:
-
+- `npm run setup`
+- `npm run dev`
 - `npm test`
-- `npm run build`
-- `npm --prefix frontend run build`
+- `npm run migrate`
 - `npm --prefix frontend run lint`
 
-For benchmark or release-gate work, also run the relevant benchmark flow.
+## Code Map
 
-## Practical Notes
+- `app/src/services`: orchestration, policy, SQL safety, provider routing, RAG workflows. Prefer business logic here.
+- `app/src/adapters`: DB-specific introspection, quoting, validation, and execution.
+- `app/src/adapters/llm`: provider-specific calls, health checks, and embeddings.
+- `db/migrations`: metadata schema. Add new numbered migrations; never edit applied migrations.
+- `docs/api/openapi.yaml`: update when API request or response shapes change.
+- `frontend/src/lib/api/types.ts`: keep frontend API types aligned with backend shape changes.
+- `.agents/skills/`: repo-local skills.
 
-- Environment variables live in `.env`; keep `.env.example` in sync when adding required config
-- Local test database fixtures and connection setup live under `/test-data`
-- Benchmark assets live under `/docs/evals`
-- Repo-local agent skills live under `.agents/skills/`
-- Planning docs in `/PLAN` and `IMPLEMENTATION_PLAN.md` describe feature intent, but the source of truth for runtime behavior is the code plus migrations
+## Hard Rules
+
+- Keep reporting SQL read-only. Do not allow writes, DDL, or bypasses around validation, safety checks, or budgets.
+- Keep generated SQL grounded in introspected schema, semantic metadata, RAG notes, and validated examples.
+- Preserve auditability and operability. Do not hide failures that should surface in logs, metrics, feedback, release gates, or benchmarks.
+- Keep DB-specific behavior in DB adapters, provider-specific behavior in LLM adapters, and shared policy in services.
+- Avoid putting business logic in route handlers or frontend components.
+
+## High-Value Files
+
+- `app/src/server.js`, `app/src/start.js`, `app/src/migrate.js`
+- `app/src/services/llmSqlService.js`, `app/src/services/sqlGenerator.js`
+- `app/src/services/sqlAstValidator.js`, `app/src/services/sqlSafety.js`, `app/src/services/queryBudget.js`
+- `app/src/services/introspectionService.js`, `app/src/services/ddlImportService.js`
+- `app/src/services/ragService.js`, `app/src/services/ragRetrieval.js`
+- `app/src/services/providerConfigService.js`
+
+## Change Coupling
+
+- API shape changes: update route code, `docs/api/openapi.yaml`, `frontend/src/lib/api/types.ts`, and affected UI calls.
+- Query generation or safety changes: review `llmSqlService.js`, `sqlGenerator.js`, `sqlAstValidator.js`, `sqlSafety.js`, and `queryBudget.js` together.
+- Introspection or RAG changes: keep schema metadata and indexed documents aligned; preserve reindex triggers after schema or semantic changes.
+- Persisted state changes: add a migration before wiring service logic.
+
+## Verification
+
+- Run the narrowest relevant checks.
+- Common checks: `npm test`, `npm run migrate`, `npm --prefix frontend run lint`
+
+## Notes
+
+- Keep `.env.example` in sync with required config changes.
+- Runtime behavior is defined by code and migrations, not planning docs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Claude Instructions
+
+Read and follow `AGENTS.md` first. It is the canonical project guide for this repository.
+
+Additional Claude-specific notes:
+
+- Apply `AGENTS.md` as the source of truth. If this file and `AGENTS.md` ever differ, `AGENTS.md` wins.
+- Preserve the read-only reporting model. Do not bypass SQL validation, execution safety checks, RAG grounding, or provider-routing guardrails.
+- Keep database-specific behavior in adapters, cross-provider orchestration in services, and UI-only concerns in the frontend.
+- When API behavior changes, update `docs/api/openapi.yaml` and the affected frontend API types.
+- Repo-local Claude/Codex skills live under `.agents/skills/`.
+- Prefer the standard repo commands listed in `AGENTS.md`.
+- Treat `.claude/worktrees/` as local machine state. Do not rely on it or commit changes from it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,7 @@
 # Claude Instructions
 
-Read and follow `AGENTS.md` first. It is the canonical project guide for this repository.
+Read and follow `AGENTS.md` first. It is canonical.
 
-Additional Claude-specific notes:
+If this file conflicts with `AGENTS.md`, `AGENTS.md` wins.
 
-- Apply `AGENTS.md` as the source of truth. If this file and `AGENTS.md` ever differ, `AGENTS.md` wins.
-- Preserve the read-only reporting model. Do not bypass SQL validation, execution safety checks, RAG grounding, or provider-routing guardrails.
-- Keep database-specific behavior in adapters, cross-provider orchestration in services, and UI-only concerns in the frontend.
-- When API behavior changes, update `docs/api/openapi.yaml` and the affected frontend API types.
-- Repo-local Claude/Codex skills live under `.agents/skills/`.
-- Prefer the standard repo commands listed in `AGENTS.md`.
-- Treat `.claude/worktrees/` as local machine state. Do not rely on it or commit changes from it.
+Treat `.claude/worktrees/` as local machine state. Do not rely on it or commit it.


### PR DESCRIPTION
## Summary
- add AGENTS.md as the canonical repository guide for local contributors and automation workflows
- add repo-local commit and PR creation skill instructions under .agents/skills
- add CLAUDE.md guidance and ignore local .claude/worktrees state in git

## Verification
- not run; docs-only change