### PR TITLE
feat(auth): AUTH-001 authentication foundation (login/logout/session)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,13 @@ OPENAI_API_KEY=
 GEMINI_API_KEY=
 DEEPSEEK_API_KEY=
 
+# AUTH-001: session handling
+# Session lifetime for the rp_session cookie, in milliseconds. Default: 12h.
+AUTH_SESSION_DURATION_MS=43200000
+# Set to "true" to force the Secure cookie attribute outside of production.
+# When unset, the cookie is Secure only when NODE_ENV=production.
+AUTH_COOKIE_SECURE=
+
 # SMTP config for email delivery (BE-002)
 SMTP_HOST=localhost
 SMTP_PORT=587

--- a/app/src/lib/sessionCookie.js
+++ b/app/src/lib/sessionCookie.js
@@ -1,0 +1,79 @@
+const { SESSION_COOKIE_NAME } = require("../services/authService");
+
+function parseCookieHeader(header) {
+  const cookies = {};
+  if (typeof header !== "string" || !header) {
+    return cookies;
+  }
+  for (const segment of header.split(";")) {
+    const idx = segment.indexOf("=");
+    if (idx === -1) {
+      continue;
+    }
+    const name = segment.slice(0, idx).trim();
+    const value = segment.slice(idx + 1).trim();
+    if (!name) {
+      continue;
+    }
+    try {
+      cookies[name] = decodeURIComponent(value);
+    } catch {
+      cookies[name] = value;
+    }
+  }
+  return cookies;
+}
+
+function readSessionToken(req) {
+  const cookies = parseCookieHeader(req.headers.cookie);
+  return cookies[SESSION_COOKIE_NAME] || null;
+}
+
+function isSecureCookie() {
+  if (process.env.AUTH_COOKIE_SECURE === "true") {
+    return true;
+  }
+  if (process.env.AUTH_COOKIE_SECURE === "false") {
+    return false;
+  }
+  return process.env.NODE_ENV === "production";
+}
+
+function buildSessionCookie(token, expiresAt) {
+  const parts = [
+    `${SESSION_COOKIE_NAME}=${encodeURIComponent(token)}`,
+    "HttpOnly",
+    "Path=/",
+    "SameSite=Lax"
+  ];
+  if (expiresAt) {
+    const expires = expiresAt instanceof Date ? expiresAt : new Date(expiresAt);
+    parts.push(`Expires=${expires.toUTCString()}`);
+  }
+  if (isSecureCookie()) {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+function buildClearSessionCookie() {
+  const parts = [
+    `${SESSION_COOKIE_NAME}=`,
+    "HttpOnly",
+    "Path=/",
+    "SameSite=Lax",
+    "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+    "Max-Age=0"
+  ];
+  if (isSecureCookie()) {
+    parts.push("Secure");
+  }
+  return parts.join("; ");
+}
+
+module.exports = {
+  parseCookieHeader,
+  readSessionToken,
+  buildSessionCookie,
+  buildClearSessionCookie
+};

--- a/app/src/routes/auth.js
+++ b/app/src/routes/auth.js
@@ -1,0 +1,91 @@
+const { json, readJsonBody, badRequest } = require("../lib/http");
+const {
+  buildSessionCookie,
+  buildClearSessionCookie,
+  readSessionToken
+} = require("../lib/sessionCookie");
+const authService = require("../services/authService");
+
+function clientAddress(req) {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string" && forwarded.length > 0) {
+    const first = forwarded.split(",")[0];
+    if (first) {
+      return first.trim();
+    }
+  }
+  return req.socket && req.socket.remoteAddress ? req.socket.remoteAddress : null;
+}
+
+function publicUser(user) {
+  if (!user) {
+    return null;
+  }
+  return {
+    id: user.id,
+    email: user.email,
+    display_name: user.display_name,
+    is_active: user.is_active,
+    last_login_at: user.last_login_at,
+    created_at: user.created_at
+  };
+}
+
+async function handleLogin(req, res) {
+  const body = await readJsonBody(req);
+  const email = typeof body.email === "string" ? body.email : "";
+  const password = typeof body.password === "string" ? body.password : "";
+
+  if (!email || !password) {
+    return badRequest(res, "email and password are required");
+  }
+
+  const result = await authService.loginWithPassword({
+    email,
+    password,
+    userAgent: req.headers["user-agent"] || null,
+    ipAddress: clientAddress(req)
+  });
+
+  if (!result) {
+    return json(res, 401, { error: "invalid_credentials" });
+  }
+
+  res.setHeader("Set-Cookie", buildSessionCookie(result.token, result.expiresAt));
+  return json(res, 200, {
+    user: publicUser(result.user),
+    expires_at: result.expiresAt
+  });
+}
+
+async function handleLogout(req, res) {
+  const token = readSessionToken(req);
+  if (token) {
+    await authService.revokeSessionByToken(token);
+  }
+  res.setHeader("Set-Cookie", buildClearSessionCookie());
+  return json(res, 200, { ok: true });
+}
+
+async function handleMe(req, res) {
+  const token = readSessionToken(req);
+  if (!token) {
+    return json(res, 401, { error: "unauthenticated" });
+  }
+  const session = await authService.findActiveSession(token);
+  if (!session) {
+    res.setHeader("Set-Cookie", buildClearSessionCookie());
+    return json(res, 401, { error: "unauthenticated" });
+  }
+  authService.touchSession(session.sessionId).catch(() => {});
+  return json(res, 200, {
+    user: publicUser(session.user),
+    expires_at: session.expiresAt
+  });
+}
+
+module.exports = {
+  handleLogin,
+  handleLogout,
+  handleMe
+};

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -70,6 +70,11 @@ const {
   handleBenchmarkCommand,
   handleCreateBenchmarkReport
 } = require("./routes/observability");
+const {
+  handleLogin,
+  handleLogout,
+  handleMe
+} = require("./routes/auth");
 
 async function routeRequest(req, res) {
   const requestUrl = new URL(req.url, "http://localhost");
@@ -109,6 +114,18 @@ async function routeRequest(req, res) {
 
   if (req.method === "GET" && serveFrontendAsset(res, pathname)) {
     return;
+  }
+
+  if (req.method === "POST" && pathname === "/v1/auth/login") {
+    return handleLogin(req, res);
+  }
+
+  if (req.method === "POST" && pathname === "/v1/auth/logout") {
+    return handleLogout(req, res);
+  }
+
+  if (req.method === "GET" && pathname === "/v1/auth/me") {
+    return handleMe(req, res);
   }
 
   if (req.method === "POST" && pathname === "/v1/data-sources") {

--- a/app/src/services/authService.js
+++ b/app/src/services/authService.js
@@ -1,0 +1,286 @@
+const crypto = require("crypto");
+const appDb = require("../lib/appDb");
+
+const SCRYPT_KEYLEN = 64;
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 };
+const SESSION_TOKEN_BYTES = 32;
+const DEFAULT_SESSION_DURATION_MS = 12 * 60 * 60 * 1000;
+const SESSION_COOKIE_NAME = "rp_session";
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_MAX_LENGTH = 256;
+const EMAIL_MAX_LENGTH = 320;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function getSessionDurationMs() {
+  const raw = Number(process.env.AUTH_SESSION_DURATION_MS);
+  if (Number.isFinite(raw) && raw > 0) {
+    return raw;
+  }
+  return DEFAULT_SESSION_DURATION_MS;
+}
+
+function normalizeEmail(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > EMAIL_MAX_LENGTH) {
+    return null;
+  }
+  if (!EMAIL_PATTERN.test(trimmed)) {
+    return null;
+  }
+  return trimmed.toLowerCase();
+}
+
+function validatePassword(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+  if (value.length < PASSWORD_MIN_LENGTH || value.length > PASSWORD_MAX_LENGTH) {
+    return false;
+  }
+  return true;
+}
+
+function hashPassword(password) {
+  const salt = crypto.randomBytes(16);
+  const derived = crypto.scryptSync(password, salt, SCRYPT_KEYLEN, SCRYPT_PARAMS);
+  return [
+    "scrypt",
+    SCRYPT_PARAMS.N,
+    SCRYPT_PARAMS.r,
+    SCRYPT_PARAMS.p,
+    salt.toString("hex"),
+    derived.toString("hex")
+  ].join("$");
+}
+
+function verifyPassword(password, encoded) {
+  if (typeof password !== "string" || typeof encoded !== "string") {
+    return false;
+  }
+  const parts = encoded.split("$");
+  if (parts.length !== 6 || parts[0] !== "scrypt") {
+    return false;
+  }
+  const N = Number(parts[1]);
+  const r = Number(parts[2]);
+  const p = Number(parts[3]);
+  if (!Number.isInteger(N) || !Number.isInteger(r) || !Number.isInteger(p)) {
+    return false;
+  }
+  let salt;
+  let expected;
+  try {
+    salt = Buffer.from(parts[4], "hex");
+    expected = Buffer.from(parts[5], "hex");
+  } catch {
+    return false;
+  }
+  if (expected.length === 0) {
+    return false;
+  }
+  let derived;
+  try {
+    derived = crypto.scryptSync(password, salt, expected.length, { N, r, p });
+  } catch {
+    return false;
+  }
+  if (derived.length !== expected.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(derived, expected);
+}
+
+function generateSessionToken() {
+  return crypto.randomBytes(SESSION_TOKEN_BYTES).toString("hex");
+}
+
+function hashSessionToken(token) {
+  return crypto.createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+function rowToUser(row) {
+  if (!row) {
+    return null;
+  }
+  return {
+    id: row.id,
+    email: row.email,
+    display_name: row.display_name,
+    is_active: row.is_active,
+    last_login_at: row.last_login_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at
+  };
+}
+
+async function findUserByEmail(email) {
+  const normalized = normalizeEmail(email);
+  if (!normalized) {
+    return null;
+  }
+  const result = await appDb.query(
+    "SELECT id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at FROM users WHERE lower(email) = $1",
+    [normalized]
+  );
+  return result.rows[0] || null;
+}
+
+async function findUserById(id) {
+  if (typeof id !== "string" || !id) {
+    return null;
+  }
+  const result = await appDb.query(
+    "SELECT id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at FROM users WHERE id = $1",
+    [id]
+  );
+  return result.rows[0] || null;
+}
+
+async function createUser({ email, password, displayName = null }) {
+  const normalized = normalizeEmail(email);
+  if (!normalized) {
+    const err = new Error("invalid email");
+    err.code = "invalid_email";
+    throw err;
+  }
+  if (!validatePassword(password)) {
+    const err = new Error(`password must be ${PASSWORD_MIN_LENGTH}-${PASSWORD_MAX_LENGTH} characters`);
+    err.code = "invalid_password";
+    throw err;
+  }
+  const passwordHash = hashPassword(password);
+  const trimmedDisplayName = typeof displayName === "string" && displayName.trim()
+    ? displayName.trim()
+    : null;
+  const result = await appDb.query(
+    `
+      INSERT INTO users (email, password_hash, display_name)
+      VALUES ($1, $2, $3)
+      RETURNING id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at
+    `,
+    [normalized, passwordHash, trimmedDisplayName]
+  );
+  return result.rows[0];
+}
+
+async function createSession(userId, { userAgent = null, ipAddress = null } = {}) {
+  const token = generateSessionToken();
+  const tokenHash = hashSessionToken(token);
+  const expiresAt = new Date(Date.now() + getSessionDurationMs());
+  const trimmedAgent = typeof userAgent === "string" ? userAgent.slice(0, 1024) : null;
+  const trimmedIp = typeof ipAddress === "string" ? ipAddress.slice(0, 64) : null;
+  const result = await appDb.query(
+    `
+      INSERT INTO user_sessions (user_id, token_hash, user_agent, ip_address, expires_at)
+      VALUES ($1, $2, $3, $4, $5)
+      RETURNING id, expires_at
+    `,
+    [userId, tokenHash, trimmedAgent, trimmedIp, expiresAt.toISOString()]
+  );
+  return {
+    token,
+    sessionId: result.rows[0].id,
+    expiresAt: result.rows[0].expires_at
+  };
+}
+
+async function findActiveSession(token) {
+  if (typeof token !== "string" || !token) {
+    return null;
+  }
+  const tokenHash = hashSessionToken(token);
+  const result = await appDb.query(
+    `
+      SELECT
+        s.id AS session_id,
+        s.expires_at,
+        s.revoked_at,
+        u.id, u.email, u.password_hash, u.display_name, u.is_active,
+        u.last_login_at, u.created_at, u.updated_at
+      FROM user_sessions s
+      JOIN users u ON u.id = s.user_id
+      WHERE s.token_hash = $1
+    `,
+    [tokenHash]
+  );
+  const row = result.rows[0];
+  if (!row) {
+    return null;
+  }
+  if (row.revoked_at) {
+    return null;
+  }
+  if (new Date(row.expires_at).getTime() <= Date.now()) {
+    return null;
+  }
+  if (!row.is_active) {
+    return null;
+  }
+  return {
+    sessionId: row.session_id,
+    expiresAt: row.expires_at,
+    user: rowToUser(row)
+  };
+}
+
+async function touchSession(sessionId) {
+  await appDb.query(
+    "UPDATE user_sessions SET last_seen_at = NOW() WHERE id = $1",
+    [sessionId]
+  );
+}
+
+async function revokeSessionByToken(token) {
+  if (typeof token !== "string" || !token) {
+    return false;
+  }
+  const tokenHash = hashSessionToken(token);
+  const result = await appDb.query(
+    "UPDATE user_sessions SET revoked_at = NOW() WHERE token_hash = $1 AND revoked_at IS NULL",
+    [tokenHash]
+  );
+  return result.rowCount > 0;
+}
+
+async function loginWithPassword({ email, password, userAgent, ipAddress }) {
+  const user = await findUserByEmail(email);
+  if (!user || !user.password_hash || !user.is_active) {
+    return null;
+  }
+  if (!verifyPassword(password, user.password_hash)) {
+    return null;
+  }
+  const session = await createSession(user.id, { userAgent, ipAddress });
+  await appDb.query("UPDATE users SET last_login_at = NOW() WHERE id = $1", [user.id]);
+  return {
+    user: rowToUser(user),
+    token: session.token,
+    sessionId: session.sessionId,
+    expiresAt: session.expiresAt
+  };
+}
+
+module.exports = {
+  SESSION_COOKIE_NAME,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_MAX_LENGTH,
+  normalizeEmail,
+  validatePassword,
+  hashPassword,
+  verifyPassword,
+  generateSessionToken,
+  hashSessionToken,
+  findUserByEmail,
+  findUserById,
+  createUser,
+  createSession,
+  findActiveSession,
+  touchSession,
+  revokeSessionByToken,
+  loginWithPassword,
+  rowToUser,
+  getSessionDurationMs
+};

--- a/app/test/authApi.test.js
+++ b/app/test/authApi.test.js
@@ -1,0 +1,309 @@
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+process.env.PORT = "0";
+process.env.AUTH_COOKIE_SECURE = "false";
+
+const appDb = require("../src/lib/appDb");
+const authService = require("../src/services/authService");
+
+let server;
+let baseUrl;
+let users;
+let sessions;
+let userIdCounter;
+let sessionIdCounter;
+let originalQuery;
+
+function uuid(prefix, counter) {
+  return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
+}
+
+function nextUserId() {
+  userIdCounter += 1;
+  return uuid("aaaa", userIdCounter);
+}
+
+function nextSessionId() {
+  sessionIdCounter += 1;
+  return uuid("bbbb", sessionIdCounter);
+}
+
+function normalizeSql(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function seedUser({ email, password, displayName = null, isActive = true }) {
+  const row = {
+    id: nextUserId(),
+    email,
+    password_hash: authService.hashPassword(password),
+    display_name: displayName,
+    is_active: isActive,
+    last_login_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  };
+  users.set(row.id, row);
+  return row;
+}
+
+async function api(method, path, body, { cookie } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (cookie) {
+    headers.Cookie = cookie;
+  }
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  });
+
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  return {
+    status: response.status,
+    payload,
+    setCookie: response.headers.get("set-cookie")
+  };
+}
+
+function parseSessionCookieValue(setCookieHeader) {
+  if (!setCookieHeader) {
+    return null;
+  }
+  const match = setCookieHeader.match(/rp_session=([^;]*)/);
+  if (!match) {
+    return null;
+  }
+  return decodeURIComponent(match[1]);
+}
+
+before(async () => {
+  originalQuery = appDb.query;
+  users = new Map();
+  sessions = new Map();
+  userIdCounter = 0;
+  sessionIdCounter = 0;
+
+  appDb.query = async (sql, params = []) => {
+    const normalized = normalizeSql(sql);
+
+    if (normalized.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
+      const [emailLower] = params;
+      const row = [...users.values()].find((entry) => entry.email.toLowerCase() === emailLower);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    if (normalized.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where id = $1")) {
+      const [id] = params;
+      const row = users.get(id);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    if (normalized.startsWith("insert into users")) {
+      const [email, passwordHash, displayName] = params;
+      const row = {
+        id: nextUserId(),
+        email,
+        password_hash: passwordHash,
+        display_name: displayName,
+        is_active: true,
+        last_login_at: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
+      };
+      users.set(row.id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (normalized.startsWith("insert into user_sessions")) {
+      const [userId, tokenHash, userAgent, ipAddress, expiresAt] = params;
+      const row = {
+        id: nextSessionId(),
+        user_id: userId,
+        token_hash: tokenHash,
+        user_agent: userAgent,
+        ip_address: ipAddress,
+        created_at: new Date().toISOString(),
+        expires_at: expiresAt,
+        last_seen_at: new Date().toISOString(),
+        revoked_at: null
+      };
+      sessions.set(row.id, row);
+      return { rowCount: 1, rows: [{ id: row.id, expires_at: row.expires_at }] };
+    }
+
+    if (
+      normalized.startsWith(
+        "select s.id as session_id, s.expires_at, s.revoked_at, u.id, u.email, u.password_hash, u.display_name, u.is_active, u.last_login_at, u.created_at, u.updated_at from user_sessions s join users u on u.id = s.user_id where s.token_hash = $1"
+      )
+    ) {
+      const [tokenHash] = params;
+      const session = [...sessions.values()].find((entry) => entry.token_hash === tokenHash);
+      if (!session) {
+        return { rowCount: 0, rows: [] };
+      }
+      const user = users.get(session.user_id);
+      if (!user) {
+        return { rowCount: 0, rows: [] };
+      }
+      return {
+        rowCount: 1,
+        rows: [{
+          session_id: session.id,
+          expires_at: session.expires_at,
+          revoked_at: session.revoked_at,
+          id: user.id,
+          email: user.email,
+          password_hash: user.password_hash,
+          display_name: user.display_name,
+          is_active: user.is_active,
+          last_login_at: user.last_login_at,
+          created_at: user.created_at,
+          updated_at: user.updated_at
+        }]
+      };
+    }
+
+    if (normalized.startsWith("update user_sessions set last_seen_at = now() where id = $1")) {
+      const [id] = params;
+      const session = sessions.get(id);
+      if (session) {
+        session.last_seen_at = new Date().toISOString();
+      }
+      return { rowCount: session ? 1 : 0, rows: [] };
+    }
+
+    if (normalized.startsWith("update user_sessions set revoked_at = now() where token_hash = $1 and revoked_at is null")) {
+      const [tokenHash] = params;
+      let count = 0;
+      for (const session of sessions.values()) {
+        if (session.token_hash === tokenHash && !session.revoked_at) {
+          session.revoked_at = new Date().toISOString();
+          count += 1;
+        }
+      }
+      return { rowCount: count, rows: [] };
+    }
+
+    if (normalized.startsWith("update users set last_login_at = now() where id = $1")) {
+      const [id] = params;
+      const user = users.get(id);
+      if (user) {
+        user.last_login_at = new Date().toISOString();
+      }
+      return { rowCount: user ? 1 : 0, rows: [] };
+    }
+
+    throw new Error(`Unexpected SQL in auth test stub: ${normalized}`);
+  };
+
+  delete require.cache[require.resolve("../src/server")];
+  const { startServer } = require("../src/server");
+  server = await startServer();
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+beforeEach(() => {
+  users.clear();
+  sessions.clear();
+  userIdCounter = 0;
+  sessionIdCounter = 0;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  appDb.query = originalQuery;
+});
+
+test("login → me → logout happy path", async () => {
+  seedUser({ email: "alice@example.com", password: "hunter22ok", displayName: "Alice" });
+
+  const login = await api("POST", "/v1/auth/login", {
+    email: "Alice@Example.com",
+    password: "hunter22ok"
+  });
+  assert.equal(login.status, 200);
+  assert.equal(login.payload.user.email, "alice@example.com");
+  assert.equal(login.payload.user.display_name, "Alice");
+  assert.ok(login.payload.expires_at);
+  assert.ok(login.setCookie);
+  assert.match(login.setCookie, /HttpOnly/);
+  assert.match(login.setCookie, /SameSite=Lax/);
+
+  const token = parseSessionCookieValue(login.setCookie);
+  assert.match(token, /^[0-9a-f]{64}$/);
+
+  const cookie = `rp_session=${encodeURIComponent(token)}`;
+  const me = await api("GET", "/v1/auth/me", undefined, { cookie });
+  assert.equal(me.status, 200);
+  assert.equal(me.payload.user.email, "alice@example.com");
+
+  const logout = await api("POST", "/v1/auth/logout", undefined, { cookie });
+  assert.equal(logout.status, 200);
+  assert.deepEqual(logout.payload, { ok: true });
+  assert.match(logout.setCookie, /Max-Age=0/);
+
+  const meAfterLogout = await api("GET", "/v1/auth/me", undefined, { cookie });
+  assert.equal(meAfterLogout.status, 401);
+});
+
+test("login fails with 401 on wrong password and unknown email", async () => {
+  seedUser({ email: "bob@example.com", password: "supersecret" });
+
+  const wrongPassword = await api("POST", "/v1/auth/login", {
+    email: "bob@example.com",
+    password: "wrong-password"
+  });
+  assert.equal(wrongPassword.status, 401);
+  assert.equal(wrongPassword.setCookie, null);
+
+  const unknownEmail = await api("POST", "/v1/auth/login", {
+    email: "nobody@example.com",
+    password: "supersecret"
+  });
+  assert.equal(unknownEmail.status, 401);
+});
+
+test("login fails with 400 when fields are missing", async () => {
+  const noBody = await api("POST", "/v1/auth/login", {});
+  assert.equal(noBody.status, 400);
+
+  const noPassword = await api("POST", "/v1/auth/login", { email: "x@y.com" });
+  assert.equal(noPassword.status, 400);
+
+  const noEmail = await api("POST", "/v1/auth/login", { password: "supersecret" });
+  assert.equal(noEmail.status, 400);
+});
+
+test("inactive users cannot log in", async () => {
+  seedUser({ email: "ghost@example.com", password: "hunter22ok", isActive: false });
+  const login = await api("POST", "/v1/auth/login", {
+    email: "ghost@example.com",
+    password: "hunter22ok"
+  });
+  assert.equal(login.status, 401);
+});
+
+test("me returns 401 without a cookie and with a bogus cookie", async () => {
+  const noCookie = await api("GET", "/v1/auth/me");
+  assert.equal(noCookie.status, 401);
+
+  const bogus = await api("GET", "/v1/auth/me", undefined, { cookie: "rp_session=not-a-real-token" });
+  assert.equal(bogus.status, 401);
+});
+
+test("logout without a session is a no-op that still clears the cookie", async () => {
+  const logout = await api("POST", "/v1/auth/logout");
+  assert.equal(logout.status, 200);
+  assert.match(logout.setCookie, /Max-Age=0/);
+});

--- a/app/test/authMigration.test.js
+++ b/app/test/authMigration.test.js
@@ -1,0 +1,26 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+test("0014_auth_users_and_sessions migration creates users and sessions tables", () => {
+  const migrationPath = path.resolve(__dirname, "../../db/migrations/0014_auth_users_and_sessions.sql");
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS users/i);
+  assert.match(sql, /email TEXT NOT NULL/i);
+  assert.match(sql, /password_hash TEXT/i);
+  assert.match(sql, /display_name TEXT/i);
+  assert.match(sql, /is_active BOOLEAN NOT NULL DEFAULT TRUE/i);
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_lower/i);
+  assert.match(sql, /ON users \(lower\(email\)\)/i);
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS user_sessions/i);
+  assert.match(sql, /user_id UUID NOT NULL REFERENCES users\(id\) ON DELETE CASCADE/i);
+  assert.match(sql, /token_hash TEXT NOT NULL/i);
+  assert.match(sql, /expires_at TIMESTAMPTZ NOT NULL/i);
+  assert.match(sql, /revoked_at TIMESTAMPTZ/i);
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS idx_user_sessions_token_hash/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_user_sessions_user_id/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_user_sessions_expires_at/i);
+});

--- a/app/test/authService.test.js
+++ b/app/test/authService.test.js
@@ -1,0 +1,50 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+
+const authService = require("../src/services/authService");
+
+test("normalizeEmail trims, lowercases, and rejects malformed addresses", () => {
+  assert.equal(authService.normalizeEmail("  Alice@Example.COM "), "alice@example.com");
+  assert.equal(authService.normalizeEmail("plain"), null);
+  assert.equal(authService.normalizeEmail("a@b"), null);
+  assert.equal(authService.normalizeEmail(""), null);
+  assert.equal(authService.normalizeEmail(undefined), null);
+  assert.equal(authService.normalizeEmail("a@b.c d"), null);
+});
+
+test("validatePassword enforces length bounds", () => {
+  assert.equal(authService.validatePassword("short"), false);
+  assert.equal(authService.validatePassword("12345678"), true);
+  assert.equal(authService.validatePassword(""), false);
+  assert.equal(authService.validatePassword("x".repeat(257)), false);
+  assert.equal(authService.validatePassword(123456789), false);
+});
+
+test("hashPassword + verifyPassword round-trip and reject wrong values", () => {
+  const encoded = authService.hashPassword("correct horse battery staple");
+  assert.match(encoded, /^scrypt\$\d+\$\d+\$\d+\$[0-9a-f]+\$[0-9a-f]+$/);
+
+  assert.equal(authService.verifyPassword("correct horse battery staple", encoded), true);
+  assert.equal(authService.verifyPassword("wrong password", encoded), false);
+  assert.equal(authService.verifyPassword("correct horse battery staple", ""), false);
+  assert.equal(authService.verifyPassword("correct horse battery staple", "scrypt$1$1$1$00$00"), false);
+});
+
+test("hashPassword produces unique encodings per call (random salt)", () => {
+  const a = authService.hashPassword("hunter22ok");
+  const b = authService.hashPassword("hunter22ok");
+  assert.notEqual(a, b);
+  assert.equal(authService.verifyPassword("hunter22ok", a), true);
+  assert.equal(authService.verifyPassword("hunter22ok", b), true);
+});
+
+test("generateSessionToken returns a 64-char hex string and hashSessionToken is deterministic", () => {
+  const token = authService.generateSessionToken();
+  assert.match(token, /^[0-9a-f]{64}$/);
+
+  const hashed = authService.hashSessionToken(token);
+  assert.equal(hashed.length, 64);
+  assert.equal(authService.hashSessionToken(token), hashed);
+});

--- a/db/migrations/0014_auth_users_and_sessions.sql
+++ b/db/migrations/0014_auth_users_and_sessions.sql
@@ -1,0 +1,38 @@
+-- AUTH-001: Authentication foundation — users and sessions.
+-- Adds the minimum tables required for email/password login and server-side
+-- session tokens. Roles and permissions are layered in by AUTH-002.
+
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  email TEXT NOT NULL,
+  password_hash TEXT,
+  display_name TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  last_login_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_lower
+  ON users (lower(email));
+
+CREATE TABLE IF NOT EXISTS user_sessions (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL,
+  user_agent TEXT,
+  ip_address TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_sessions_token_hash
+  ON user_sessions (token_hash);
+
+CREATE INDEX IF NOT EXISTS idx_user_sessions_user_id
+  ON user_sessions (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_sessions_expires_at
+  ON user_sessions (expires_at);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -12,7 +12,58 @@ tags:
   - name: Admin
   - name: Providers
   - name: Observability
+  - name: Auth
 paths:
+  /v1/auth/login:
+    post:
+      tags: [Auth]
+      summary: Authenticate with email and password
+      description: Returns the authenticated user and sets an HttpOnly session cookie.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+      responses:
+        "200":
+          description: Authenticated. Session cookie set in `Set-Cookie`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthMeResponse"
+        "400":
+          description: Missing email or password
+        "401":
+          description: Invalid credentials
+  /v1/auth/logout:
+    post:
+      tags: [Auth]
+      summary: End the current session
+      description: Revokes the current session token (if any) and clears the cookie.
+      responses:
+        "200":
+          description: Session revoked. Cookie cleared.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+  /v1/auth/me:
+    get:
+      tags: [Auth]
+      summary: Get the currently authenticated user
+      responses:
+        "200":
+          description: Authenticated user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthMeResponse"
+        "401":
+          description: No active session
   /v1/query/prompts/history:
     get:
       tags: [Query]
@@ -987,6 +1038,43 @@ components:
       schema:
         type: string
   schemas:
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+    AuthUser:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        is_active:
+          type: boolean
+        last_login_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+    AuthMeResponse:
+      type: object
+      properties:
+        user:
+          $ref: "#/components/schemas/AuthUser"
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
     PromptHistoryItem:
       type: object
       properties:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter as Router, Navigate, Routes, Route } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { AppShell } from './components/Layout/AppShell';
+import { RequireAuth } from './components/Auth/RequireAuth';
+import { AuthProvider } from './contexts/AuthContext';
 import { DataSourceProvider } from './contexts/DataSourceContext';
 import { Dashboard } from './pages/Dashboard';
 import { DataSources } from './pages/DataSources';
@@ -8,6 +10,7 @@ import { SchemaExplorer } from './pages/SchemaExplorer';
 import { QueryWorkspace } from './pages/QueryWorkspace';
 import { SavedQueries } from './pages/SavedQueries';
 import { ComingSoon } from './pages/ComingSoon';
+import { Login } from './pages/Login';
 import { NotFound } from './pages/NotFound';
 import { Settings } from './pages/Settings';
 import { LLMProviders } from './pages/LLMProviders';
@@ -16,29 +19,39 @@ function App() {
   return (
     <Router>
       <Toaster position="top-right" richColors duration={10000} />
-      <DataSourceProvider>
+      <AuthProvider>
         <Routes>
-        <Route element={<AppShell />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/queries" element={<SavedQueries />} />
-          <Route path="/query" element={<QueryWorkspace />} />
-          <Route path="/data-sources" element={<DataSources />} />
-          <Route path="/schema" element={<SchemaExplorer />} />
-          <Route path="/observability" element={<Navigate to="/dashboard?tab=observability" replace />} />
-          <Route path="/release-gates" element={<Navigate to="/dashboard?tab=release-gates" replace />} />
-          <Route path="/llm-providers" element={<LLMProviders />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/folders" element={<ComingSoon />} />
-          <Route path="/favorites" element={<ComingSoon />} />
-          <Route path="/recent" element={<ComingSoon />} />
-          <Route path="/docs" element={<ComingSoon />} />
-        </Route>
+          <Route path="/login" element={<Login />} />
+
+          <Route
+            element={(
+              <RequireAuth>
+                <DataSourceProvider>
+                  <AppShell />
+                </DataSourceProvider>
+              </RequireAuth>
+            )}
+          >
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/queries" element={<SavedQueries />} />
+            <Route path="/query" element={<QueryWorkspace />} />
+            <Route path="/data-sources" element={<DataSources />} />
+            <Route path="/schema" element={<SchemaExplorer />} />
+            <Route path="/observability" element={<Navigate to="/dashboard?tab=observability" replace />} />
+            <Route path="/release-gates" element={<Navigate to="/dashboard?tab=release-gates" replace />} />
+            <Route path="/llm-providers" element={<LLMProviders />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/folders" element={<ComingSoon />} />
+            <Route path="/favorites" element={<ComingSoon />} />
+            <Route path="/recent" element={<ComingSoon />} />
+            <Route path="/docs" element={<ComingSoon />} />
+          </Route>
 
           {/* 404 Route */}
           <Route path="*" element={<NotFound />} />
         </Routes>
-      </DataSourceProvider>
+      </AuthProvider>
     </Router>
   );
 }

--- a/frontend/src/components/Auth/RequireAuth.tsx
+++ b/frontend/src/components/Auth/RequireAuth.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+
+interface RequireAuthProps {
+    children?: ReactNode;
+}
+
+export function RequireAuth({ children }: RequireAuthProps) {
+    const { status } = useAuth();
+    const location = useLocation();
+
+    if (status === 'unknown') {
+        return (
+            <div className="flex items-center justify-center h-screen text-sm text-gray-500">
+                Loading…
+            </div>
+        );
+    }
+
+    if (status === 'unauthenticated') {
+        const redirectTo = `${location.pathname}${location.search}${location.hash}`;
+        return <Navigate to="/login" replace state={{ from: redirectTo }} />;
+    }
+
+    return <>{children}</>;
+}

--- a/frontend/src/components/Layout/TopHeader.tsx
+++ b/frontend/src/components/Layout/TopHeader.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Database, Search, User, ChevronDown } from 'lucide-react';
 import appLogo from '../../assets/report-pilot.png';
+import { useAuth } from '../../hooks/useAuth';
 
 interface TopHeaderProps {
     currentConnection?: string;
@@ -15,8 +16,10 @@ export const TopHeader: React.FC<TopHeaderProps> = ({
 }) => {
     const [showConnectionMenu, setShowConnectionMenu] = useState(false);
     const [showUserMenu, setShowUserMenu] = useState(false);
+    const { user, logout } = useAuth();
 
     const selectedDataSource = dataSources.find(ds => ds.id === currentConnection);
+    const userLabel = user?.display_name || user?.email || 'User';
 
     return (
         <header className="h-14 bg-white border-b border-gray-200 flex items-center px-4 gap-4 flex-shrink-0">
@@ -105,13 +108,21 @@ export const TopHeader: React.FC<TopHeaderProps> = ({
                         />
                         <div className="absolute top-full right-0 mt-1 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-20 py-1">
                             <div className="px-3 py-2 border-b border-gray-100">
-                                <div className="text-sm font-medium text-gray-800">User</div>
-                                <div className="text-xs text-gray-500">user@example.com</div>
+                                <div className="text-sm font-medium text-gray-800 truncate">{userLabel}</div>
+                                {user?.email && user.display_name && (
+                                    <div className="text-xs text-gray-500 truncate">{user.email}</div>
+                                )}
                             </div>
                             <button className="w-full px-3 py-2 text-sm text-left text-gray-700 hover:bg-gray-50">
                                 Settings
                             </button>
-                            <button className="w-full px-3 py-2 text-sm text-left text-gray-700 hover:bg-gray-50">
+                            <button
+                                onClick={() => {
+                                    setShowUserMenu(false);
+                                    void logout();
+                                }}
+                                className="w-full px-3 py-2 text-sm text-left text-gray-700 hover:bg-gray-50"
+                            >
                                 Logout
                             </button>
                         </div>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { client } from '../lib/api/client';
+import { AuthContext, type AuthStatus, type AuthUser } from './authContextValue';
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+    const [status, setStatus] = useState<AuthStatus>('unknown');
+    const [user, setUser] = useState<AuthUser | null>(null);
+    const [expiresAt, setExpiresAt] = useState<string | null>(null);
+
+    const refresh = useCallback(async () => {
+        const { data, response } = await client.GET('/v1/auth/me');
+        if (response.ok && data?.user) {
+            setUser(data.user);
+            setExpiresAt(data.expires_at ?? null);
+            setStatus('authenticated');
+            return;
+        }
+        setUser(null);
+        setExpiresAt(null);
+        setStatus('unauthenticated');
+    }, []);
+
+    useEffect(() => {
+        void refresh();
+    }, [refresh]);
+
+    const login = useCallback(
+        async (email: string, password: string) => {
+            const { data, response } = await client.POST('/v1/auth/login', {
+                body: { email, password },
+            });
+            if (response.ok && data?.user) {
+                setUser(data.user);
+                setExpiresAt(data.expires_at ?? null);
+                setStatus('authenticated');
+                return { ok: true } as const;
+            }
+            const message =
+                response.status === 401
+                    ? 'Invalid email or password.'
+                    : `Login failed (${response.status}).`;
+            return { ok: false, message } as const;
+        },
+        [],
+    );
+
+    const logout = useCallback(async () => {
+        try {
+            await client.POST('/v1/auth/logout');
+        } finally {
+            setUser(null);
+            setExpiresAt(null);
+            setStatus('unauthenticated');
+        }
+    }, []);
+
+    const value = useMemo(
+        () => ({ status, user, expiresAt, login, logout, refresh }),
+        [status, user, expiresAt, login, logout, refresh],
+    );
+
+    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/frontend/src/contexts/authContextValue.ts
+++ b/frontend/src/contexts/authContextValue.ts
@@ -1,0 +1,17 @@
+import { createContext } from 'react';
+import type { components } from '../lib/api/types';
+
+export type AuthUser = components['schemas']['AuthUser'];
+
+export type AuthStatus = 'unknown' | 'authenticated' | 'unauthenticated';
+
+export interface AuthContextValue {
+    status: AuthStatus;
+    user: AuthUser | null;
+    expiresAt: string | null;
+    login: (email: string, password: string) => Promise<{ ok: true } | { ok: false; message: string }>;
+    logout: () => Promise<void>;
+    refresh: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/authContextValue';
+
+export function useAuth() {
+    const ctx = useContext(AuthContext);
+    if (!ctx) {
+        throw new Error('useAuth must be used inside AuthProvider');
+    }
+    return ctx;
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -6,6 +6,7 @@ const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
 
 export const client = createClient<paths>({
     baseUrl,
+    credentials: 'include',
 });
 
 // Add a response interceptor to handle global errors
@@ -26,8 +27,9 @@ client.use({
             // Log error to console
             console.error(`API Request Failed: ${response.url}`, errorMessage);
 
-            // Show toast for errors (unless it's a 404 which might be handled by UI)
-            if (response.status !== 404) {
+            // 401 is surfaced via the auth flow (redirect to /login). 404 is usually
+            // handled inline by the UI. Skip global toasts for both.
+            if (response.status !== 404 && response.status !== 401) {
                 toast.error(errorMessage);
             }
         }

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -4,6 +4,147 @@
  */
 
 export interface paths {
+    "/v1/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Authenticate with email and password
+         * @description Returns the authenticated user and sets an HttpOnly session cookie.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["LoginRequest"];
+                };
+            };
+            responses: {
+                /** @description Authenticated. Session cookie set in `Set-Cookie`. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AuthMeResponse"];
+                    };
+                };
+                /** @description Missing email or password */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Invalid credentials */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * End the current session
+         * @description Revokes the current session token (if any) and clears the cookie.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Session revoked. Cookie cleared. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            ok?: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the currently authenticated user */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Authenticated user */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AuthMeResponse"];
+                    };
+                };
+                /** @description No active session */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/query/prompts/history": {
         parameters: {
             query?: never;
@@ -1698,6 +1839,26 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        LoginRequest: {
+            /** Format: email */
+            email: string;
+            password: string;
+        };
+        AuthUser: {
+            id?: string;
+            email?: string;
+            display_name?: string | null;
+            is_active?: boolean;
+            /** Format: date-time */
+            last_login_at?: string | null;
+            /** Format: date-time */
+            created_at?: string;
+        };
+        AuthMeResponse: {
+            user?: components["schemas"]["AuthUser"];
+            /** Format: date-time */
+            expires_at?: string | null;
+        };
         PromptHistoryItem: {
             id: string;
             question: string;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,102 @@
+import { useState, type FormEvent } from 'react';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import appLogo from '../assets/report-pilot.png';
+import { useAuth } from '../hooks/useAuth';
+
+interface LocationState {
+    from?: string;
+}
+
+export function Login() {
+    const { status, login } = useAuth();
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    if (status === 'authenticated') {
+        const target = (location.state as LocationState | null)?.from || '/dashboard';
+        return <Navigate to={target} replace />;
+    }
+
+    async function onSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (submitting) return;
+        setSubmitting(true);
+        setError(null);
+        const result = await login(email, password);
+        setSubmitting(false);
+        if (result.ok) {
+            const target = (location.state as LocationState | null)?.from || '/dashboard';
+            navigate(target, { replace: true });
+            return;
+        }
+        setError(result.message);
+    }
+
+    return (
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+            <div className="w-full max-w-sm bg-white border border-gray-200 rounded-lg shadow-sm p-8">
+                <div className="flex items-center gap-2 justify-center mb-6">
+                    <img src={appLogo} alt="Report Pilot logo" className="w-8 h-8 object-contain" />
+                    <span className="text-lg font-semibold text-gray-800">Report Pilot</span>
+                </div>
+                <h1 className="text-xl font-semibold text-gray-800 mb-1 text-center">Sign in</h1>
+                <p className="text-sm text-gray-500 mb-6 text-center">
+                    Use your account email and password.
+                </p>
+
+                <form onSubmit={onSubmit} className="space-y-4" noValidate>
+                    <div>
+                        <label htmlFor="login-email" className="block text-sm font-medium text-gray-700 mb-1">
+                            Email
+                        </label>
+                        <input
+                            id="login-email"
+                            type="email"
+                            autoComplete="email"
+                            required
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-oxblood focus:border-transparent"
+                        />
+                    </div>
+                    <div>
+                        <label htmlFor="login-password" className="block text-sm font-medium text-gray-700 mb-1">
+                            Password
+                        </label>
+                        <input
+                            id="login-password"
+                            type="password"
+                            autoComplete="current-password"
+                            required
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-oxblood focus:border-transparent"
+                        />
+                    </div>
+
+                    {error && (
+                        <div
+                            role="alert"
+                            className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2"
+                        >
+                            {error}
+                        </div>
+                    )}
+
+                    <button
+                        type="submit"
+                        disabled={submitting}
+                        className="w-full px-3 py-2 text-sm font-medium text-white bg-oxblood rounded-md hover:bg-oxblood-deep disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                        {submitting ? 'Signing in…' : 'Sign in'}
+                    </button>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/scripts/create-user.js
+++ b/scripts/create-user.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// AUTH-001: bootstrap a user account (e.g. the initial admin) without going
+// through the (not-yet-built) admin API. Reads DATABASE_URL from the env.
+//
+// Usage:
+//   node scripts/create-user.js --email alice@example.com --password 'hunter22ok'
+//   node scripts/create-user.js --email alice@example.com --password '...' --display-name 'Alice' --update-if-exists
+
+const path = require("path");
+const readline = require("readline");
+
+const authService = require(path.resolve(__dirname, "../app/src/services/authService"));
+const appDb = require(path.resolve(__dirname, "../app/src/lib/appDb"));
+
+function parseArgs(argv) {
+  const opts = { updateIfExists: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--email":
+        opts.email = argv[++i];
+        break;
+      case "--password":
+        opts.password = argv[++i];
+        break;
+      case "--display-name":
+        opts.displayName = argv[++i];
+        break;
+      case "--update-if-exists":
+        opts.updateIfExists = true;
+        break;
+      case "-h":
+      case "--help":
+        opts.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/create-user.js --email <email> [options]\n\n`
+    + `Options:\n`
+    + `  --email <email>        Email address (required)\n`
+    + `  --password <pw>        Password. If omitted, you'll be prompted.\n`
+    + `  --display-name <name>  Optional display name\n`
+    + `  --update-if-exists     Reset password and display name if the user already exists\n`
+    + `  -h, --help             Show this help\n`);
+}
+
+function promptHidden(prompt) {
+  return new Promise((resolve, reject) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const onData = (char) => {
+      const c = String(char);
+      if (c === "\n" || c === "\r" || c === "") {
+        process.stdin.removeListener("data", onData);
+        return;
+      }
+      // Re-render the prompt without echoing the character.
+      readline.cursorTo(process.stdout, prompt.length);
+      readline.clearLine(process.stdout, 1);
+    };
+    process.stdin.on("data", onData);
+    rl.question(prompt, (answer) => {
+      rl.close();
+      process.stdin.removeListener("data", onData);
+      process.stdout.write("\n");
+      if (!answer) {
+        reject(new Error("Password is required."));
+        return;
+      }
+      resolve(answer);
+    });
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printHelp();
+    return;
+  }
+  if (!opts.email) {
+    printHelp();
+    throw new Error("--email is required");
+  }
+  if (!opts.password) {
+    opts.password = await promptHidden(`Password for ${opts.email}: `);
+  }
+  const normalized = authService.normalizeEmail(opts.email);
+  if (!normalized) {
+    throw new Error("Email is not a valid address.");
+  }
+  if (!authService.validatePassword(opts.password)) {
+    throw new Error(`Password must be ${authService.PASSWORD_MIN_LENGTH}-${authService.PASSWORD_MAX_LENGTH} characters.`);
+  }
+
+  const existing = await authService.findUserByEmail(normalized);
+  if (existing && !opts.updateIfExists) {
+    throw new Error(`User ${normalized} already exists. Pass --update-if-exists to reset the password.`);
+  }
+
+  if (existing) {
+    const passwordHash = authService.hashPassword(opts.password);
+    const result = await appDb.query(
+      `
+        UPDATE users
+        SET password_hash = $1,
+            display_name = COALESCE($2, display_name),
+            updated_at = NOW()
+        WHERE id = $3
+        RETURNING id, email
+      `,
+      [passwordHash, opts.displayName || null, existing.id]
+    );
+    process.stdout.write(`Updated user ${result.rows[0].email} (id=${result.rows[0].id}).\n`);
+  } else {
+    const created = await authService.createUser({
+      email: normalized,
+      password: opts.password,
+      displayName: opts.displayName
+    });
+    process.stdout.write(`Created user ${created.email} (id=${created.id}).\n`);
+  }
+}
+
+main()
+  .catch((err) => {
+    process.stderr.write(`[create-user] ${err.message}\n`);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    try {
+      await appDb.close();
+    } catch {
+      // already closed
+    }
+  });


### PR DESCRIPTION
Closes #21 — AUTH-001.

## Summary
- Adds email/password login backed by a server-side session cookie (`rp_session`, HttpOnly, SameSite=Lax, Secure in production).
- New backend: scrypt password hashing (no new deps), sha256-hashed opaque session tokens, `POST /v1/auth/login`, `POST /v1/auth/logout`, `GET /v1/auth/me`.
- New frontend: `AuthContext` + `useAuth`, `RequireAuth` route guard, `Login` page, real user identity + working logout in `TopHeader`. Unauthenticated visits are redirected to `/login` (with the intended path preserved). Type definitions regenerated from `openapi.yaml`.
- New CLI [scripts/create-user.js](scripts/create-user.js) to bootstrap the initial account before the admin API ships in AUTH-002.
- `.env.example` documents the two new knobs (`AUTH_SESSION_DURATION_MS`, `AUTH_COOKIE_SECURE`).

## Acceptance criteria
- [x] Unauthenticated users are redirected to login — handled by `RequireAuth`, intended path preserved in router state.
- [x] Authenticated users can access protected routes — guard renders children when status is `authenticated`.
- [x] Sessions expire correctly — `expires_at` enforced in DB lookup; cookie also carries `Expires`; expired/revoked sessions return 401 and the cookie is cleared.
- [x] UI shows current user identity via `/v1/auth/me` — `TopHeader` reads from `useAuth`.
- [x] Logout endpoint + client flow — `/v1/auth/logout` revokes the session and `Set-Cookie: rp_session=…; Max-Age=0`.

## Schema
- `0014_auth_users_and_sessions.sql` adds `users` (with `lower(email)` unique index) and `user_sessions` (token_hash unique index, indexed by `user_id` and `expires_at`).

## Test plan
- [x] `DATABASE_URL=postgresql://test:test@localhost:5432/test npm test` → 61/61 passing (12 new auth tests covering migration shape, password/token logic, end-to-end login/me/logout, wrong password, missing fields, inactive user, bogus cookie, idempotent logout).
- [x] `npm --prefix frontend run lint` clean.
- [x] `npm --prefix frontend run build` clean (`tsc -b` + `vite build`).
- [ ] Manual: `npm run migrate`, then `node scripts/create-user.js --email you@example.com --password '<8+ chars>'`, log in via `/login`, exercise logout from the user menu.

## Out of scope (follow-up tickets)
- Roles, admin user endpoints, default-role-on-create → AUTH-002 (#22).
- RBAC enforcement middleware on the rest of the API → AUTH-003 (#23).
- Frontend permission-aware UI / role-based hides → AUTH-004 (#24).
- OIDC / SSO → AUTH-010 (#30).