### PR TITLE
Add parameterized saved query support

### DIFF
--- a/app/src/adapters/mssqlAdapter.js
+++ b/app/src/adapters/mssqlAdapter.js
@@ -1,5 +1,6 @@
 const sql = require("mssql");
 const { validateAstReadOnly } = require("../services/sqlAstValidator");
+const { extractPlaceholders, replaceNamedPlaceholders } = require("../services/queryParameterParser");
 
 class MssqlAdapter {
   constructor(connectionString) {
@@ -197,11 +198,47 @@ class MssqlAdapter {
   }
 
   async executeReadOnly(sqlText, opts = {}) {
+    return this.executeWithRequest((request) => request.query(sqlText), opts);
+  }
+
+  async executeParameterizedReadOnly(sqlText, paramValues, paramSchema, opts = {}) {
+    const placeholders = extractPlaceholders(sqlText);
+    const schemaByName = new Map(
+      (Array.isArray(paramSchema) ? paramSchema : []).map((entry) => [entry.name, entry])
+    );
+    const usedNames = new Set();
+    const transformedSql = replaceNamedPlaceholders(sqlText, (name) => {
+      usedNames.add(name);
+      return `@${name}`;
+    });
+
+    return this.executeWithRequest((request) => {
+      for (const name of placeholders) {
+        if (usedNames.has(name) && !Object.prototype.hasOwnProperty.call(paramValues || {}, name)) {
+          throw new Error(`Missing parameter value for :${name}`);
+        }
+        if (!usedNames.has(name)) {
+          continue;
+        }
+        const type = schemaByName.get(name)?.type || "text";
+        request.input(name, getMssqlParameterType(type), convertMssqlParameterValue(type, paramValues[name]));
+      }
+      return request.query(transformedSql);
+    }, opts);
+  }
+
+  async executeWithRequest(runQuery, opts = {}) {
     const timeoutMs = Number(opts.timeoutMs || 20000);
     const maxRows = Number(opts.maxRows || 1000);
     const startedAt = Date.now();
 
-    const result = await this.query(sqlText, timeoutMs);
+    await this.poolConnect;
+    const request = this.pool.request();
+    if (Number.isFinite(timeoutMs)) {
+      request.timeout = timeoutMs;
+    }
+
+    const result = await runQuery(request);
     const rows = tables(result);
     const columns = extractColumns(result, rows);
     const truncated = rows.length > maxRows;
@@ -399,6 +436,38 @@ function parseIndexColumns(rawColumns) {
     .split(",")
     .map((part) => part.trim().replace(/[\[\]]/g, ""))
     .filter(Boolean);
+}
+
+function getMssqlParameterType(type) {
+  if (type === "integer") {
+    return sql.Int;
+  }
+  if (type === "decimal") {
+    return sql.Decimal(18, 6);
+  }
+  if (type === "date") {
+    return sql.Date;
+  }
+  if (type === "boolean") {
+    return sql.Bit;
+  }
+  if (type === "timestamp") {
+    return sql.DateTime2;
+  }
+  return sql.NVarChar(sql.MAX);
+}
+
+function convertMssqlParameterValue(type, value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (type === "timestamp") {
+    return new Date(value);
+  }
+  if (type === "date") {
+    return new Date(`${value}T00:00:00.000Z`);
+  }
+  return value;
 }
 
 function normalizeMssqlValidationError(err) {

--- a/app/src/adapters/postgresAdapter.js
+++ b/app/src/adapters/postgresAdapter.js
@@ -1,5 +1,6 @@
 const { Pool } = require("pg");
 const { validateAstReadOnly } = require("../services/sqlAstValidator");
+const { replaceNamedPlaceholders } = require("../services/queryParameterParser");
 
 class PostgresAdapter {
   constructor(connectionString) {
@@ -147,6 +148,15 @@ class PostgresAdapter {
   }
 
   async executeReadOnly(sql, opts = {}) {
+    return this.executeWithReadOnlyTransaction(() => sql, opts);
+  }
+
+  async executeParameterizedReadOnly(sql, paramValues, opts = {}) {
+    const { text, values } = transformPostgresNamedParameters(sql, paramValues);
+    return this.executeWithReadOnlyTransaction(() => ({ text, values }), opts);
+  }
+
+  async executeWithReadOnlyTransaction(buildQuery, opts = {}) {
     const timeoutMs = Number(opts.timeoutMs || 20000);
     const maxRows = Number(opts.maxRows || 1000);
 
@@ -155,7 +165,7 @@ class PostgresAdapter {
     try {
       await client.query("BEGIN");
       await client.query(`SET LOCAL statement_timeout = ${Number.isFinite(timeoutMs) ? timeoutMs : 20000}`);
-      const result = await client.query(sql);
+      const result = await client.query(buildQuery());
       await client.query("COMMIT");
 
       const rows = Array.isArray(result.rows) ? result.rows : [];
@@ -194,6 +204,26 @@ class PostgresAdapter {
   quoteIdentifier(identifier) {
     return `"${String(identifier).replace(/"/g, "\"\"")}"`;
   }
+}
+
+function transformPostgresNamedParameters(sql, paramValues) {
+  const values = [];
+  const positions = new Map();
+
+  const text = replaceNamedPlaceholders(sql, (name, rawMatch) => {
+    if (!Object.prototype.hasOwnProperty.call(paramValues || {}, name)) {
+      throw new Error(`Missing parameter value for :${name}`);
+    }
+
+    if (!positions.has(name)) {
+      positions.set(name, values.length + 1);
+      values.push(paramValues[name]);
+    }
+
+    return `$${positions.get(name)}`;
+  });
+
+  return { text, values };
 }
 
 function formatPgObject(val) {

--- a/app/src/lib/constants.js
+++ b/app/src/lib/constants.js
@@ -16,6 +16,9 @@ const RAG_NOTE_CONTENT_MAX_LENGTH = 20000;
 const SAVED_QUERY_NAME_MAX_LENGTH = 200;
 const SAVED_QUERY_DESCRIPTION_MAX_LENGTH = 1000;
 const SAVED_QUERY_DEFAULT_RUN_PARAM_KEYS = new Set(["llm_provider", "model", "max_rows", "timeout_ms", "no_execute"]);
+const PARAMETER_TYPES = new Set(["text", "integer", "decimal", "date", "boolean", "timestamp"]);
+const PARAMETER_NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
+const MAX_PARAMETER_COUNT = 50;
 const OPENAPI_SPEC_PATH = path.resolve(__dirname, "../../../docs/api/openapi.yaml");
 const FRONTEND_DIST_PATH = path.resolve(__dirname, "../../../frontend/dist");
 const FRONTEND_INDEX_PATH = path.join(FRONTEND_DIST_PATH, "index.html");
@@ -50,6 +53,9 @@ module.exports = {
   SAVED_QUERY_NAME_MAX_LENGTH,
   SAVED_QUERY_DESCRIPTION_MAX_LENGTH,
   SAVED_QUERY_DEFAULT_RUN_PARAM_KEYS,
+  PARAMETER_TYPES,
+  PARAMETER_NAME_PATTERN,
+  MAX_PARAMETER_COUNT,
   OPENAPI_SPEC_PATH,
   FRONTEND_DIST_PATH,
   FRONTEND_INDEX_PATH,

--- a/app/src/routes/savedQueries.js
+++ b/app/src/routes/savedQueries.js
@@ -2,15 +2,134 @@ const appDb = require("../lib/appDb");
 const { json, badRequest, readJsonBody } = require("../lib/http");
 const { SAVED_QUERY_NAME_MAX_LENGTH, SAVED_QUERY_DESCRIPTION_MAX_LENGTH } = require("../lib/constants");
 const {
+  clamp,
   isUuid,
   isPgUniqueViolation,
   normalizeOptionalTrimmedString,
   validateSavedQueryDefaultRunParams
 } = require("../lib/validation");
+const { createDatabaseAdapter, isSupportedDbType } = require("../adapters/dbAdapterFactory");
+const { validateAndNormalizeSql, sanitizeGeneratedSql, ensureLimit } = require("../services/sqlSafety");
+const {
+  extractPlaceholders,
+  buildParameterSchemaFromPlaceholders
+} = require("../services/queryParameterParser");
+const {
+  validateParameterSchema,
+  validateParameterValues,
+  substitutePlaceholdersForValidation
+} = require("../services/queryParameterService");
 
 async function ensureDataSourceExists(dataSourceId) {
   const sourceResult = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [dataSourceId]);
   return sourceResult.rowCount > 0;
+}
+
+async function loadSavedQuery(savedQueryId) {
+  const result = await appDb.query(
+    `
+      SELECT
+        id,
+        owner_id,
+        name,
+        description,
+        data_source_id,
+        sql,
+        default_run_params,
+        parameter_schema,
+        created_at,
+        updated_at
+      FROM saved_queries
+      WHERE id = $1
+    `,
+    [savedQueryId]
+  );
+
+  return result.rows[0] || null;
+}
+
+async function loadSavedQueryForExecution(savedQueryId) {
+  const result = await appDb.query(
+    `
+      SELECT
+        sq.id,
+        sq.owner_id,
+        sq.name,
+        sq.description,
+        sq.data_source_id,
+        sq.sql,
+        sq.default_run_params,
+        sq.parameter_schema,
+        sq.created_at,
+        sq.updated_at,
+        ds.connection_ref,
+        ds.db_type
+      FROM saved_queries sq
+      JOIN data_sources ds ON ds.id = sq.data_source_id
+      WHERE sq.id = $1
+    `,
+    [savedQueryId]
+  );
+
+  return result.rows[0] || null;
+}
+
+async function loadSchemaObjects(dataSourceId) {
+  const result = await appDb.query(
+    `
+      SELECT schema_name, object_name
+      FROM schema_objects
+      WHERE data_source_id = $1
+        AND is_ignored = FALSE
+        AND object_type IN ('table', 'view', 'materialized_view')
+    `,
+    [dataSourceId]
+  );
+
+  return result.rows;
+}
+
+function resolveParameterSchema(sql, providedParameterSchema, existingSchema) {
+  const placeholders = extractPlaceholders(sql);
+
+  if (providedParameterSchema === undefined) {
+    return {
+      ok: true,
+      value: buildParameterSchemaFromPlaceholders(placeholders, existingSchema)
+    };
+  }
+
+  const schemaValidation = validateParameterSchema(providedParameterSchema);
+  if (!schemaValidation.ok) {
+    return schemaValidation;
+  }
+
+  return {
+    ok: true,
+    value: buildParameterSchemaFromPlaceholders(placeholders, schemaValidation.value)
+  };
+}
+
+function resolveSavedQueryRunOptions(defaultRunParams, body) {
+  const merged = {
+    max_rows: defaultRunParams?.max_rows,
+    timeout_ms: defaultRunParams?.timeout_ms
+  };
+
+  if (Object.prototype.hasOwnProperty.call(body || {}, "max_rows")) {
+    merged.max_rows = body.max_rows;
+  }
+  if (Object.prototype.hasOwnProperty.call(body || {}, "timeout_ms")) {
+    merged.timeout_ms = body.timeout_ms;
+  }
+
+  const maxRows = Number(merged.max_rows);
+  const timeoutMs = Number(merged.timeout_ms);
+
+  return {
+    maxRows: clamp(Number.isFinite(maxRows) ? maxRows : 1000, 1, 100000),
+    timeoutMs: clamp(Number.isFinite(timeoutMs) ? timeoutMs : 20000, 1000, 120000)
+  };
 }
 
 async function handleCreateSavedQuery(req, res) {
@@ -21,6 +140,7 @@ async function handleCreateSavedQuery(req, res) {
   const sql = typeof body.sql === "string" ? body.sql.trim() : "";
   const description = normalizeOptionalTrimmedString(body.description);
   const defaultRunParamsValidation = validateSavedQueryDefaultRunParams(body.default_run_params);
+  const parameterSchemaValidation = resolveParameterSchema(sql, body.parameter_schema, []);
 
   if (!name || !dataSourceId || !sql) {
     return badRequest(res, "name, data_source_id and sql are required");
@@ -37,6 +157,9 @@ async function handleCreateSavedQuery(req, res) {
   if (!defaultRunParamsValidation.ok) {
     return badRequest(res, defaultRunParamsValidation.message);
   }
+  if (!parameterSchemaValidation.ok) {
+    return badRequest(res, parameterSchemaValidation.message);
+  }
 
   if (!(await ensureDataSourceExists(dataSourceId))) {
     return json(res, 404, { error: "not_found", message: "Data source not found" });
@@ -51,8 +174,9 @@ async function handleCreateSavedQuery(req, res) {
           description,
           data_source_id,
           sql,
-          default_run_params
-        ) VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+          default_run_params,
+          parameter_schema
+        ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb)
         RETURNING
           id,
           owner_id,
@@ -61,10 +185,19 @@ async function handleCreateSavedQuery(req, res) {
           data_source_id,
           sql,
           default_run_params,
+          parameter_schema,
           created_at,
           updated_at
       `,
-      [ownerId, name, description, dataSourceId, sql, JSON.stringify(defaultRunParamsValidation.value)]
+      [
+        ownerId,
+        name,
+        description,
+        dataSourceId,
+        sql,
+        JSON.stringify(defaultRunParamsValidation.value),
+        JSON.stringify(parameterSchemaValidation.value)
+      ]
     );
 
     return json(res, 201, insertResult.rows[0]);
@@ -95,6 +228,7 @@ async function handleListSavedQueries(_req, res, requestUrl) {
         data_source_id,
         sql,
         default_run_params,
+        parameter_schema,
         created_at,
         updated_at
       FROM saved_queries
@@ -112,29 +246,12 @@ async function handleGetSavedQuery(_req, res, savedQueryId) {
     return badRequest(res, "savedQueryId must be a valid UUID");
   }
 
-  const result = await appDb.query(
-    `
-      SELECT
-        id,
-        owner_id,
-        name,
-        description,
-        data_source_id,
-        sql,
-        default_run_params,
-        created_at,
-        updated_at
-      FROM saved_queries
-      WHERE id = $1
-    `,
-    [savedQueryId]
-  );
-
-  if (result.rowCount === 0) {
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
     return json(res, 404, { error: "not_found", message: "Saved query not found" });
   }
 
-  return json(res, 200, result.rows[0]);
+  return json(res, 200, savedQuery);
 }
 
 async function handleUpdateSavedQuery(req, res, savedQueryId) {
@@ -143,11 +260,17 @@ async function handleUpdateSavedQuery(req, res, savedQueryId) {
   }
 
   const body = await readJsonBody(req);
+  const existingSavedQuery = await loadSavedQuery(savedQueryId);
+  if (!existingSavedQuery) {
+    return json(res, 404, { error: "not_found", message: "Saved query not found" });
+  }
+
   const dataSourceId = String(body.data_source_id || "").trim();
   const name = typeof body.name === "string" ? body.name.trim() : "";
   const sql = typeof body.sql === "string" ? body.sql.trim() : "";
   const description = normalizeOptionalTrimmedString(body.description);
   const defaultRunParamsValidation = validateSavedQueryDefaultRunParams(body.default_run_params);
+  const parameterSchemaValidation = resolveParameterSchema(sql, body.parameter_schema, existingSavedQuery.parameter_schema);
 
   if (!name || !dataSourceId || !sql) {
     return badRequest(res, "name, data_source_id and sql are required");
@@ -164,6 +287,9 @@ async function handleUpdateSavedQuery(req, res, savedQueryId) {
   if (!defaultRunParamsValidation.ok) {
     return badRequest(res, defaultRunParamsValidation.message);
   }
+  if (!parameterSchemaValidation.ok) {
+    return badRequest(res, parameterSchemaValidation.message);
+  }
 
   if (!(await ensureDataSourceExists(dataSourceId))) {
     return json(res, 404, { error: "not_found", message: "Data source not found" });
@@ -179,6 +305,7 @@ async function handleUpdateSavedQuery(req, res, savedQueryId) {
           data_source_id = $4,
           sql = $5,
           default_run_params = $6::jsonb,
+          parameter_schema = $7::jsonb,
           updated_at = NOW()
         WHERE id = $1
         RETURNING
@@ -189,15 +316,20 @@ async function handleUpdateSavedQuery(req, res, savedQueryId) {
           data_source_id,
           sql,
           default_run_params,
+          parameter_schema,
           created_at,
           updated_at
       `,
-      [savedQueryId, name, description, dataSourceId, sql, JSON.stringify(defaultRunParamsValidation.value)]
+      [
+        savedQueryId,
+        name,
+        description,
+        dataSourceId,
+        sql,
+        JSON.stringify(defaultRunParamsValidation.value),
+        JSON.stringify(parameterSchemaValidation.value)
+      ]
     );
-
-    if (updateResult.rowCount === 0) {
-      return json(res, 404, { error: "not_found", message: "Saved query not found" });
-    }
 
     return json(res, 200, updateResult.rows[0]);
   } catch (err) {
@@ -232,10 +364,106 @@ async function handleDeleteSavedQuery(_req, res, savedQueryId) {
   return json(res, 200, { ok: true, id: deleteResult.rows[0].id });
 }
 
+async function handleValidateParams(req, res, savedQueryId) {
+  if (!isUuid(savedQueryId)) {
+    return badRequest(res, "savedQueryId must be a valid UUID");
+  }
+
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
+    return json(res, 404, { error: "not_found", message: "Saved query not found" });
+  }
+
+  const body = await readJsonBody(req);
+  const validation = validateParameterValues(savedQuery.parameter_schema, body.params);
+  if (!validation.ok) {
+    return json(res, 200, { ok: false, errors: validation.errors });
+  }
+
+  return json(res, 200, { ok: true, resolved_values: validation.resolvedValues });
+}
+
+async function handleRunSavedQuery(req, res, savedQueryId) {
+  if (!isUuid(savedQueryId)) {
+    return badRequest(res, "savedQueryId must be a valid UUID");
+  }
+
+  const savedQuery = await loadSavedQueryForExecution(savedQueryId);
+  if (!savedQuery) {
+    return json(res, 404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (!isSupportedDbType(savedQuery.db_type)) {
+    return badRequest(res, `Unsupported db_type for execution: ${savedQuery.db_type}`);
+  }
+
+  const body = await readJsonBody(req);
+  const parameterValidation = validateParameterValues(savedQuery.parameter_schema, body.params);
+  if (!parameterValidation.ok) {
+    return json(res, 400, {
+      error: "bad_request",
+      message: "Invalid saved query parameters",
+      errors: parameterValidation.errors
+    });
+  }
+
+  const dialect = savedQuery.db_type === "mssql" ? "mssql" : "postgres";
+  const { maxRows, timeoutMs } = resolveSavedQueryRunOptions(savedQuery.default_run_params, body);
+  const executableSql = ensureLimit(sanitizeGeneratedSql(savedQuery.sql), maxRows, dialect);
+  const schemaObjects = await loadSchemaObjects(savedQuery.data_source_id);
+  const validationSql = substitutePlaceholdersForValidation(executableSql, savedQuery.parameter_schema);
+  const normalized = validateAndNormalizeSql(validationSql, {
+    maxRows,
+    schemaObjects,
+    dialect
+  });
+
+  if (!normalized.ok) {
+    return json(res, 400, {
+      error: "bad_request",
+      message: normalized.errors.join("; "),
+      errors: normalized.errors
+    });
+  }
+
+  let adapter = null;
+  try {
+    adapter = createDatabaseAdapter(savedQuery.db_type, savedQuery.connection_ref);
+    const adapterValidation = await adapter.validateSql(normalized.sql);
+    if (!adapterValidation.ok) {
+      return json(res, 400, {
+        error: "bad_request",
+        message: adapterValidation.errors.join("; "),
+        errors: adapterValidation.errors
+      });
+    }
+
+    const execution = await adapter.executeParameterizedReadOnly(
+      executableSql,
+      parameterValidation.resolvedValues,
+      savedQuery.parameter_schema,
+      { maxRows, timeoutMs }
+    );
+
+    return json(res, 200, {
+      sql: executableSql,
+      columns: execution.columns,
+      rows: execution.rows,
+      row_count: execution.rowCount,
+      duration_ms: execution.durationMs
+    });
+  } finally {
+    if (adapter) {
+      await adapter.close();
+    }
+  }
+}
+
 module.exports = {
   handleCreateSavedQuery,
   handleListSavedQueries,
   handleGetSavedQuery,
   handleUpdateSavedQuery,
-  handleDeleteSavedQuery
+  handleDeleteSavedQuery,
+  handleValidateParams,
+  handleRunSavedQuery
 };

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -49,7 +49,9 @@ const {
   handleListSavedQueries,
   handleGetSavedQuery,
   handleUpdateSavedQuery,
-  handleDeleteSavedQuery
+  handleDeleteSavedQuery,
+  handleValidateParams,
+  handleRunSavedQuery
 } = require("./routes/savedQueries");
 const {
   handleExportSession,
@@ -176,6 +178,16 @@ async function routeRequest(req, res) {
 
   if (req.method === "GET" && pathname === "/v1/saved-queries") {
     return handleListSavedQueries(req, res, requestUrl);
+  }
+
+  const savedQueryValidateParamsMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/validate-params$/);
+  if (req.method === "POST" && savedQueryValidateParamsMatch) {
+    return handleValidateParams(req, res, savedQueryValidateParamsMatch[1]);
+  }
+
+  const savedQueryRunMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/run$/);
+  if (req.method === "POST" && savedQueryRunMatch) {
+    return handleRunSavedQuery(req, res, savedQueryRunMatch[1]);
   }
 
   const savedQueryMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)$/);

--- a/app/src/services/queryParameterParser.js
+++ b/app/src/services/queryParameterParser.js
@@ -1,0 +1,135 @@
+const PLACEHOLDER_REGEX = /(?<!:):([a-z][a-z0-9_]*)\b/gi;
+
+function createDefaultParameterSchemaEntry(name) {
+  return {
+    name,
+    type: "text",
+    required: true,
+    default: null,
+    allowed_values: null
+  };
+}
+
+function stripSingleQuotedLiterals(sql) {
+  const text = String(sql || "");
+  let output = "";
+  let index = 0;
+
+  while (index < text.length) {
+    if (text[index] !== "'") {
+      output += text[index];
+      index += 1;
+      continue;
+    }
+
+    output += " ";
+    index += 1;
+
+    while (index < text.length) {
+      output += " ";
+
+      if (text[index] === "'" && text[index + 1] === "'") {
+        output += " ";
+        index += 2;
+        continue;
+      }
+
+      if (text[index] === "'") {
+        index += 1;
+        break;
+      }
+
+      index += 1;
+    }
+  }
+
+  return output;
+}
+
+function extractPlaceholders(sql) {
+  const stripped = stripSingleQuotedLiterals(sql);
+  const seen = new Set();
+  const placeholders = [];
+
+  for (const match of stripped.matchAll(PLACEHOLDER_REGEX)) {
+    const name = String(match[1] || "").toLowerCase();
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    placeholders.push(name);
+  }
+
+  return placeholders;
+}
+
+function buildParameterSchemaFromPlaceholders(placeholders, existingSchema = []) {
+  const existingMap = new Map();
+  for (const entry of Array.isArray(existingSchema) ? existingSchema : []) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry) || typeof entry.name !== "string") {
+      continue;
+    }
+    existingMap.set(entry.name, {
+      name: entry.name,
+      type: typeof entry.type === "string" ? entry.type : "text",
+      required: entry.required !== false,
+      default: Object.prototype.hasOwnProperty.call(entry, "default") ? entry.default : null,
+      allowed_values: Object.prototype.hasOwnProperty.call(entry, "allowed_values") ? entry.allowed_values : null
+    });
+  }
+
+  return (Array.isArray(placeholders) ? placeholders : []).map((name) => existingMap.get(name) || createDefaultParameterSchemaEntry(name));
+}
+
+function replaceNamedPlaceholders(sql, replacer) {
+  const text = String(sql || "");
+  let output = "";
+  let index = 0;
+
+  while (index < text.length) {
+    if (text[index] === "'") {
+      output += "'";
+      index += 1;
+
+      while (index < text.length) {
+        output += text[index];
+
+        if (text[index] === "'" && text[index + 1] === "'") {
+          output += "'";
+          index += 2;
+          continue;
+        }
+
+        if (text[index] === "'") {
+          index += 1;
+          break;
+        }
+
+        index += 1;
+      }
+
+      continue;
+    }
+
+    const slice = text.slice(index);
+    const match = slice.match(/^:([a-z][a-z0-9_]*)\b/i);
+    if (match && text[index - 1] !== ":") {
+      const placeholderName = String(match[1] || "").toLowerCase();
+      output += String(replacer(placeholderName, match[0]));
+      index += match[0].length;
+      continue;
+    }
+
+    output += text[index];
+    index += 1;
+  }
+
+  return output;
+}
+
+module.exports = {
+  extractPlaceholders,
+  buildParameterSchemaFromPlaceholders,
+  replaceNamedPlaceholders,
+  stripSingleQuotedLiterals
+};

--- a/app/src/services/queryParameterService.js
+++ b/app/src/services/queryParameterService.js
@@ -1,0 +1,303 @@
+const {
+  PARAMETER_TYPES,
+  PARAMETER_NAME_PATTERN,
+  MAX_PARAMETER_COUNT
+} = require("../lib/constants");
+const { replaceNamedPlaceholders } = require("./queryParameterParser");
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseDateOnly(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [year, month, day] = value.split("-").map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year
+    || parsed.getUTCMonth() !== month - 1
+    || parsed.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return value;
+}
+
+function coerceParameterValue(type, value) {
+  if (value === null || value === undefined) {
+    return { ok: true, value: null };
+  }
+
+  if (type === "text") {
+    if (typeof value === "string") {
+      return { ok: true, value };
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      return { ok: true, value: String(value) };
+    }
+    return { ok: false, message: "must be a string" };
+  }
+
+  if (type === "integer") {
+    if (typeof value === "number" && Number.isInteger(value)) {
+      return { ok: true, value };
+    }
+    if (typeof value === "string" && /^[-+]?\d+$/.test(value.trim())) {
+      const parsed = Number(value.trim());
+      if (Number.isInteger(parsed)) {
+        return { ok: true, value: parsed };
+      }
+    }
+    return { ok: false, message: "must be an integer" };
+  }
+
+  if (type === "decimal") {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return { ok: true, value };
+    }
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number(value.trim());
+      if (Number.isFinite(parsed)) {
+        return { ok: true, value: parsed };
+      }
+    }
+    return { ok: false, message: "must be a decimal number" };
+  }
+
+  if (type === "date") {
+    const normalized = parseDateOnly(typeof value === "string" ? value.trim() : value);
+    if (normalized) {
+      return { ok: true, value: normalized };
+    }
+    return { ok: false, message: "must be a valid date in YYYY-MM-DD format" };
+  }
+
+  if (type === "boolean") {
+    if (typeof value === "boolean") {
+      return { ok: true, value };
+    }
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === "true") {
+        return { ok: true, value: true };
+      }
+      if (normalized === "false") {
+        return { ok: true, value: false };
+      }
+    }
+    return { ok: false, message: "must be true or false" };
+  }
+
+  if (type === "timestamp") {
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      return { ok: true, value: value.toISOString() };
+    }
+    if (typeof value === "string" && value.trim()) {
+      const parsed = new Date(value.trim());
+      if (!Number.isNaN(parsed.getTime())) {
+        return { ok: true, value: parsed.toISOString() };
+      }
+    }
+    return { ok: false, message: "must be a valid timestamp" };
+  }
+
+  return { ok: false, message: "has an unsupported type" };
+}
+
+function validateParameterSchema(schema) {
+  if (schema === undefined) {
+    return { ok: true, value: [] };
+  }
+
+  if (!Array.isArray(schema)) {
+    return { ok: false, message: "parameter_schema must be an array" };
+  }
+
+  if (schema.length > MAX_PARAMETER_COUNT) {
+    return { ok: false, message: `parameter_schema cannot contain more than ${MAX_PARAMETER_COUNT} parameters` };
+  }
+
+  const seenNames = new Set();
+  const normalized = [];
+
+  for (const entry of schema) {
+    if (!isPlainObject(entry)) {
+      return { ok: false, message: "parameter_schema entries must be objects" };
+    }
+
+    const name = typeof entry.name === "string" ? entry.name.trim().toLowerCase() : "";
+    if (!PARAMETER_NAME_PATTERN.test(name)) {
+      return { ok: false, message: "parameter_schema names must match /^[a-z][a-z0-9_]*$/" };
+    }
+    if (seenNames.has(name)) {
+      return { ok: false, message: `parameter_schema contains duplicate parameter name: ${name}` };
+    }
+    seenNames.add(name);
+
+    const type = typeof entry.type === "string" ? entry.type.trim().toLowerCase() : "text";
+    if (!PARAMETER_TYPES.has(type)) {
+      return { ok: false, message: `parameter_schema.${name}.type is not supported` };
+    }
+
+    const required = entry.required === undefined ? true : entry.required;
+    if (typeof required !== "boolean") {
+      return { ok: false, message: `parameter_schema.${name}.required must be a boolean` };
+    }
+
+    const allowedValues = entry.allowed_values === undefined ? null : entry.allowed_values;
+    if (allowedValues !== null && !Array.isArray(allowedValues)) {
+      return { ok: false, message: `parameter_schema.${name}.allowed_values must be an array or null` };
+    }
+
+    let normalizedAllowedValues = null;
+    if (Array.isArray(allowedValues)) {
+      normalizedAllowedValues = [];
+      const allowedSet = new Set();
+      for (const rawAllowedValue of allowedValues) {
+        const coercedAllowedValue = coerceParameterValue(type, rawAllowedValue);
+        if (!coercedAllowedValue.ok || coercedAllowedValue.value === null) {
+          return { ok: false, message: `parameter_schema.${name}.allowed_values contains an invalid value` };
+        }
+        const key = JSON.stringify(coercedAllowedValue.value);
+        if (allowedSet.has(key)) {
+          continue;
+        }
+        allowedSet.add(key);
+        normalizedAllowedValues.push(coercedAllowedValue.value);
+      }
+    }
+
+    const defaultValue = entry.default === undefined ? null : entry.default;
+    let normalizedDefaultValue = null;
+    if (defaultValue !== null) {
+      const coercedDefault = coerceParameterValue(type, defaultValue);
+      if (!coercedDefault.ok) {
+        return { ok: false, message: `parameter_schema.${name}.default ${coercedDefault.message}` };
+      }
+      normalizedDefaultValue = coercedDefault.value;
+    }
+
+    if (normalizedAllowedValues && normalizedDefaultValue !== null) {
+      const defaultKey = JSON.stringify(normalizedDefaultValue);
+      const allowedKeys = new Set(normalizedAllowedValues.map((value) => JSON.stringify(value)));
+      if (!allowedKeys.has(defaultKey)) {
+        return { ok: false, message: `parameter_schema.${name}.default must be included in allowed_values` };
+      }
+    }
+
+    normalized.push({
+      name,
+      type,
+      required,
+      default: normalizedDefaultValue,
+      allowed_values: normalizedAllowedValues
+    });
+  }
+
+  return { ok: true, value: normalized };
+}
+
+function validateParameterValues(parameterSchema, suppliedValues) {
+  const schemaValidation = validateParameterSchema(parameterSchema);
+  if (!schemaValidation.ok) {
+    return {
+      ok: false,
+      errors: [{ param: null, message: schemaValidation.message }]
+    };
+  }
+
+  if (suppliedValues !== undefined && !isPlainObject(suppliedValues)) {
+    return {
+      ok: false,
+      errors: [{ param: null, message: "params must be an object" }]
+    };
+  }
+
+  const params = suppliedValues || {};
+  const resolvedValues = {};
+  const errors = [];
+  const knownNames = new Set(schemaValidation.value.map((entry) => entry.name));
+
+  for (const entry of schemaValidation.value) {
+    const hasSuppliedValue = Object.prototype.hasOwnProperty.call(params, entry.name);
+    const rawValue = hasSuppliedValue ? params[entry.name] : undefined;
+
+    if (rawValue === undefined || rawValue === null) {
+      if (entry.default !== null) {
+        resolvedValues[entry.name] = entry.default;
+        continue;
+      }
+      if (entry.required) {
+        errors.push({ param: entry.name, message: "is required" });
+        continue;
+      }
+      resolvedValues[entry.name] = null;
+      continue;
+    }
+
+    const coerced = coerceParameterValue(entry.type, rawValue);
+    if (!coerced.ok) {
+      errors.push({ param: entry.name, message: coerced.message });
+      continue;
+    }
+
+    if (entry.allowed_values) {
+      const allowedKeys = new Set(entry.allowed_values.map((value) => JSON.stringify(value)));
+      if (!allowedKeys.has(JSON.stringify(coerced.value))) {
+        errors.push({ param: entry.name, message: "must be one of the allowed values" });
+        continue;
+      }
+    }
+
+    resolvedValues[entry.name] = coerced.value;
+  }
+
+  for (const name of Object.keys(params)) {
+    if (!knownNames.has(name)) {
+      errors.push({ param: name, message: "is not defined in parameter_schema" });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, resolvedValues };
+}
+
+function substitutePlaceholdersForValidation(sql, parameterSchema) {
+  const schemaValidation = validateParameterSchema(parameterSchema);
+  const schema = schemaValidation.ok ? schemaValidation.value : [];
+  const schemaByName = new Map(schema.map((entry) => [entry.name, entry]));
+
+  return replaceNamedPlaceholders(sql, (name) => {
+    const type = schemaByName.get(name)?.type || "text";
+
+    if (type === "integer") {
+      return "0";
+    }
+    if (type === "decimal") {
+      return "0.0";
+    }
+    if (type === "date") {
+      return "'1900-01-01'";
+    }
+    if (type === "boolean") {
+      return "1";
+    }
+    if (type === "timestamp") {
+      return "'1900-01-01T00:00:00.000Z'";
+    }
+    return "'x'";
+  });
+}
+
+module.exports = {
+  validateParameterSchema,
+  validateParameterValues,
+  substitutePlaceholdersForValidation
+};

--- a/app/src/services/sqlSafety.js
+++ b/app/src/services/sqlSafety.js
@@ -182,5 +182,6 @@ function validateAndNormalizeSql(rawSql, opts = {}) {
 
 module.exports = {
   validateAndNormalizeSql,
-  sanitizeGeneratedSql
+  sanitizeGeneratedSql,
+  ensureLimit
 };

--- a/app/test/queryParameterService.test.js
+++ b/app/test/queryParameterService.test.js
@@ -1,0 +1,117 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  extractPlaceholders,
+  buildParameterSchemaFromPlaceholders
+} = require("../src/services/queryParameterParser");
+const {
+  validateParameterSchema,
+  validateParameterValues,
+  substitutePlaceholdersForValidation
+} = require("../src/services/queryParameterService");
+
+test("extractPlaceholders ignores string literals and postgres casts", () => {
+  const sql = `
+    SELECT *
+    FROM revenue
+    WHERE country = :country
+      AND note <> ':ignored'
+      AND sold_at::date >= :start_date
+      AND region = :country
+  `;
+
+  assert.deepEqual(extractPlaceholders(sql), ["country", "start_date"]);
+});
+
+test("buildParameterSchemaFromPlaceholders preserves matching schema entries", () => {
+  const schema = buildParameterSchemaFromPlaceholders(["start_date", "country"], [
+    { name: "start_date", type: "date", required: false, default: "2026-01-01", allowed_values: null },
+    { name: "unused", type: "text", required: true, default: null, allowed_values: null }
+  ]);
+
+  assert.deepEqual(schema, [
+    { name: "start_date", type: "date", required: false, default: "2026-01-01", allowed_values: null },
+    { name: "country", type: "text", required: true, default: null, allowed_values: null }
+  ]);
+});
+
+test("validateParameterSchema normalizes defaults and allowed values", () => {
+  const result = validateParameterSchema([
+    {
+      name: "country",
+      type: "text",
+      required: false,
+      default: "US",
+      allowed_values: ["US", "CA", "US"]
+    },
+    {
+      name: "start_date",
+      type: "date",
+      default: "2026-01-01"
+    }
+  ]);
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value, [
+    {
+      name: "country",
+      type: "text",
+      required: false,
+      default: "US",
+      allowed_values: ["US", "CA"]
+    },
+    {
+      name: "start_date",
+      type: "date",
+      required: true,
+      default: "2026-01-01",
+      allowed_values: null
+    }
+  ]);
+});
+
+test("validateParameterValues coerces and rejects invalid values", () => {
+  const schema = [
+    { name: "country", type: "text", required: true, default: null, allowed_values: ["US", "CA"] },
+    { name: "limit", type: "integer", required: false, default: 10, allowed_values: null },
+    { name: "include_deleted", type: "boolean", required: false, default: false, allowed_values: null }
+  ];
+
+  const success = validateParameterValues(schema, {
+    country: "CA",
+    limit: "25",
+    include_deleted: "true"
+  });
+  assert.equal(success.ok, true);
+  assert.deepEqual(success.resolvedValues, {
+    country: "CA",
+    limit: 25,
+    include_deleted: true
+  });
+
+  const failure = validateParameterValues(schema, {
+    country: "BR",
+    extra: "value"
+  });
+  assert.equal(failure.ok, false);
+  assert.deepEqual(failure.errors, [
+    { param: "country", message: "must be one of the allowed values" },
+    { param: "extra", message: "is not defined in parameter_schema" }
+  ]);
+});
+
+test("substitutePlaceholdersForValidation replaces placeholders outside literals", () => {
+  const substituted = substitutePlaceholdersForValidation(
+    "SELECT * FROM revenue WHERE country = :country AND sold_at >= :start_date AND note = ':country'",
+    [
+      { name: "country", type: "text", required: true, default: null, allowed_values: null },
+      { name: "start_date", type: "date", required: true, default: null, allowed_values: null }
+    ]
+  );
+
+  assert.equal(
+    substituted,
+    "SELECT * FROM revenue WHERE country = 'x' AND sold_at >= '1900-01-01' AND note = ':country'"
+  );
+});

--- a/app/test/savedQueriesApi.test.js
+++ b/app/test/savedQueriesApi.test.js
@@ -5,6 +5,7 @@ process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@l
 process.env.PORT = "0";
 
 const appDb = require("../src/lib/appDb");
+const dbAdapterFactory = require("../src/adapters/dbAdapterFactory");
 
 const DATA_SOURCE_ID = "00000000-0000-4000-8000-000000000111";
 const OTHER_SOURCE_ID = "00000000-0000-4000-8000-000000000222";
@@ -15,6 +16,9 @@ let baseUrl;
 let savedQueries;
 let savedQueryCounter;
 let originalQuery;
+let originalCreateDatabaseAdapter;
+let originalIsSupportedDbType;
+let adapterCalls;
 
 function normalizeSql(sql) {
   return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
@@ -66,8 +70,31 @@ async function api(method, path, body, userId = "test-user") {
 
 before(async () => {
   originalQuery = appDb.query;
+  originalCreateDatabaseAdapter = dbAdapterFactory.createDatabaseAdapter;
+  originalIsSupportedDbType = dbAdapterFactory.isSupportedDbType;
   savedQueries = new Map();
   savedQueryCounter = 0;
+  adapterCalls = [];
+
+  dbAdapterFactory.createDatabaseAdapter = () => ({
+    async validateSql(sql) {
+      adapterCalls.push({ type: "validateSql", sql });
+      return { ok: true, errors: [], refs: [] };
+    },
+    async executeParameterizedReadOnly(sql, params, parameterSchema, opts) {
+      adapterCalls.push({ type: "executeParameterizedReadOnly", sql, params, parameterSchema, opts });
+      return {
+        columns: ["country", "total"],
+        rows: [{ country: params.country || "US", total: 42 }],
+        rowCount: 1,
+        durationMs: 7
+      };
+    },
+    async close() {
+      adapterCalls.push({ type: "close" });
+    }
+  });
+  dbAdapterFactory.isSupportedDbType = (dbType) => dbType === "postgres" || dbType === "mssql";
 
   appDb.query = async (sql, params = []) => {
     const normalized = normalizeSql(sql);
@@ -81,7 +108,7 @@ before(async () => {
     }
 
     if (normalized.startsWith("insert into saved_queries")) {
-      const [ownerId, name, description, dataSourceId, querySql, defaultRunParamsJson] = params;
+      const [ownerId, name, description, dataSourceId, querySql, defaultRunParamsJson, parameterSchemaJson] = params;
       const duplicate = [...savedQueries.values()].find((entry) => (
         entry.owner_id === ownerId
         && entry.data_source_id === dataSourceId
@@ -100,6 +127,7 @@ before(async () => {
         data_source_id: dataSourceId,
         sql: querySql,
         default_run_params: JSON.parse(defaultRunParamsJson),
+        parameter_schema: JSON.parse(parameterSchemaJson),
         created_at: now,
         updated_at: now
       };
@@ -107,7 +135,7 @@ before(async () => {
       return { rowCount: 1, rows: [row] };
     }
 
-    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, created_at, updated_at from saved_queries where ($1::uuid is null or data_source_id = $1::uuid)")) {
+    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, created_at, updated_at from saved_queries where ($1::uuid is null or data_source_id = $1::uuid)")) {
       const [dataSourceId] = params;
       const rows = sortSavedQueries(
         [...savedQueries.values()].filter((entry) => !dataSourceId || entry.data_source_id === dataSourceId)
@@ -115,14 +143,34 @@ before(async () => {
       return { rowCount: rows.length, rows };
     }
 
-    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, created_at, updated_at from saved_queries where id = $1")) {
+    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, created_at, updated_at from saved_queries where id = $1")) {
       const [id] = params;
       const row = savedQueries.get(id);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
 
+    if (normalized.startsWith("select sq.id, sq.owner_id, sq.name, sq.description, sq.data_source_id, sq.sql, sq.default_run_params, sq.parameter_schema, sq.created_at, sq.updated_at, ds.connection_ref, ds.db_type from saved_queries sq join data_sources ds on ds.id = sq.data_source_id where sq.id = $1")) {
+      const [id] = params;
+      const row = savedQueries.get(id);
+      if (!row) {
+        return { rowCount: 0, rows: [] };
+      }
+      return {
+        rowCount: 1,
+        rows: [{
+          ...row,
+          connection_ref: "postgresql://example",
+          db_type: "postgres"
+        }]
+      };
+    }
+
+    if (normalized.startsWith("select schema_name, object_name from schema_objects where data_source_id = $1 and is_ignored = false and object_type in ('table', 'view', 'materialized_view')")) {
+      return { rowCount: 1, rows: [{ schema_name: "public", object_name: "revenue" }] };
+    }
+
     if (normalized.startsWith("update saved_queries set")) {
-      const [id, name, description, dataSourceId, querySql, defaultRunParamsJson] = params;
+      const [id, name, description, dataSourceId, querySql, defaultRunParamsJson, parameterSchemaJson] = params;
       const existing = savedQueries.get(id);
       if (!existing) {
         return { rowCount: 0, rows: [] };
@@ -145,6 +193,7 @@ before(async () => {
         data_source_id: dataSourceId,
         sql: querySql,
         default_run_params: JSON.parse(defaultRunParamsJson),
+        parameter_schema: JSON.parse(parameterSchemaJson),
         updated_at: new Date().toISOString()
       };
       savedQueries.set(id, updated);
@@ -174,6 +223,7 @@ before(async () => {
 beforeEach(() => {
   savedQueries.clear();
   savedQueryCounter = 0;
+  adapterCalls = [];
 });
 
 after(async () => {
@@ -182,6 +232,8 @@ after(async () => {
   });
 
   appDb.query = originalQuery;
+  dbAdapterFactory.createDatabaseAdapter = originalCreateDatabaseAdapter;
+  dbAdapterFactory.isSupportedDbType = originalIsSupportedDbType;
 });
 
 test("saved queries create/list/get/update/delete happy path", async () => {
@@ -211,6 +263,7 @@ test("saved queries create/list/get/update/delete happy path", async () => {
     timeout_ms: 30000,
     no_execute: false
   });
+  assert.deepEqual(create.payload.parameter_schema, []);
 
   const savedQueryId = create.payload.id;
 
@@ -241,6 +294,7 @@ test("saved queries create/list/get/update/delete happy path", async () => {
     model: "gpt-4.1-mini",
     no_execute: true
   });
+  assert.deepEqual(update.payload.parameter_schema, []);
 
   const filteredList = await api("GET", `/v1/saved-queries?data_source_id=${OTHER_SOURCE_ID}`, undefined, "carol");
   assert.equal(filteredList.status, 200);
@@ -280,6 +334,125 @@ test("saved queries are publicly readable and openly writable", async () => {
 
   const deletedByOtherUser = await api("DELETE", `/v1/saved-queries/${savedQueryId}`, undefined, "owner-c");
   assert.equal(deletedByOtherUser.status, 200);
+});
+
+test("saved queries auto-extract placeholders and preserve schema customizations on update", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Revenue by Country",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT * FROM revenue WHERE sold_at >= :start_date AND country = :country",
+    parameter_schema: [
+      { name: "start_date", type: "date", required: true, default: "2026-01-01" },
+      { name: "country", type: "text", required: false, default: "US" }
+    ]
+  });
+
+  assert.equal(created.status, 201);
+  assert.deepEqual(created.payload.parameter_schema, [
+    { name: "start_date", type: "date", required: true, default: "2026-01-01", allowed_values: null },
+    { name: "country", type: "text", required: false, default: "US", allowed_values: null }
+  ]);
+
+  const updated = await api("PUT", `/v1/saved-queries/${created.payload.id}`, {
+    name: "Revenue by Country",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT * FROM revenue WHERE sold_at >= :start_date AND sold_at < :end_date AND country = :country"
+  });
+
+  assert.equal(updated.status, 200);
+  assert.deepEqual(updated.payload.parameter_schema, [
+    { name: "start_date", type: "date", required: true, default: "2026-01-01", allowed_values: null },
+    { name: "end_date", type: "text", required: true, default: null, allowed_values: null },
+    { name: "country", type: "text", required: false, default: "US", allowed_values: null }
+  ]);
+});
+
+test("saved query validate-params and run use resolved parameter values", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Revenue by Country",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT country, SUM(amount) AS total FROM revenue WHERE sold_at >= :start_date AND country = :country GROUP BY country",
+    default_run_params: {
+      max_rows: 250,
+      timeout_ms: 30000
+    },
+    parameter_schema: [
+      { name: "start_date", type: "date", required: true, default: null },
+      { name: "country", type: "text", required: false, default: "US", allowed_values: ["US", "CA"] }
+    ]
+  });
+  assert.equal(created.status, 201);
+
+  const validated = await api("POST", `/v1/saved-queries/${created.payload.id}/validate-params`, {
+    params: {
+      start_date: "2026-02-01"
+    }
+  });
+  assert.equal(validated.status, 200);
+  assert.deepEqual(validated.payload, {
+    ok: true,
+    resolved_values: {
+      start_date: "2026-02-01",
+      country: "US"
+    }
+  });
+
+  const validationFailure = await api("POST", `/v1/saved-queries/${created.payload.id}/validate-params`, {
+    params: {
+      start_date: "bad-date",
+      country: "BR"
+    }
+  });
+  assert.equal(validationFailure.status, 200);
+  assert.deepEqual(validationFailure.payload, {
+    ok: false,
+    errors: [
+      { param: "start_date", message: "must be a valid date in YYYY-MM-DD format" },
+      { param: "country", message: "must be one of the allowed values" }
+    ]
+  });
+
+  const run = await api("POST", `/v1/saved-queries/${created.payload.id}/run`, {
+    params: {
+      start_date: "2026-02-01",
+      country: "CA"
+    },
+    max_rows: 25,
+    timeout_ms: 15000
+  });
+
+  assert.equal(run.status, 200);
+  assert.match(run.payload.sql, /country = :country/i);
+  assert.match(run.payload.sql, /\bLIMIT 25;$/i);
+  assert.deepEqual(run.payload.columns, ["country", "total"]);
+  assert.deepEqual(run.payload.rows, [{ country: "CA", total: 42 }]);
+  assert.equal(run.payload.row_count, 1);
+
+  assert.deepEqual(adapterCalls, [
+    {
+      type: "validateSql",
+      sql: "SELECT country, SUM(amount) AS total FROM revenue WHERE sold_at >= '1900-01-01' AND country = 'x' GROUP BY country LIMIT 25;"
+    },
+    {
+      type: "executeParameterizedReadOnly",
+      sql: "SELECT country, SUM(amount) AS total FROM revenue WHERE sold_at >= :start_date AND country = :country GROUP BY country LIMIT 25;",
+      params: {
+        start_date: "2026-02-01",
+        country: "CA"
+      },
+      parameterSchema: [
+        { name: "start_date", type: "date", required: true, default: null, allowed_values: null },
+        { name: "country", type: "text", required: false, default: "US", allowed_values: ["US", "CA"] }
+      ],
+      opts: {
+        maxRows: 25,
+        timeoutMs: 15000
+      }
+    },
+    {
+      type: "close"
+    }
+  ]);
 });
 
 test("saved query duplicate names are rejected per owner and data source", async () => {
@@ -364,6 +537,16 @@ test("saved query validation returns 400", async () => {
     }
   });
   assert.equal(invalidDefaultParamValue.status, 400);
+
+  const invalidParameterSchema = await api("POST", "/v1/saved-queries", {
+    name: "Revenue",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT * FROM revenue WHERE sold_at >= :start_date",
+    parameter_schema: [
+      { name: "1start_date", type: "date" }
+    ]
+  });
+  assert.equal(invalidParameterSchema.status, 400);
 });
 
 test("saved query not found paths return 404", async () => {

--- a/app/test/savedQueryParametersMigration.test.js
+++ b/app/test/savedQueryParametersMigration.test.js
@@ -1,0 +1,12 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+test("0012_saved_query_parameters migration adds parameter_schema", () => {
+  const migrationPath = path.resolve(__dirname, "../../db/migrations/0012_saved_query_parameters.sql");
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /ALTER TABLE saved_queries/i);
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS parameter_schema JSONB NOT NULL DEFAULT '\[\]'::jsonb/i);
+});

--- a/db/migrations/0012_saved_query_parameters.sql
+++ b/db/migrations/0012_saved_query_parameters.sql
@@ -1,0 +1,2 @@
+ALTER TABLE saved_queries
+  ADD COLUMN IF NOT EXISTS parameter_schema JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -178,6 +178,93 @@ paths:
                   message:
                     type: string
                 required: [error, message]
+  /v1/saved-queries/{savedQueryId}/validate-params:
+    post:
+      tags: [Query]
+      summary: Validate saved query parameters
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ValidateParamsRequest"
+      responses:
+        "200":
+          description: Parameter validation result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidateParamsResponse"
+        "404":
+          description: Saved query not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required: [error, message]
+  /v1/saved-queries/{savedQueryId}/run:
+    post:
+      tags: [Query]
+      summary: Run a saved query with parameters
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RunSavedQueryRequest"
+      responses:
+        "200":
+          description: Saved query result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RunSavedQueryResponse"
+        "400":
+          description: Invalid saved query parameters or SQL
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                  errors:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            param:
+                              type: string
+                              nullable: true
+                            message:
+                              type: string
+                          required: [message]
+                        - type: string
+                required: [error, message]
+        "404":
+          description: Saved query not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required: [error, message]
   /v1/query/sessions:
     post:
       tags: [Query]
@@ -918,6 +1005,24 @@ components:
           items:
             $ref: "#/components/schemas/PromptHistoryItem"
       required: [items]
+    QueryParameter:
+      type: object
+      properties:
+        name:
+          type: string
+          pattern: "^[a-z][a-z0-9_]*$"
+        type:
+          type: string
+          enum: [text, integer, decimal, date, boolean, timestamp]
+        required:
+          type: boolean
+        default: {}
+        allowed_values:
+          oneOf:
+            - type: "null"
+            - type: array
+              items: {}
+      required: [name, type, required, default, allowed_values]
     SavedQuery:
       type: object
       properties:
@@ -952,13 +1057,17 @@ components:
               maximum: 120000
             no_execute:
               type: boolean
+        parameter_schema:
+          type: array
+          items:
+            $ref: "#/components/schemas/QueryParameter"
         created_at:
           type: string
           format: date-time
         updated_at:
           type: string
           format: date-time
-      required: [id, owner_id, name, data_source_id, sql, default_run_params, created_at, updated_at]
+      required: [id, owner_id, name, data_source_id, sql, default_run_params, parameter_schema, created_at, updated_at]
     SavedQueryListResponse:
       type: object
       properties:
@@ -1006,6 +1115,10 @@ components:
               maximum: 120000
             no_execute:
               type: boolean
+        parameter_schema:
+          type: array
+          items:
+            $ref: "#/components/schemas/QueryParameter"
       required: [name, data_source_id, sql]
     UpdateSavedQueryRequest:
       type: object
@@ -1038,7 +1151,71 @@ components:
               maximum: 120000
             no_execute:
               type: boolean
+        parameter_schema:
+          type: array
+          items:
+            $ref: "#/components/schemas/QueryParameter"
       required: [name, data_source_id, sql]
+    ValidateParamsRequest:
+      type: object
+      properties:
+        params:
+          type: object
+          additionalProperties: true
+      required: [params]
+    ValidateParamsResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        resolved_values:
+          type: object
+          additionalProperties: true
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              param:
+                type: string
+                nullable: true
+              message:
+                type: string
+            required: [message]
+      required: [ok]
+    RunSavedQueryRequest:
+      type: object
+      properties:
+        params:
+          type: object
+          additionalProperties: true
+        max_rows:
+          type: integer
+          minimum: 1
+          maximum: 100000
+        timeout_ms:
+          type: integer
+          minimum: 1000
+          maximum: 120000
+    RunSavedQueryResponse:
+      type: object
+      properties:
+        sql:
+          type: string
+        columns:
+          type: array
+          items:
+            type: string
+        rows:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        row_count:
+          type: integer
+        duration_ms:
+          type: integer
+      required: [sql, columns, rows, row_count, duration_ms]
     CreateSessionRequest:
       type: object
       properties:

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -252,6 +252,130 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/saved-queries/{savedQueryId}/validate-params": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Validate saved query parameters */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ValidateParamsRequest"];
+                };
+            };
+            responses: {
+                /** @description Parameter validation result */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidateParamsResponse"];
+                    };
+                };
+                /** @description Saved query not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/saved-queries/{savedQueryId}/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Run a saved query with parameters */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["RunSavedQueryRequest"];
+                };
+            };
+            responses: {
+                /** @description Saved query result */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["RunSavedQueryResponse"];
+                    };
+                };
+                /** @description Invalid saved query parameters or SQL */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            message: string;
+                            errors?: ({
+                                param?: string | null;
+                                message: string;
+                            } | string)[];
+                        };
+                    };
+                };
+                /** @description Saved query not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/query/sessions": {
         parameters: {
             query?: never;
@@ -1583,6 +1707,14 @@ export interface components {
         PromptHistoryResponse: {
             items: components["schemas"]["PromptHistoryItem"][];
         };
+        QueryParameter: {
+            name: string;
+            /** @enum {string} */
+            type: "text" | "integer" | "decimal" | "date" | "boolean" | "timestamp";
+            required: boolean;
+            default: unknown;
+            allowed_values: null | unknown[];
+        };
         SavedQuery: {
             id: string;
             owner_id: string;
@@ -1597,6 +1729,7 @@ export interface components {
                 timeout_ms?: number;
                 no_execute?: boolean;
             };
+            parameter_schema: components["schemas"]["QueryParameter"][];
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -1621,6 +1754,7 @@ export interface components {
                 timeout_ms?: number;
                 no_execute?: boolean;
             };
+            parameter_schema?: components["schemas"]["QueryParameter"][];
         };
         UpdateSavedQueryRequest: {
             name: string;
@@ -1634,6 +1768,38 @@ export interface components {
                 timeout_ms?: number;
                 no_execute?: boolean;
             };
+            parameter_schema?: components["schemas"]["QueryParameter"][];
+        };
+        ValidateParamsRequest: {
+            params: {
+                [key: string]: unknown;
+            };
+        };
+        ValidateParamsResponse: {
+            ok: boolean;
+            resolved_values?: {
+                [key: string]: unknown;
+            };
+            errors?: {
+                param?: string | null;
+                message: string;
+            }[];
+        };
+        RunSavedQueryRequest: {
+            params?: {
+                [key: string]: unknown;
+            };
+            max_rows?: number;
+            timeout_ms?: number;
+        };
+        RunSavedQueryResponse: {
+            sql: string;
+            columns: string[];
+            rows: {
+                [key: string]: unknown;
+            }[];
+            row_count: number;
+            duration_ms: number;
         };
         CreateSessionRequest: {
             data_source_id: string;


### PR DESCRIPTION
## Summary
- add saved query parameter schema extraction, validation, and placeholder substitution services
- add validate-params and run endpoints with native parameter binding for Postgres and MSSQL adapters
- update the saved query API contract, generated frontend types, and test coverage for parameterized execution

## Verification
- npm test
- npm --prefix frontend run lint
- npm run migrate *(fails in this environment because DATABASE_URL is not set)*

Closes #37
Ticket: QUERY-002