### PR TITLE
refactor(saved-queries): extract savedQueryService from route handlers

### DIFF
--- a/app/src/routes/savedQueries.js
+++ b/app/src/routes/savedQueries.js
@@ -1,461 +1,66 @@
-const appDb = require("../lib/appDb");
-const { json, badRequest, readJsonBody } = require("../lib/http");
-const { SAVED_QUERY_NAME_MAX_LENGTH, SAVED_QUERY_DESCRIPTION_MAX_LENGTH } = require("../lib/constants");
-const {
-  clamp,
-  isUuid,
-  isPgUniqueViolation,
-  normalizeOptionalTrimmedString,
-  validateSavedQueryDefaultRunParams
-} = require("../lib/validation");
-const { createDatabaseAdapter, isSupportedDbType } = require("../adapters/dbAdapterFactory");
-const { validateAndNormalizeSql, sanitizeGeneratedSql, ensureLimit } = require("../services/sqlSafety");
-const {
-  extractPlaceholders,
-  buildParameterSchemaFromPlaceholders
-} = require("../services/queryParameterParser");
-const {
-  validateParameterSchema,
-  validateParameterValues,
-  substitutePlaceholdersForValidation
-} = require("../services/queryParameterService");
+const { json, readJsonBody } = require("../lib/http");
+const savedQueryService = require("../services/savedQueryService");
 
-async function ensureDataSourceExists(dataSourceId) {
-  const sourceResult = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [dataSourceId]);
-  return sourceResult.rowCount > 0;
-}
-
-async function loadSavedQuery(savedQueryId) {
-  const result = await appDb.query(
-    `
-      SELECT
-        id,
-        owner_id,
-        name,
-        description,
-        data_source_id,
-        sql,
-        default_run_params,
-        parameter_schema,
-        created_at,
-        updated_at
-      FROM saved_queries
-      WHERE id = $1
-    `,
-    [savedQueryId]
-  );
-
-  return result.rows[0] || null;
-}
-
-async function loadSavedQueryForExecution(savedQueryId) {
-  const result = await appDb.query(
-    `
-      SELECT
-        sq.id,
-        sq.owner_id,
-        sq.name,
-        sq.description,
-        sq.data_source_id,
-        sq.sql,
-        sq.default_run_params,
-        sq.parameter_schema,
-        sq.created_at,
-        sq.updated_at,
-        ds.connection_ref,
-        ds.db_type
-      FROM saved_queries sq
-      JOIN data_sources ds ON ds.id = sq.data_source_id
-      WHERE sq.id = $1
-    `,
-    [savedQueryId]
-  );
-
-  return result.rows[0] || null;
-}
-
-async function loadSchemaObjects(dataSourceId) {
-  const result = await appDb.query(
-    `
-      SELECT schema_name, object_name
-      FROM schema_objects
-      WHERE data_source_id = $1
-        AND is_ignored = FALSE
-        AND object_type IN ('table', 'view', 'materialized_view')
-    `,
-    [dataSourceId]
-  );
-
-  return result.rows;
-}
-
-function resolveParameterSchema(sql, providedParameterSchema, existingSchema) {
-  const placeholders = extractPlaceholders(sql);
-
-  if (providedParameterSchema === undefined) {
-    return {
-      ok: true,
-      value: buildParameterSchemaFromPlaceholders(placeholders, existingSchema)
-    };
-  }
-
-  const schemaValidation = validateParameterSchema(providedParameterSchema);
-  if (!schemaValidation.ok) {
-    return schemaValidation;
-  }
-
-  return {
-    ok: true,
-    value: buildParameterSchemaFromPlaceholders(placeholders, schemaValidation.value)
-  };
-}
-
-function resolveSavedQueryRunOptions(defaultRunParams, body) {
-  const merged = {
-    max_rows: defaultRunParams?.max_rows,
-    timeout_ms: defaultRunParams?.timeout_ms
-  };
-
-  if (Object.prototype.hasOwnProperty.call(body || {}, "max_rows")) {
-    merged.max_rows = body.max_rows;
-  }
-  if (Object.prototype.hasOwnProperty.call(body || {}, "timeout_ms")) {
-    merged.timeout_ms = body.timeout_ms;
-  }
-
-  const maxRows = Number(merged.max_rows);
-  const timeoutMs = Number(merged.timeout_ms);
-
-  return {
-    maxRows: clamp(Number.isFinite(maxRows) ? maxRows : 1000, 1, 100000),
-    timeoutMs: clamp(Number.isFinite(timeoutMs) ? timeoutMs : 20000, 1000, 120000)
-  };
+function writeResult(res, result) {
+  return json(res, result.statusCode, result.body);
 }
 
 async function handleCreateSavedQuery(req, res) {
   const body = await readJsonBody(req);
-  const ownerId = String(req.headers["x-user-id"] || "anonymous").trim() || "anonymous";
-  const dataSourceId = String(body.data_source_id || "").trim();
-  const name = typeof body.name === "string" ? body.name.trim() : "";
-  const sql = typeof body.sql === "string" ? body.sql.trim() : "";
-  const description = normalizeOptionalTrimmedString(body.description);
-  const defaultRunParamsValidation = validateSavedQueryDefaultRunParams(body.default_run_params);
-  const parameterSchemaValidation = resolveParameterSchema(sql, body.parameter_schema, []);
-
-  if (!name || !dataSourceId || !sql) {
-    return badRequest(res, "name, data_source_id and sql are required");
-  }
-  if (!isUuid(dataSourceId)) {
-    return badRequest(res, "data_source_id must be a valid UUID");
-  }
-  if (name.length > SAVED_QUERY_NAME_MAX_LENGTH) {
-    return badRequest(res, `name cannot exceed ${SAVED_QUERY_NAME_MAX_LENGTH} characters`);
-  }
-  if (description && description.length > SAVED_QUERY_DESCRIPTION_MAX_LENGTH) {
-    return badRequest(res, `description cannot exceed ${SAVED_QUERY_DESCRIPTION_MAX_LENGTH} characters`);
-  }
-  if (!defaultRunParamsValidation.ok) {
-    return badRequest(res, defaultRunParamsValidation.message);
-  }
-  if (!parameterSchemaValidation.ok) {
-    return badRequest(res, parameterSchemaValidation.message);
-  }
-
-  if (!(await ensureDataSourceExists(dataSourceId))) {
-    return json(res, 404, { error: "not_found", message: "Data source not found" });
-  }
-
-  try {
-    const insertResult = await appDb.query(
-      `
-        INSERT INTO saved_queries (
-          owner_id,
-          name,
-          description,
-          data_source_id,
-          sql,
-          default_run_params,
-          parameter_schema
-        ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb)
-        RETURNING
-          id,
-          owner_id,
-          name,
-          description,
-          data_source_id,
-          sql,
-          default_run_params,
-          parameter_schema,
-          created_at,
-          updated_at
-      `,
-      [
-        ownerId,
-        name,
-        description,
-        dataSourceId,
-        sql,
-        JSON.stringify(defaultRunParamsValidation.value),
-        JSON.stringify(parameterSchemaValidation.value)
-      ]
-    );
-
-    return json(res, 201, insertResult.rows[0]);
-  } catch (err) {
-    if (isPgUniqueViolation(err)) {
-      return json(res, 409, {
-        error: "conflict",
-        message: "Saved query name already exists for this owner and data source"
-      });
-    }
-    throw err;
-  }
+  const result = await savedQueryService.createSavedQuery({
+    ownerId: req.headers["x-user-id"],
+    name: body.name,
+    description: body.description,
+    dataSourceId: body.data_source_id,
+    sql: body.sql,
+    defaultRunParams: body.default_run_params,
+    parameterSchema: body.parameter_schema
+  });
+  return writeResult(res, result);
 }
 
 async function handleListSavedQueries(_req, res, requestUrl) {
-  const dataSourceId = String(requestUrl.searchParams.get("data_source_id") || "").trim();
-  if (dataSourceId && !isUuid(dataSourceId)) {
-    return badRequest(res, "data_source_id must be a valid UUID");
-  }
-
-  const result = await appDb.query(
-    `
-      SELECT
-        id,
-        owner_id,
-        name,
-        description,
-        data_source_id,
-        sql,
-        default_run_params,
-        parameter_schema,
-        created_at,
-        updated_at
-      FROM saved_queries
-      WHERE ($1::uuid IS NULL OR data_source_id = $1::uuid)
-      ORDER BY updated_at DESC, created_at DESC
-    `,
-    [dataSourceId || null]
-  );
-
-  return json(res, 200, { items: result.rows });
+  const result = await savedQueryService.listSavedQueries(requestUrl.searchParams.get("data_source_id"));
+  return writeResult(res, result);
 }
 
 async function handleGetSavedQuery(_req, res, savedQueryId) {
-  if (!isUuid(savedQueryId)) {
-    return badRequest(res, "savedQueryId must be a valid UUID");
-  }
-
-  const savedQuery = await loadSavedQuery(savedQueryId);
-  if (!savedQuery) {
-    return json(res, 404, { error: "not_found", message: "Saved query not found" });
-  }
-
-  return json(res, 200, savedQuery);
+  const result = await savedQueryService.getSavedQuery(savedQueryId);
+  return writeResult(res, result);
 }
 
 async function handleUpdateSavedQuery(req, res, savedQueryId) {
-  if (!isUuid(savedQueryId)) {
-    return badRequest(res, "savedQueryId must be a valid UUID");
-  }
-
   const body = await readJsonBody(req);
-  const existingSavedQuery = await loadSavedQuery(savedQueryId);
-  if (!existingSavedQuery) {
-    return json(res, 404, { error: "not_found", message: "Saved query not found" });
-  }
-
-  const dataSourceId = String(body.data_source_id || "").trim();
-  const name = typeof body.name === "string" ? body.name.trim() : "";
-  const sql = typeof body.sql === "string" ? body.sql.trim() : "";
-  const description = normalizeOptionalTrimmedString(body.description);
-  const defaultRunParamsValidation = validateSavedQueryDefaultRunParams(body.default_run_params);
-  const parameterSchemaValidation = resolveParameterSchema(sql, body.parameter_schema, existingSavedQuery.parameter_schema);
-
-  if (!name || !dataSourceId || !sql) {
-    return badRequest(res, "name, data_source_id and sql are required");
-  }
-  if (!isUuid(dataSourceId)) {
-    return badRequest(res, "data_source_id must be a valid UUID");
-  }
-  if (name.length > SAVED_QUERY_NAME_MAX_LENGTH) {
-    return badRequest(res, `name cannot exceed ${SAVED_QUERY_NAME_MAX_LENGTH} characters`);
-  }
-  if (description && description.length > SAVED_QUERY_DESCRIPTION_MAX_LENGTH) {
-    return badRequest(res, `description cannot exceed ${SAVED_QUERY_DESCRIPTION_MAX_LENGTH} characters`);
-  }
-  if (!defaultRunParamsValidation.ok) {
-    return badRequest(res, defaultRunParamsValidation.message);
-  }
-  if (!parameterSchemaValidation.ok) {
-    return badRequest(res, parameterSchemaValidation.message);
-  }
-
-  if (!(await ensureDataSourceExists(dataSourceId))) {
-    return json(res, 404, { error: "not_found", message: "Data source not found" });
-  }
-
-  try {
-    const updateResult = await appDb.query(
-      `
-        UPDATE saved_queries
-        SET
-          name = $2,
-          description = $3,
-          data_source_id = $4,
-          sql = $5,
-          default_run_params = $6::jsonb,
-          parameter_schema = $7::jsonb,
-          updated_at = NOW()
-        WHERE id = $1
-        RETURNING
-          id,
-          owner_id,
-          name,
-          description,
-          data_source_id,
-          sql,
-          default_run_params,
-          parameter_schema,
-          created_at,
-          updated_at
-      `,
-      [
-        savedQueryId,
-        name,
-        description,
-        dataSourceId,
-        sql,
-        JSON.stringify(defaultRunParamsValidation.value),
-        JSON.stringify(parameterSchemaValidation.value)
-      ]
-    );
-
-    return json(res, 200, updateResult.rows[0]);
-  } catch (err) {
-    if (isPgUniqueViolation(err)) {
-      return json(res, 409, {
-        error: "conflict",
-        message: "Saved query name already exists for this owner and data source"
-      });
-    }
-    throw err;
-  }
+  const result = await savedQueryService.updateSavedQuery(savedQueryId, {
+    name: body.name,
+    description: body.description,
+    dataSourceId: body.data_source_id,
+    sql: body.sql,
+    defaultRunParams: body.default_run_params,
+    parameterSchema: body.parameter_schema
+  });
+  return writeResult(res, result);
 }
 
 async function handleDeleteSavedQuery(_req, res, savedQueryId) {
-  if (!isUuid(savedQueryId)) {
-    return badRequest(res, "savedQueryId must be a valid UUID");
-  }
-
-  const deleteResult = await appDb.query(
-    `
-      DELETE FROM saved_queries
-      WHERE id = $1
-      RETURNING id
-    `,
-    [savedQueryId]
-  );
-
-  if (deleteResult.rowCount === 0) {
-    return json(res, 404, { error: "not_found", message: "Saved query not found" });
-  }
-
-  return json(res, 200, { ok: true, id: deleteResult.rows[0].id });
+  const result = await savedQueryService.deleteSavedQuery(savedQueryId);
+  return writeResult(res, result);
 }
 
 async function handleValidateParams(req, res, savedQueryId) {
-  if (!isUuid(savedQueryId)) {
-    return badRequest(res, "savedQueryId must be a valid UUID");
-  }
-
-  const savedQuery = await loadSavedQuery(savedQueryId);
-  if (!savedQuery) {
-    return json(res, 404, { error: "not_found", message: "Saved query not found" });
-  }
-
   const body = await readJsonBody(req);
-  const validation = validateParameterValues(savedQuery.parameter_schema, body.params);
-  if (!validation.ok) {
-    return json(res, 200, { ok: false, errors: validation.errors });
-  }
-
-  return json(res, 200, { ok: true, resolved_values: validation.resolvedValues });
+  const result = await savedQueryService.validateSavedQueryParams(savedQueryId, body.params);
+  return writeResult(res, result);
 }
 
 async function handleRunSavedQuery(req, res, savedQueryId) {
-  if (!isUuid(savedQueryId)) {
-    return badRequest(res, "savedQueryId must be a valid UUID");
-  }
-
-  const savedQuery = await loadSavedQueryForExecution(savedQueryId);
-  if (!savedQuery) {
-    return json(res, 404, { error: "not_found", message: "Saved query not found" });
-  }
-  if (!isSupportedDbType(savedQuery.db_type)) {
-    return badRequest(res, `Unsupported db_type for execution: ${savedQuery.db_type}`);
-  }
-
   const body = await readJsonBody(req);
-  const parameterValidation = validateParameterValues(savedQuery.parameter_schema, body.params);
-  if (!parameterValidation.ok) {
-    return json(res, 400, {
-      error: "bad_request",
-      message: "Invalid saved query parameters",
-      errors: parameterValidation.errors
-    });
-  }
-
-  const dialect = savedQuery.db_type === "mssql" ? "mssql" : "postgres";
-  const { maxRows, timeoutMs } = resolveSavedQueryRunOptions(savedQuery.default_run_params, body);
-  const executableSql = ensureLimit(sanitizeGeneratedSql(savedQuery.sql), maxRows, dialect);
-  const schemaObjects = await loadSchemaObjects(savedQuery.data_source_id);
-  const validationSql = substitutePlaceholdersForValidation(executableSql, savedQuery.parameter_schema);
-  const normalized = validateAndNormalizeSql(validationSql, {
-    maxRows,
-    schemaObjects,
-    dialect
+  const result = await savedQueryService.executeSavedQuery(savedQueryId, {
+    params: body.params,
+    maxRows: body.max_rows,
+    timeoutMs: body.timeout_ms
   });
-
-  if (!normalized.ok) {
-    return json(res, 400, {
-      error: "bad_request",
-      message: normalized.errors.join("; "),
-      errors: normalized.errors
-    });
-  }
-
-  let adapter = null;
-  try {
-    adapter = createDatabaseAdapter(savedQuery.db_type, savedQuery.connection_ref);
-    const adapterValidation = await adapter.validateSql(normalized.sql);
-    if (!adapterValidation.ok) {
-      return json(res, 400, {
-        error: "bad_request",
-        message: adapterValidation.errors.join("; "),
-        errors: adapterValidation.errors
-      });
-    }
-
-    const execution = await adapter.executeParameterizedReadOnly(
-      executableSql,
-      parameterValidation.resolvedValues,
-      savedQuery.parameter_schema,
-      { maxRows, timeoutMs }
-    );
-
-    return json(res, 200, {
-      sql: executableSql,
-      columns: execution.columns,
-      rows: execution.rows,
-      row_count: execution.rowCount,
-      duration_ms: execution.durationMs
-    });
-  } finally {
-    if (adapter) {
-      await adapter.close();
-    }
-  }
+  return writeResult(res, result);
 }
 
 module.exports = {

--- a/app/src/services/savedQueryService.js
+++ b/app/src/services/savedQueryService.js
@@ -1,0 +1,466 @@
+const appDb = require("../lib/appDb");
+const { SAVED_QUERY_NAME_MAX_LENGTH, SAVED_QUERY_DESCRIPTION_MAX_LENGTH } = require("../lib/constants");
+const {
+  clamp,
+  isUuid,
+  isPgUniqueViolation,
+  normalizeOptionalTrimmedString,
+  validateSavedQueryDefaultRunParams
+} = require("../lib/validation");
+const { createDatabaseAdapter, isSupportedDbType } = require("../adapters/dbAdapterFactory");
+const { validateAndNormalizeSql, sanitizeGeneratedSql, ensureLimit } = require("./sqlSafety");
+const {
+  extractPlaceholders,
+  buildParameterSchemaFromPlaceholders
+} = require("./queryParameterParser");
+const {
+  validateParameterSchema,
+  validateParameterValues,
+  substitutePlaceholdersForValidation
+} = require("./queryParameterService");
+
+function success(body, statusCode = 200) {
+  return { ok: true, statusCode, body };
+}
+
+function failure(statusCode, body) {
+  return { ok: false, statusCode, body };
+}
+
+const SAVED_QUERY_COLUMNS = `
+  id,
+  owner_id,
+  name,
+  description,
+  data_source_id,
+  sql,
+  default_run_params,
+  parameter_schema,
+  created_at,
+  updated_at
+`;
+
+async function ensureDataSourceExists(dataSourceId) {
+  const sourceResult = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [dataSourceId]);
+  return sourceResult.rowCount > 0;
+}
+
+async function loadSavedQuery(savedQueryId) {
+  const result = await appDb.query(
+    `SELECT ${SAVED_QUERY_COLUMNS} FROM saved_queries WHERE id = $1`,
+    [savedQueryId]
+  );
+  return result.rows[0] || null;
+}
+
+async function loadSavedQueryForExecution(savedQueryId) {
+  const result = await appDb.query(
+    `
+      SELECT
+        sq.id,
+        sq.owner_id,
+        sq.name,
+        sq.description,
+        sq.data_source_id,
+        sq.sql,
+        sq.default_run_params,
+        sq.parameter_schema,
+        sq.created_at,
+        sq.updated_at,
+        ds.connection_ref,
+        ds.db_type
+      FROM saved_queries sq
+      JOIN data_sources ds ON ds.id = sq.data_source_id
+      WHERE sq.id = $1
+    `,
+    [savedQueryId]
+  );
+
+  return result.rows[0] || null;
+}
+
+async function loadSchemaObjects(dataSourceId) {
+  const result = await appDb.query(
+    `
+      SELECT schema_name, object_name
+      FROM schema_objects
+      WHERE data_source_id = $1
+        AND is_ignored = FALSE
+        AND object_type IN ('table', 'view', 'materialized_view')
+    `,
+    [dataSourceId]
+  );
+  return result.rows;
+}
+
+function resolveParameterSchema(sql, providedParameterSchema, existingSchema) {
+  const placeholders = extractPlaceholders(sql);
+
+  if (providedParameterSchema === undefined) {
+    return {
+      ok: true,
+      value: buildParameterSchemaFromPlaceholders(placeholders, existingSchema)
+    };
+  }
+
+  const schemaValidation = validateParameterSchema(providedParameterSchema);
+  if (!schemaValidation.ok) {
+    return schemaValidation;
+  }
+
+  return {
+    ok: true,
+    value: buildParameterSchemaFromPlaceholders(placeholders, schemaValidation.value)
+  };
+}
+
+function resolveRunOptions(defaultRunParams, requested) {
+  const merged = {
+    max_rows: defaultRunParams?.max_rows,
+    timeout_ms: defaultRunParams?.timeout_ms
+  };
+
+  if (requested && Object.prototype.hasOwnProperty.call(requested, "maxRows") && requested.maxRows !== undefined) {
+    merged.max_rows = requested.maxRows;
+  }
+  if (requested && Object.prototype.hasOwnProperty.call(requested, "timeoutMs") && requested.timeoutMs !== undefined) {
+    merged.timeout_ms = requested.timeoutMs;
+  }
+
+  const maxRows = Number(merged.max_rows);
+  const timeoutMs = Number(merged.timeout_ms);
+
+  return {
+    maxRows: clamp(Number.isFinite(maxRows) ? maxRows : 1000, 1, 100000),
+    timeoutMs: clamp(Number.isFinite(timeoutMs) ? timeoutMs : 20000, 1000, 120000)
+  };
+}
+
+async function getSavedQuery(savedQueryId) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  return success(savedQuery);
+}
+
+async function listSavedQueries(dataSourceId) {
+  const filter = typeof dataSourceId === "string" ? dataSourceId.trim() : "";
+  if (filter && !isUuid(filter)) {
+    return failure(400, { error: "bad_request", message: "data_source_id must be a valid UUID" });
+  }
+
+  const result = await appDb.query(
+    `
+      SELECT ${SAVED_QUERY_COLUMNS}
+      FROM saved_queries
+      WHERE ($1::uuid IS NULL OR data_source_id = $1::uuid)
+      ORDER BY updated_at DESC, created_at DESC
+    `,
+    [filter || null]
+  );
+
+  return success({ items: result.rows });
+}
+
+async function createSavedQuery({
+  ownerId,
+  name,
+  description,
+  dataSourceId,
+  sql,
+  defaultRunParams,
+  parameterSchema
+}) {
+  const trimmedOwnerId = String(ownerId || "anonymous").trim() || "anonymous";
+  const trimmedDataSourceId = String(dataSourceId || "").trim();
+  const trimmedName = typeof name === "string" ? name.trim() : "";
+  const trimmedSql = typeof sql === "string" ? sql.trim() : "";
+  const normalizedDescription = normalizeOptionalTrimmedString(description);
+  const defaultRunParamsValidation = validateSavedQueryDefaultRunParams(defaultRunParams);
+  const parameterSchemaValidation = resolveParameterSchema(trimmedSql, parameterSchema, []);
+
+  if (!trimmedName || !trimmedDataSourceId || !trimmedSql) {
+    return failure(400, { error: "bad_request", message: "name, data_source_id and sql are required" });
+  }
+  if (!isUuid(trimmedDataSourceId)) {
+    return failure(400, { error: "bad_request", message: "data_source_id must be a valid UUID" });
+  }
+  if (trimmedName.length > SAVED_QUERY_NAME_MAX_LENGTH) {
+    return failure(400, {
+      error: "bad_request",
+      message: `name cannot exceed ${SAVED_QUERY_NAME_MAX_LENGTH} characters`
+    });
+  }
+  if (normalizedDescription && normalizedDescription.length > SAVED_QUERY_DESCRIPTION_MAX_LENGTH) {
+    return failure(400, {
+      error: "bad_request",
+      message: `description cannot exceed ${SAVED_QUERY_DESCRIPTION_MAX_LENGTH} characters`
+    });
+  }
+  if (!defaultRunParamsValidation.ok) {
+    return failure(400, { error: "bad_request", message: defaultRunParamsValidation.message });
+  }
+  if (!parameterSchemaValidation.ok) {
+    return failure(400, { error: "bad_request", message: parameterSchemaValidation.message });
+  }
+
+  if (!(await ensureDataSourceExists(trimmedDataSourceId))) {
+    return failure(404, { error: "not_found", message: "Data source not found" });
+  }
+
+  try {
+    const insertResult = await appDb.query(
+      `
+        INSERT INTO saved_queries (
+          owner_id,
+          name,
+          description,
+          data_source_id,
+          sql,
+          default_run_params,
+          parameter_schema
+        ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb)
+        RETURNING ${SAVED_QUERY_COLUMNS}
+      `,
+      [
+        trimmedOwnerId,
+        trimmedName,
+        normalizedDescription,
+        trimmedDataSourceId,
+        trimmedSql,
+        JSON.stringify(defaultRunParamsValidation.value),
+        JSON.stringify(parameterSchemaValidation.value)
+      ]
+    );
+
+    return success(insertResult.rows[0], 201);
+  } catch (err) {
+    if (isPgUniqueViolation(err)) {
+      return failure(409, {
+        error: "conflict",
+        message: "Saved query name already exists for this owner and data source"
+      });
+    }
+    throw err;
+  }
+}
+
+async function updateSavedQuery(savedQueryId, {
+  name,
+  description,
+  dataSourceId,
+  sql,
+  defaultRunParams,
+  parameterSchema
+}) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+
+  const existing = await loadSavedQuery(savedQueryId);
+  if (!existing) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+
+  const trimmedDataSourceId = String(dataSourceId || "").trim();
+  const trimmedName = typeof name === "string" ? name.trim() : "";
+  const trimmedSql = typeof sql === "string" ? sql.trim() : "";
+  const normalizedDescription = normalizeOptionalTrimmedString(description);
+  const defaultRunParamsValidation = validateSavedQueryDefaultRunParams(defaultRunParams);
+  const parameterSchemaValidation = resolveParameterSchema(trimmedSql, parameterSchema, existing.parameter_schema);
+
+  if (!trimmedName || !trimmedDataSourceId || !trimmedSql) {
+    return failure(400, { error: "bad_request", message: "name, data_source_id and sql are required" });
+  }
+  if (!isUuid(trimmedDataSourceId)) {
+    return failure(400, { error: "bad_request", message: "data_source_id must be a valid UUID" });
+  }
+  if (trimmedName.length > SAVED_QUERY_NAME_MAX_LENGTH) {
+    return failure(400, {
+      error: "bad_request",
+      message: `name cannot exceed ${SAVED_QUERY_NAME_MAX_LENGTH} characters`
+    });
+  }
+  if (normalizedDescription && normalizedDescription.length > SAVED_QUERY_DESCRIPTION_MAX_LENGTH) {
+    return failure(400, {
+      error: "bad_request",
+      message: `description cannot exceed ${SAVED_QUERY_DESCRIPTION_MAX_LENGTH} characters`
+    });
+  }
+  if (!defaultRunParamsValidation.ok) {
+    return failure(400, { error: "bad_request", message: defaultRunParamsValidation.message });
+  }
+  if (!parameterSchemaValidation.ok) {
+    return failure(400, { error: "bad_request", message: parameterSchemaValidation.message });
+  }
+
+  if (!(await ensureDataSourceExists(trimmedDataSourceId))) {
+    return failure(404, { error: "not_found", message: "Data source not found" });
+  }
+
+  try {
+    const updateResult = await appDb.query(
+      `
+        UPDATE saved_queries
+        SET
+          name = $2,
+          description = $3,
+          data_source_id = $4,
+          sql = $5,
+          default_run_params = $6::jsonb,
+          parameter_schema = $7::jsonb,
+          updated_at = NOW()
+        WHERE id = $1
+        RETURNING ${SAVED_QUERY_COLUMNS}
+      `,
+      [
+        savedQueryId,
+        trimmedName,
+        normalizedDescription,
+        trimmedDataSourceId,
+        trimmedSql,
+        JSON.stringify(defaultRunParamsValidation.value),
+        JSON.stringify(parameterSchemaValidation.value)
+      ]
+    );
+
+    return success(updateResult.rows[0]);
+  } catch (err) {
+    if (isPgUniqueViolation(err)) {
+      return failure(409, {
+        error: "conflict",
+        message: "Saved query name already exists for this owner and data source"
+      });
+    }
+    throw err;
+  }
+}
+
+async function deleteSavedQuery(savedQueryId) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+
+  const deleteResult = await appDb.query(
+    `DELETE FROM saved_queries WHERE id = $1 RETURNING id`,
+    [savedQueryId]
+  );
+
+  if (deleteResult.rowCount === 0) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+
+  return success({ ok: true, id: deleteResult.rows[0].id });
+}
+
+async function validateSavedQueryParams(savedQueryId, providedParams) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+
+  const validation = validateParameterValues(savedQuery.parameter_schema, providedParams);
+  if (!validation.ok) {
+    return success({ ok: false, errors: validation.errors });
+  }
+
+  return success({ ok: true, resolved_values: validation.resolvedValues });
+}
+
+async function executeSavedQuery(savedQueryId, { params, maxRows, timeoutMs } = {}) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+
+  const savedQuery = await loadSavedQueryForExecution(savedQueryId);
+  if (!savedQuery) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (!isSupportedDbType(savedQuery.db_type)) {
+    return failure(400, {
+      error: "bad_request",
+      message: `Unsupported db_type for execution: ${savedQuery.db_type}`
+    });
+  }
+
+  const parameterValidation = validateParameterValues(savedQuery.parameter_schema, params);
+  if (!parameterValidation.ok) {
+    return failure(400, {
+      error: "bad_request",
+      message: "Invalid saved query parameters",
+      errors: parameterValidation.errors
+    });
+  }
+
+  const dialect = savedQuery.db_type === "mssql" ? "mssql" : "postgres";
+  const { maxRows: resolvedMaxRows, timeoutMs: resolvedTimeoutMs } = resolveRunOptions(
+    savedQuery.default_run_params,
+    { maxRows, timeoutMs }
+  );
+  const executableSql = ensureLimit(sanitizeGeneratedSql(savedQuery.sql), resolvedMaxRows, dialect);
+  const schemaObjects = await loadSchemaObjects(savedQuery.data_source_id);
+  const validationSql = substitutePlaceholdersForValidation(executableSql, savedQuery.parameter_schema);
+  const normalized = validateAndNormalizeSql(validationSql, {
+    maxRows: resolvedMaxRows,
+    schemaObjects,
+    dialect
+  });
+
+  if (!normalized.ok) {
+    return failure(400, {
+      error: "bad_request",
+      message: normalized.errors.join("; "),
+      errors: normalized.errors
+    });
+  }
+
+  let adapter = null;
+  try {
+    adapter = createDatabaseAdapter(savedQuery.db_type, savedQuery.connection_ref);
+    const adapterValidation = await adapter.validateSql(normalized.sql);
+    if (!adapterValidation.ok) {
+      return failure(400, {
+        error: "bad_request",
+        message: adapterValidation.errors.join("; "),
+        errors: adapterValidation.errors
+      });
+    }
+
+    const execution = await adapter.executeParameterizedReadOnly(
+      executableSql,
+      parameterValidation.resolvedValues,
+      savedQuery.parameter_schema,
+      { maxRows: resolvedMaxRows, timeoutMs: resolvedTimeoutMs }
+    );
+
+    return success({
+      sql: executableSql,
+      columns: execution.columns,
+      rows: execution.rows,
+      row_count: execution.rowCount,
+      duration_ms: execution.durationMs
+    });
+  } finally {
+    if (adapter) {
+      await adapter.close();
+    }
+  }
+}
+
+module.exports = {
+  getSavedQuery,
+  listSavedQueries,
+  createSavedQuery,
+  updateSavedQuery,
+  deleteSavedQuery,
+  validateSavedQueryParams,
+  executeSavedQuery
+};


### PR DESCRIPTION
## Summary

- Move all saved-query business logic out of [app/src/routes/savedQueries.js](app/src/routes/savedQueries.js) into a new [app/src/services/savedQueryService.js](app/src/services/savedQueryService.js). Route handlers become thin HTTP wrappers (parse → call service → write result envelope).
- Service uses the same `{ ok, statusCode, body }` envelope already established in [queryOrchestrationService.js](app/src/services/queryOrchestrationService.js) — no third pattern introduced.
- Adapter lifecycle in `executeSavedQuery` preserves the original `try { adapter = createDatabaseAdapter(...); ... } finally { if (adapter) await adapter.close(); }` shape exactly, including the early-return-400 path on adapter validation failure.

Addresses the AGENTS.md rule: *"Avoid putting business logic in route handlers."* This is Tier 1 of a planned set of refactors against route files >300 lines; PR 2 (`dataSourceExportImport`) follows separately.

## Test plan

- [x] `node --test app/test/savedQueriesApi.test.js` — 7/7 pass (HTTP-level coverage, mocks `appDb` and `dbAdapterFactory` only; no test edits needed)
- [x] `npm test` — 48/48 pass
- [x] `npm --prefix frontend run lint` — clean
- [x] Independent code review confirmed no behavioral drift in validation order, error messages, status codes, response shapes, or adapter close semantics
- [ ] Manual smoke against a dev DB before merge if reviewer wants

🤖 Generated with [Claude Code](https://claude.com/claude-code)