### PR TITLE
feat(auth): AUTH-002 user and role data model with admin endpoints

### DIFF
--- a/app/src/lib/authGate.js
+++ b/app/src/lib/authGate.js
@@ -1,0 +1,54 @@
+const { json } = require("./http");
+const { readSessionToken, buildClearSessionCookie } = require("./sessionCookie");
+const authService = require("../services/authService");
+const roleService = require("../services/roleService");
+
+async function loadCurrentUser(req) {
+  const token = readSessionToken(req);
+  if (!token) {
+    return null;
+  }
+  const session = await authService.findActiveSession(token);
+  if (!session) {
+    return { expired: true };
+  }
+  const roles = await roleService.listRoleNamesForUser(session.user.id);
+  return {
+    user: session.user,
+    roles,
+    sessionId: session.sessionId,
+    expiresAt: session.expiresAt
+  };
+}
+
+async function requireAuthenticated(req, res) {
+  const current = await loadCurrentUser(req);
+  if (!current) {
+    json(res, 401, { error: "unauthenticated" });
+    return null;
+  }
+  if (current.expired) {
+    res.setHeader("Set-Cookie", buildClearSessionCookie());
+    json(res, 401, { error: "unauthenticated" });
+    return null;
+  }
+  return current;
+}
+
+async function requireRole(req, res, roleName) {
+  const current = await requireAuthenticated(req, res);
+  if (!current) {
+    return null;
+  }
+  if (!current.roles.includes(roleName)) {
+    json(res, 403, { error: "forbidden", message: `requires role: ${roleName}` });
+    return null;
+  }
+  return current;
+}
+
+module.exports = {
+  loadCurrentUser,
+  requireAuthenticated,
+  requireRole
+};

--- a/app/src/routes/admin.js
+++ b/app/src/routes/admin.js
@@ -1,0 +1,51 @@
+const { json, readJsonBody, badRequest } = require("../lib/http");
+const { isUuid } = require("../lib/validation");
+const { requireRole } = require("../lib/authGate");
+const adminUserService = require("../services/adminUserService");
+
+function writeResult(res, result) {
+  return json(res, result.statusCode, result.body);
+}
+
+async function handleListUsers(req, res) {
+  const current = await requireRole(req, res, "admin");
+  if (!current) return undefined;
+  const result = await adminUserService.listUsers();
+  return writeResult(res, result);
+}
+
+async function handleCreateUser(req, res) {
+  const current = await requireRole(req, res, "admin");
+  if (!current) return undefined;
+  const body = await readJsonBody(req);
+  const result = await adminUserService.createUser({
+    email: body.email,
+    password: body.password,
+    displayName: body.display_name,
+    roles: body.roles,
+    actorUserId: current.user.id
+  });
+  return writeResult(res, result);
+}
+
+async function handleUpdateUserRoles(req, res, userId) {
+  const current = await requireRole(req, res, "admin");
+  if (!current) return undefined;
+  if (!isUuid(userId)) {
+    return badRequest(res, "user id must be a uuid");
+  }
+  const body = await readJsonBody(req);
+  const result = await adminUserService.updateUserRoles({
+    userId,
+    assign: body.assign,
+    revoke: body.revoke,
+    actorUserId: current.user.id
+  });
+  return writeResult(res, result);
+}
+
+module.exports = {
+  handleListUsers,
+  handleCreateUser,
+  handleUpdateUserRoles
+};

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -75,6 +75,11 @@ const {
   handleLogout,
   handleMe
 } = require("./routes/auth");
+const {
+  handleListUsers,
+  handleCreateUser,
+  handleUpdateUserRoles
+} = require("./routes/admin");
 
 async function routeRequest(req, res) {
   const requestUrl = new URL(req.url, "http://localhost");
@@ -126,6 +131,19 @@ async function routeRequest(req, res) {
 
   if (req.method === "GET" && pathname === "/v1/auth/me") {
     return handleMe(req, res);
+  }
+
+  if (req.method === "GET" && pathname === "/v1/admin/users") {
+    return handleListUsers(req, res);
+  }
+
+  if (req.method === "POST" && pathname === "/v1/admin/users") {
+    return handleCreateUser(req, res);
+  }
+
+  const adminUserRolesMatch = pathname.match(/^\/v1\/admin\/users\/([^/]+)\/roles$/);
+  if (req.method === "POST" && adminUserRolesMatch) {
+    return handleUpdateUserRoles(req, res, adminUserRolesMatch[1]);
   }
 
   if (req.method === "POST" && pathname === "/v1/data-sources") {

--- a/app/src/services/adminUserService.js
+++ b/app/src/services/adminUserService.js
@@ -1,0 +1,201 @@
+const appDb = require("../lib/appDb");
+const authService = require("./authService");
+const roleService = require("./roleService");
+
+function success(body, statusCode = 200) {
+  return { ok: true, statusCode, body };
+}
+
+function failure(statusCode, body) {
+  return { ok: false, statusCode, body };
+}
+
+function publicUser(user, roles) {
+  return {
+    id: user.id,
+    email: user.email,
+    display_name: user.display_name,
+    is_active: user.is_active,
+    last_login_at: user.last_login_at,
+    created_at: user.created_at,
+    updated_at: user.updated_at,
+    roles: Array.isArray(roles) ? roles : []
+  };
+}
+
+async function listUsers() {
+  const result = await appDb.query(
+    `
+      SELECT
+        u.id,
+        u.email,
+        u.display_name,
+        u.is_active,
+        u.last_login_at,
+        u.created_at,
+        u.updated_at,
+        COALESCE(
+          (
+            SELECT array_agg(r.name ORDER BY r.name)
+            FROM user_roles ur
+            JOIN roles r ON r.id = ur.role_id
+            WHERE ur.user_id = u.id
+          ),
+          ARRAY[]::text[]
+        ) AS roles
+      FROM users u
+      ORDER BY lower(u.email)
+    `
+  );
+  return success({
+    items: result.rows.map((row) => publicUser(row, row.roles))
+  });
+}
+
+async function createUser({ email, password, displayName, roles, actorUserId }) {
+  const normalizedEmail = authService.normalizeEmail(email);
+  if (!normalizedEmail) {
+    return failure(400, { error: "bad_request", message: "email is not a valid address" });
+  }
+  if (!authService.validatePassword(password)) {
+    return failure(400, {
+      error: "bad_request",
+      message: `password must be ${authService.PASSWORD_MIN_LENGTH}-${authService.PASSWORD_MAX_LENGTH} characters`
+    });
+  }
+
+  let requestedRoleNames = null;
+  if (roles !== undefined && roles !== null) {
+    const parsed = roleService.uniqueRoleNames(roles);
+    if (parsed === null) {
+      return failure(400, { error: "bad_request", message: "roles must be an array of role names" });
+    }
+    requestedRoleNames = parsed;
+  }
+  const rolesToAssign = requestedRoleNames && requestedRoleNames.length > 0
+    ? requestedRoleNames
+    : [roleService.DEFAULT_ROLE];
+
+  const passwordHash = authService.hashPassword(password);
+  const trimmedDisplayName = typeof displayName === "string" && displayName.trim()
+    ? displayName.trim()
+    : null;
+
+  try {
+    const result = await appDb.withTransaction(async (client) => {
+      const userInsert = await client.query(
+        `
+          INSERT INTO users (email, password_hash, display_name)
+          VALUES ($1, $2, $3)
+          RETURNING id, email, display_name, is_active, last_login_at, created_at, updated_at
+        `,
+        [normalizedEmail, passwordHash, trimmedDisplayName]
+      );
+      const user = userInsert.rows[0];
+
+      await roleService.writeAuditEntry(client, {
+        actorUserId,
+        targetUserId: user.id,
+        action: "user.created",
+        details: { email: user.email }
+      });
+
+      const { assigned } = await roleService.assignRolesByName(client, {
+        userId: user.id,
+        roleNames: rolesToAssign,
+        actorUserId
+      });
+
+      return { user, roles: assigned };
+    });
+    return success(publicUser(result.user, result.roles), 201);
+  } catch (err) {
+    if (err && err.code === "23505") {
+      return failure(409, { error: "conflict", message: "a user with that email already exists" });
+    }
+    if (err && err.code === "unknown_role") {
+      return failure(400, {
+        error: "bad_request",
+        message: `unknown role(s): ${err.unknown.join(", ")}`
+      });
+    }
+    throw err;
+  }
+}
+
+async function updateUserRoles({ userId, assign, revoke, actorUserId }) {
+  const userResult = await appDb.query(
+    "SELECT id, email, display_name, is_active, last_login_at, created_at, updated_at FROM users WHERE id = $1",
+    [userId]
+  );
+  if (userResult.rowCount === 0) {
+    return failure(404, { error: "not_found", message: "user not found" });
+  }
+  const user = userResult.rows[0];
+
+  let assignNames = [];
+  let revokeNames = [];
+  if (assign !== undefined && assign !== null) {
+    const parsed = roleService.uniqueRoleNames(assign);
+    if (parsed === null) {
+      return failure(400, { error: "bad_request", message: "assign must be an array of role names" });
+    }
+    assignNames = parsed;
+  }
+  if (revoke !== undefined && revoke !== null) {
+    const parsed = roleService.uniqueRoleNames(revoke);
+    if (parsed === null) {
+      return failure(400, { error: "bad_request", message: "revoke must be an array of role names" });
+    }
+    revokeNames = parsed;
+  }
+  if (assignNames.length === 0 && revokeNames.length === 0) {
+    return failure(400, { error: "bad_request", message: "assign or revoke must contain at least one role" });
+  }
+
+  const overlap = assignNames.filter((name) => revokeNames.includes(name));
+  if (overlap.length > 0) {
+    return failure(400, {
+      error: "bad_request",
+      message: `cannot assign and revoke the same role(s): ${overlap.join(", ")}`
+    });
+  }
+
+  try {
+    return await appDb.withTransaction(async (client) => {
+      const assignResult = await roleService.assignRolesByName(client, {
+        userId: user.id,
+        roleNames: assignNames,
+        actorUserId
+      });
+      const revokeResult = await roleService.revokeRolesByName(client, {
+        userId: user.id,
+        roleNames: revokeNames,
+        actorUserId
+      });
+      const rolesAfter = await roleService.listRoleNamesForUser(user.id, client);
+      return success({
+        user: publicUser(user, rolesAfter),
+        assigned: assignResult.assigned,
+        revoked: revokeResult.revoked,
+        skipped_assign: assignResult.skipped,
+        skipped_revoke: revokeResult.skipped
+      });
+    });
+  } catch (err) {
+    if (err && err.code === "unknown_role") {
+      return failure(400, {
+        error: "bad_request",
+        message: `unknown role(s): ${err.unknown.join(", ")}`
+      });
+    }
+    throw err;
+  }
+}
+
+module.exports = {
+  listUsers,
+  createUser,
+  updateUserRoles,
+  publicUser
+};

--- a/app/src/services/roleService.js
+++ b/app/src/services/roleService.js
@@ -1,0 +1,217 @@
+const appDb = require("../lib/appDb");
+
+const DEFAULT_ROLE = "viewer";
+const SYSTEM_ROLE_NAMES = new Set(["admin", "analyst", "viewer"]);
+
+function normalizeRoleName(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim().toLowerCase();
+  return trimmed || null;
+}
+
+function uniqueRoleNames(values) {
+  if (!Array.isArray(values)) {
+    return null;
+  }
+  const seen = new Set();
+  const result = [];
+  for (const entry of values) {
+    const name = normalizeRoleName(entry);
+    if (!name) {
+      return null;
+    }
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    result.push(name);
+  }
+  return result;
+}
+
+async function listRoles() {
+  const result = await appDb.query(
+    "SELECT id, name, description, is_system, created_at FROM roles ORDER BY name"
+  );
+  return result.rows;
+}
+
+async function findRoleByName(name) {
+  const normalized = normalizeRoleName(name);
+  if (!normalized) {
+    return null;
+  }
+  const result = await appDb.query(
+    "SELECT id, name, description, is_system FROM roles WHERE lower(name) = $1",
+    [normalized]
+  );
+  return result.rows[0] || null;
+}
+
+async function findRolesByNames(names) {
+  if (!Array.isArray(names) || names.length === 0) {
+    return [];
+  }
+  const normalized = names
+    .map(normalizeRoleName)
+    .filter((value) => value !== null);
+  if (normalized.length === 0) {
+    return [];
+  }
+  const result = await appDb.query(
+    "SELECT id, name, description, is_system FROM roles WHERE lower(name) = ANY($1::text[])",
+    [normalized]
+  );
+  return result.rows;
+}
+
+async function listRolesForUser(userId, client = null) {
+  const exec = client || appDb;
+  const result = await exec.query(
+    `
+      SELECT r.id, r.name, r.description, r.is_system, ur.assigned_at
+      FROM user_roles ur
+      JOIN roles r ON r.id = ur.role_id
+      WHERE ur.user_id = $1
+      ORDER BY r.name
+    `,
+    [userId]
+  );
+  return result.rows;
+}
+
+async function listRoleNamesForUser(userId, client = null) {
+  const rows = await listRolesForUser(userId, client);
+  return rows.map((row) => row.name);
+}
+
+async function listPermissionNamesForUser(userId, client = null) {
+  const exec = client || appDb;
+  const result = await exec.query(
+    `
+      SELECT DISTINCT p.name
+      FROM user_roles ur
+      JOIN role_permissions rp ON rp.role_id = ur.role_id
+      JOIN permissions p ON p.id = rp.permission_id
+      WHERE ur.user_id = $1
+      ORDER BY p.name
+    `,
+    [userId]
+  );
+  return result.rows.map((row) => row.name);
+}
+
+async function writeAuditEntry(client, { actorUserId, targetUserId, action, details = {} }) {
+  await client.query(
+    `
+      INSERT INTO auth_audit_log (actor_user_id, target_user_id, action, details)
+      VALUES ($1, $2, $3, $4::jsonb)
+    `,
+    [actorUserId || null, targetUserId || null, action, JSON.stringify(details)]
+  );
+}
+
+async function assignRolesByName(client, { userId, roleNames, actorUserId }) {
+  const distinct = uniqueRoleNames(roleNames) || [];
+  if (distinct.length === 0) {
+    return { assigned: [], skipped: [] };
+  }
+  const rolesResult = await client.query(
+    "SELECT id, name FROM roles WHERE lower(name) = ANY($1::text[])",
+    [distinct]
+  );
+  const found = new Map(rolesResult.rows.map((row) => [row.name, row]));
+  const missing = distinct.filter((name) => !found.has(name));
+  if (missing.length > 0) {
+    const err = new Error(`unknown roles: ${missing.join(", ")}`);
+    err.code = "unknown_role";
+    err.unknown = missing;
+    throw err;
+  }
+
+  const assigned = [];
+  const skipped = [];
+  for (const name of distinct) {
+    const role = found.get(name);
+    const insert = await client.query(
+      `
+        INSERT INTO user_roles (user_id, role_id, assigned_by_user_id)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (user_id, role_id) DO NOTHING
+        RETURNING role_id
+      `,
+      [userId, role.id, actorUserId || null]
+    );
+    if (insert.rowCount > 0) {
+      assigned.push(role.name);
+      await writeAuditEntry(client, {
+        actorUserId,
+        targetUserId: userId,
+        action: "role.assigned",
+        details: { role: role.name }
+      });
+    } else {
+      skipped.push(role.name);
+    }
+  }
+  return { assigned, skipped };
+}
+
+async function revokeRolesByName(client, { userId, roleNames, actorUserId }) {
+  const distinct = uniqueRoleNames(roleNames) || [];
+  if (distinct.length === 0) {
+    return { revoked: [], skipped: [] };
+  }
+  const rolesResult = await client.query(
+    "SELECT id, name FROM roles WHERE lower(name) = ANY($1::text[])",
+    [distinct]
+  );
+  const found = new Map(rolesResult.rows.map((row) => [row.name, row]));
+  const missing = distinct.filter((name) => !found.has(name));
+  if (missing.length > 0) {
+    const err = new Error(`unknown roles: ${missing.join(", ")}`);
+    err.code = "unknown_role";
+    err.unknown = missing;
+    throw err;
+  }
+
+  const revoked = [];
+  const skipped = [];
+  for (const name of distinct) {
+    const role = found.get(name);
+    const del = await client.query(
+      "DELETE FROM user_roles WHERE user_id = $1 AND role_id = $2 RETURNING role_id",
+      [userId, role.id]
+    );
+    if (del.rowCount > 0) {
+      revoked.push(role.name);
+      await writeAuditEntry(client, {
+        actorUserId,
+        targetUserId: userId,
+        action: "role.revoked",
+        details: { role: role.name }
+      });
+    } else {
+      skipped.push(role.name);
+    }
+  }
+  return { revoked, skipped };
+}
+
+module.exports = {
+  DEFAULT_ROLE,
+  SYSTEM_ROLE_NAMES,
+  normalizeRoleName,
+  uniqueRoleNames,
+  listRoles,
+  findRoleByName,
+  findRolesByNames,
+  listRolesForUser,
+  listRoleNamesForUser,
+  listPermissionNamesForUser,
+  assignRolesByName,
+  revokeRolesByName,
+  writeAuditEntry
+};

--- a/app/test/adminUsersApi.test.js
+++ b/app/test/adminUsersApi.test.js
@@ -1,0 +1,564 @@
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+process.env.PORT = "0";
+process.env.AUTH_COOKIE_SECURE = "false";
+
+const appDb = require("../src/lib/appDb");
+const authService = require("../src/services/authService");
+
+const SYSTEM_ROLES = ["admin", "analyst", "viewer"];
+
+let server;
+let baseUrl;
+let users;
+let sessions;
+let roles;
+let userRoles;
+let auditLog;
+let userCounter;
+let sessionCounter;
+let roleCounter;
+let originalQuery;
+let originalWithTransaction;
+
+function uuid(prefix, counter) {
+  return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
+}
+
+function nextUserId() {
+  userCounter += 1;
+  return uuid("aaaa", userCounter);
+}
+
+function nextSessionId() {
+  sessionCounter += 1;
+  return uuid("bbbb", sessionCounter);
+}
+
+function nextRoleId() {
+  roleCounter += 1;
+  return uuid("cccc", roleCounter);
+}
+
+function normalizeSql(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function seedSystemRoles() {
+  for (const name of SYSTEM_ROLES) {
+    roles.set(name, {
+      id: nextRoleId(),
+      name,
+      description: `${name} role`,
+      is_system: true,
+      created_at: new Date().toISOString()
+    });
+  }
+}
+
+function seedUser({ email, password, displayName = null, isActive = true, roleNames = [] }) {
+  const row = {
+    id: nextUserId(),
+    email,
+    password_hash: authService.hashPassword(password),
+    display_name: displayName,
+    is_active: isActive,
+    last_login_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  };
+  users.set(row.id, row);
+  for (const name of roleNames) {
+    const role = roles.get(name);
+    assert.ok(role, `seed role ${name} must exist`);
+    userRoles.set(`${row.id}:${role.id}`, {
+      user_id: row.id,
+      role_id: role.id,
+      assigned_at: new Date().toISOString(),
+      assigned_by_user_id: null
+    });
+  }
+  return row;
+}
+
+function seedSession(userId, { expiresInMs = 60 * 60 * 1000 } = {}) {
+  const token = authService.generateSessionToken();
+  const tokenHash = authService.hashSessionToken(token);
+  const expiresAt = new Date(Date.now() + expiresInMs).toISOString();
+  const row = {
+    id: nextSessionId(),
+    user_id: userId,
+    token_hash: tokenHash,
+    user_agent: null,
+    ip_address: null,
+    created_at: new Date().toISOString(),
+    expires_at: expiresAt,
+    last_seen_at: new Date().toISOString(),
+    revoked_at: null
+  };
+  sessions.set(row.id, row);
+  return { token, sessionId: row.id, expiresAt };
+}
+
+function rolesForUser(userId) {
+  const names = [];
+  for (const link of userRoles.values()) {
+    if (link.user_id !== userId) continue;
+    for (const role of roles.values()) {
+      if (role.id === link.role_id) {
+        names.push(role.name);
+        break;
+      }
+    }
+  }
+  return names.sort();
+}
+
+function duplicateEmailError() {
+  const err = new Error("duplicate key value violates unique constraint");
+  err.code = "23505";
+  return err;
+}
+
+async function runQuery(sql, params = []) {
+  const normalized = normalizeSql(sql);
+
+  // --- authService.findActiveSession
+  if (normalized.startsWith(
+    "select s.id as session_id, s.expires_at, s.revoked_at, u.id, u.email, u.password_hash, u.display_name, u.is_active, u.last_login_at, u.created_at, u.updated_at from user_sessions s join users u on u.id = s.user_id where s.token_hash = $1"
+  )) {
+    const [tokenHash] = params;
+    const session = [...sessions.values()].find((entry) => entry.token_hash === tokenHash);
+    if (!session) return { rowCount: 0, rows: [] };
+    const user = users.get(session.user_id);
+    if (!user) return { rowCount: 0, rows: [] };
+    return {
+      rowCount: 1,
+      rows: [{
+        session_id: session.id,
+        expires_at: session.expires_at,
+        revoked_at: session.revoked_at,
+        id: user.id,
+        email: user.email,
+        password_hash: user.password_hash,
+        display_name: user.display_name,
+        is_active: user.is_active,
+        last_login_at: user.last_login_at,
+        created_at: user.created_at,
+        updated_at: user.updated_at
+      }]
+    };
+  }
+
+  // --- authService.touchSession
+  if (normalized.startsWith("update user_sessions set last_seen_at = now() where id = $1")) {
+    return { rowCount: 1, rows: [] };
+  }
+
+  // --- roleService.listRolesForUser
+  if (normalized.startsWith(
+    "select r.id, r.name, r.description, r.is_system, ur.assigned_at from user_roles ur join roles r on r.id = ur.role_id where ur.user_id = $1 order by r.name"
+  )) {
+    const [userId] = params;
+    const rows = [];
+    for (const link of userRoles.values()) {
+      if (link.user_id !== userId) continue;
+      for (const role of roles.values()) {
+        if (role.id === link.role_id) {
+          rows.push({
+            id: role.id,
+            name: role.name,
+            description: role.description,
+            is_system: role.is_system,
+            assigned_at: link.assigned_at
+          });
+          break;
+        }
+      }
+    }
+    rows.sort((a, b) => a.name.localeCompare(b.name));
+    return { rowCount: rows.length, rows };
+  }
+
+  // --- adminUserService.listUsers
+  if (normalized.startsWith(
+    "select u.id, u.email, u.display_name, u.is_active, u.last_login_at, u.created_at, u.updated_at, coalesce( ( select array_agg(r.name order by r.name) from user_roles ur join roles r on r.id = ur.role_id where ur.user_id = u.id ), array[]::text[] ) as roles from users u order by lower(u.email)"
+  )) {
+    const sorted = [...users.values()].sort((a, b) => a.email.localeCompare(b.email));
+    const rows = sorted.map((u) => ({
+      id: u.id,
+      email: u.email,
+      display_name: u.display_name,
+      is_active: u.is_active,
+      last_login_at: u.last_login_at,
+      created_at: u.created_at,
+      updated_at: u.updated_at,
+      roles: rolesForUser(u.id)
+    }));
+    return { rowCount: rows.length, rows };
+  }
+
+  // --- adminUserService.updateUserRoles user lookup
+  if (normalized.startsWith(
+    "select id, email, display_name, is_active, last_login_at, created_at, updated_at from users where id = $1"
+  )) {
+    const [id] = params;
+    const u = users.get(id);
+    return u
+      ? { rowCount: 1, rows: [{
+          id: u.id,
+          email: u.email,
+          display_name: u.display_name,
+          is_active: u.is_active,
+          last_login_at: u.last_login_at,
+          created_at: u.created_at,
+          updated_at: u.updated_at
+        }] }
+      : { rowCount: 0, rows: [] };
+  }
+
+  // --- adminUserService.createUser insert
+  if (normalized.startsWith("insert into users")) {
+    const [email, passwordHash, displayName] = params;
+    const dup = [...users.values()].some((u) => u.email.toLowerCase() === email.toLowerCase());
+    if (dup) {
+      throw duplicateEmailError();
+    }
+    const row = {
+      id: nextUserId(),
+      email,
+      password_hash: passwordHash,
+      display_name: displayName,
+      is_active: true,
+      last_login_at: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    };
+    users.set(row.id, row);
+    return {
+      rowCount: 1,
+      rows: [{
+        id: row.id,
+        email: row.email,
+        display_name: row.display_name,
+        is_active: row.is_active,
+        last_login_at: row.last_login_at,
+        created_at: row.created_at,
+        updated_at: row.updated_at
+      }]
+    };
+  }
+
+  // --- roleService.assignRolesByName / revokeRolesByName lookup
+  if (normalized.startsWith("select id, name from roles where lower(name) = any($1::text[])")) {
+    const [names] = params;
+    const rows = [];
+    for (const role of roles.values()) {
+      if (names.includes(role.name)) {
+        rows.push({ id: role.id, name: role.name });
+      }
+    }
+    return { rowCount: rows.length, rows };
+  }
+
+  // --- roleService.assignRolesByName insert
+  if (normalized.startsWith(
+    "insert into user_roles (user_id, role_id, assigned_by_user_id) values ($1, $2, $3) on conflict (user_id, role_id) do nothing returning role_id"
+  )) {
+    const [userId, roleId, actorUserId] = params;
+    const key = `${userId}:${roleId}`;
+    if (userRoles.has(key)) {
+      return { rowCount: 0, rows: [] };
+    }
+    userRoles.set(key, {
+      user_id: userId,
+      role_id: roleId,
+      assigned_at: new Date().toISOString(),
+      assigned_by_user_id: actorUserId
+    });
+    return { rowCount: 1, rows: [{ role_id: roleId }] };
+  }
+
+  // --- roleService.revokeRolesByName delete
+  if (normalized.startsWith("delete from user_roles where user_id = $1 and role_id = $2 returning role_id")) {
+    const [userId, roleId] = params;
+    const key = `${userId}:${roleId}`;
+    if (!userRoles.has(key)) {
+      return { rowCount: 0, rows: [] };
+    }
+    userRoles.delete(key);
+    return { rowCount: 1, rows: [{ role_id: roleId }] };
+  }
+
+  // --- roleService.writeAuditEntry
+  if (normalized.startsWith("insert into auth_audit_log")) {
+    const [actorUserId, targetUserId, action, detailsJson] = params;
+    auditLog.push({
+      actor_user_id: actorUserId,
+      target_user_id: targetUserId,
+      action,
+      details: JSON.parse(detailsJson),
+      created_at: new Date().toISOString()
+    });
+    return { rowCount: 1, rows: [] };
+  }
+
+  throw new Error(`Unexpected SQL in admin test stub: ${normalized}`);
+}
+
+async function api(method, path, body, { cookie } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (cookie) headers.Cookie = cookie;
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+  return { status: response.status, payload };
+}
+
+function cookieFor(token) {
+  return `rp_session=${encodeURIComponent(token)}`;
+}
+
+before(async () => {
+  originalQuery = appDb.query;
+  originalWithTransaction = appDb.withTransaction;
+  users = new Map();
+  sessions = new Map();
+  roles = new Map();
+  userRoles = new Map();
+  auditLog = [];
+  userCounter = 0;
+  sessionCounter = 0;
+  roleCounter = 0;
+
+  appDb.query = (sql, params = []) => runQuery(sql, params);
+  appDb.withTransaction = async (handler) => {
+    return handler({ query: (sql, params = []) => runQuery(sql, params) });
+  };
+
+  delete require.cache[require.resolve("../src/server")];
+  const { startServer } = require("../src/server");
+  server = await startServer();
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+beforeEach(() => {
+  users.clear();
+  sessions.clear();
+  roles.clear();
+  userRoles.clear();
+  auditLog.length = 0;
+  userCounter = 0;
+  sessionCounter = 0;
+  roleCounter = 0;
+  seedSystemRoles();
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  appDb.query = originalQuery;
+  appDb.withTransaction = originalWithTransaction;
+});
+
+test("GET /v1/admin/users requires auth and admin role", async () => {
+  const admin = seedUser({ email: "admin@example.com", password: "hunter22ok", roleNames: ["admin"] });
+  const viewerUser = seedUser({ email: "viewer@example.com", password: "hunter22ok", roleNames: ["viewer"] });
+
+  const noAuth = await api("GET", "/v1/admin/users");
+  assert.equal(noAuth.status, 401);
+
+  const viewerSession = seedSession(viewerUser.id);
+  const viewerAttempt = await api("GET", "/v1/admin/users", undefined, { cookie: cookieFor(viewerSession.token) });
+  assert.equal(viewerAttempt.status, 403);
+
+  const adminSession = seedSession(admin.id);
+  const allowed = await api("GET", "/v1/admin/users", undefined, { cookie: cookieFor(adminSession.token) });
+  assert.equal(allowed.status, 200);
+  assert.equal(allowed.payload.items.length, 2);
+  const sorted = [...allowed.payload.items].sort((a, b) => a.email.localeCompare(b.email));
+  assert.deepEqual(sorted.map((u) => u.email), ["admin@example.com", "viewer@example.com"]);
+  const adminItem = sorted.find((u) => u.email === "admin@example.com");
+  const viewerItem = sorted.find((u) => u.email === "viewer@example.com");
+  assert.deepEqual(adminItem.roles, ["admin"]);
+  assert.deepEqual(viewerItem.roles, ["viewer"]);
+});
+
+test("POST /v1/admin/users defaults to viewer role and writes audit log", async () => {
+  const admin = seedUser({ email: "root@example.com", password: "hunter22ok", roleNames: ["admin"] });
+  const session = seedSession(admin.id);
+  const cookie = cookieFor(session.token);
+
+  const created = await api("POST", "/v1/admin/users", {
+    email: "  New@Example.com ",
+    password: "hunter22ok",
+    display_name: "  Newbie  "
+  }, { cookie });
+
+  assert.equal(created.status, 201);
+  assert.equal(created.payload.email, "new@example.com");
+  assert.equal(created.payload.display_name, "Newbie");
+  assert.deepEqual(created.payload.roles, ["viewer"]);
+
+  const userCreated = auditLog.find((e) => e.action === "user.created" && e.target_user_id === created.payload.id);
+  assert.ok(userCreated);
+  assert.equal(userCreated.actor_user_id, admin.id);
+  const roleAssigned = auditLog.find((e) => e.action === "role.assigned"
+    && e.target_user_id === created.payload.id
+    && e.details.role === "viewer");
+  assert.ok(roleAssigned);
+});
+
+test("POST /v1/admin/users accepts explicit roles", async () => {
+  const admin = seedUser({ email: "root@example.com", password: "hunter22ok", roleNames: ["admin"] });
+  const cookie = cookieFor(seedSession(admin.id).token);
+
+  const created = await api("POST", "/v1/admin/users", {
+    email: "analyst@example.com",
+    password: "hunter22ok",
+    roles: ["ANALYST", "analyst", " analyst "]
+  }, { cookie });
+
+  assert.equal(created.status, 201);
+  assert.deepEqual(created.payload.roles, ["analyst"]);
+});
+
+test("POST /v1/admin/users rejects invalid input, duplicate email, and unknown roles", async () => {
+  const admin = seedUser({ email: "root@example.com", password: "hunter22ok", roleNames: ["admin"] });
+  const cookie = cookieFor(seedSession(admin.id).token);
+
+  const badEmail = await api("POST", "/v1/admin/users", {
+    email: "not-an-email",
+    password: "hunter22ok"
+  }, { cookie });
+  assert.equal(badEmail.status, 400);
+
+  const shortPassword = await api("POST", "/v1/admin/users", {
+    email: "x@y.com",
+    password: "short"
+  }, { cookie });
+  assert.equal(shortPassword.status, 400);
+
+  const created = await api("POST", "/v1/admin/users", {
+    email: "dup@example.com",
+    password: "hunter22ok"
+  }, { cookie });
+  assert.equal(created.status, 201);
+
+  const conflict = await api("POST", "/v1/admin/users", {
+    email: "DUP@example.com",
+    password: "hunter22ok"
+  }, { cookie });
+  assert.equal(conflict.status, 409);
+
+  const unknownRole = await api("POST", "/v1/admin/users", {
+    email: "ghost@example.com",
+    password: "hunter22ok",
+    roles: ["wizard"]
+  }, { cookie });
+  assert.equal(unknownRole.status, 400);
+
+  const rolesNotArray = await api("POST", "/v1/admin/users", {
+    email: "ghost@example.com",
+    password: "hunter22ok",
+    roles: "admin"
+  }, { cookie });
+  assert.equal(rolesNotArray.status, 400);
+});
+
+test("POST /v1/admin/users/{id}/roles assigns and revokes with audit and idempotence", async () => {
+  const admin = seedUser({ email: "root@example.com", password: "hunter22ok", roleNames: ["admin"] });
+  const target = seedUser({ email: "subject@example.com", password: "hunter22ok", roleNames: ["viewer"] });
+  const cookie = cookieFor(seedSession(admin.id).token);
+
+  const promote = await api("POST", `/v1/admin/users/${target.id}/roles`, {
+    assign: ["analyst"],
+    revoke: ["viewer"]
+  }, { cookie });
+  assert.equal(promote.status, 200);
+  assert.deepEqual(promote.payload.assigned, ["analyst"]);
+  assert.deepEqual(promote.payload.revoked, ["viewer"]);
+  assert.deepEqual(promote.payload.skipped_assign, []);
+  assert.deepEqual(promote.payload.skipped_revoke, []);
+  assert.deepEqual(promote.payload.user.roles, ["analyst"]);
+
+  const repeat = await api("POST", `/v1/admin/users/${target.id}/roles`, {
+    assign: ["analyst"],
+    revoke: ["viewer"]
+  }, { cookie });
+  assert.equal(repeat.status, 200);
+  assert.deepEqual(repeat.payload.assigned, []);
+  assert.deepEqual(repeat.payload.revoked, []);
+  assert.deepEqual(repeat.payload.skipped_assign, ["analyst"]);
+  assert.deepEqual(repeat.payload.skipped_revoke, ["viewer"]);
+  assert.deepEqual(repeat.payload.user.roles, ["analyst"]);
+
+  const auditAssigned = auditLog.filter((e) => e.action === "role.assigned" && e.target_user_id === target.id);
+  const auditRevoked = auditLog.filter((e) => e.action === "role.revoked" && e.target_user_id === target.id);
+  assert.equal(auditAssigned.length, 1);
+  assert.equal(auditAssigned[0].details.role, "analyst");
+  assert.equal(auditRevoked.length, 1);
+  assert.equal(auditRevoked[0].details.role, "viewer");
+});
+
+test("POST /v1/admin/users/{id}/roles validates input", async () => {
+  const admin = seedUser({ email: "root@example.com", password: "hunter22ok", roleNames: ["admin"] });
+  const target = seedUser({ email: "subject@example.com", password: "hunter22ok", roleNames: ["viewer"] });
+  const cookie = cookieFor(seedSession(admin.id).token);
+
+  const badId = await api("POST", "/v1/admin/users/not-a-uuid/roles", { assign: ["analyst"] }, { cookie });
+  assert.equal(badId.status, 400);
+
+  const unknownUser = await api(
+    "POST",
+    "/v1/admin/users/00000000-0000-4000-8000-aaaa99999999/roles",
+    { assign: ["analyst"] },
+    { cookie }
+  );
+  assert.equal(unknownUser.status, 404);
+
+  const empty = await api("POST", `/v1/admin/users/${target.id}/roles`, {}, { cookie });
+  assert.equal(empty.status, 400);
+
+  const overlap = await api("POST", `/v1/admin/users/${target.id}/roles`, {
+    assign: ["analyst"],
+    revoke: ["analyst"]
+  }, { cookie });
+  assert.equal(overlap.status, 400);
+
+  const unknownRole = await api("POST", `/v1/admin/users/${target.id}/roles`, {
+    assign: ["wizard"]
+  }, { cookie });
+  assert.equal(unknownRole.status, 400);
+});
+
+test("admin endpoints require admin role, not just authentication", async () => {
+  const analyst = seedUser({ email: "an@example.com", password: "hunter22ok", roleNames: ["analyst"] });
+  const target = seedUser({ email: "v@example.com", password: "hunter22ok", roleNames: ["viewer"] });
+  const cookie = cookieFor(seedSession(analyst.id).token);
+
+  const list = await api("GET", "/v1/admin/users", undefined, { cookie });
+  assert.equal(list.status, 403);
+
+  const create = await api("POST", "/v1/admin/users", {
+    email: "new@example.com",
+    password: "hunter22ok"
+  }, { cookie });
+  assert.equal(create.status, 403);
+
+  const update = await api("POST", `/v1/admin/users/${target.id}/roles`, {
+    assign: ["analyst"]
+  }, { cookie });
+  assert.equal(update.status, 403);
+});

--- a/app/test/authRolesMigration.test.js
+++ b/app/test/authRolesMigration.test.js
@@ -1,0 +1,50 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+test("0015_auth_roles_and_permissions migration creates role tables, audit log, and seeds system roles", () => {
+  const migrationPath = path.resolve(__dirname, "../../db/migrations/0015_auth_roles_and_permissions.sql");
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS roles/i);
+  assert.match(sql, /is_system BOOLEAN NOT NULL DEFAULT FALSE/i);
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS idx_roles_name_lower/i);
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS permissions/i);
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS idx_permissions_name/i);
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS role_permissions/i);
+  assert.match(sql, /PRIMARY KEY \(role_id, permission_id\)/i);
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS user_roles/i);
+  assert.match(sql, /assigned_by_user_id UUID REFERENCES users\(id\) ON DELETE SET NULL/i);
+  assert.match(sql, /PRIMARY KEY \(user_id, role_id\)/i);
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS auth_audit_log/i);
+  assert.match(sql, /actor_user_id UUID REFERENCES users\(id\) ON DELETE SET NULL/i);
+  assert.match(sql, /target_user_id UUID REFERENCES users\(id\) ON DELETE SET NULL/i);
+  assert.match(sql, /action TEXT NOT NULL/i);
+  assert.match(sql, /details JSONB NOT NULL DEFAULT '\{\}'::jsonb/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_auth_audit_log_target_user/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_auth_audit_log_action/i);
+
+  // Seed system roles
+  assert.match(sql, /INSERT INTO roles \(name, description, is_system\)/i);
+  assert.match(sql, /\('admin',/i);
+  assert.match(sql, /\('analyst',/i);
+  assert.match(sql, /\('viewer',/i);
+
+  // Permission seeds we will rely on in AUTH-003
+  for (const perm of [
+    "users.read",
+    "users.write",
+    "roles.assign",
+    "data_sources.read",
+    "data_sources.write",
+    "query.run",
+    "saved_queries.write"
+  ]) {
+    assert.match(sql, new RegExp(`'${perm.replace(/\./g, "\\.")}'`, "i"));
+  }
+});

--- a/db/migrations/0015_auth_roles_and_permissions.sql
+++ b/db/migrations/0015_auth_roles_and_permissions.sql
@@ -1,0 +1,129 @@
+-- AUTH-002: User and role data model.
+-- Adds roles, optional permissions, role-membership, and an audit log used to
+-- record user/role lifecycle events. Seeds the three system roles
+-- (admin, analyst, viewer) and an initial permission grid that AUTH-003 will
+-- consume for endpoint-level enforcement.
+
+CREATE TABLE IF NOT EXISTS roles (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name TEXT NOT NULL,
+  description TEXT,
+  is_system BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_roles_name_lower
+  ON roles (lower(name));
+
+CREATE TABLE IF NOT EXISTS permissions (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name TEXT NOT NULL,
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_permissions_name
+  ON permissions (name);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+  role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  permission_id UUID NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+  PRIMARY KEY (role_id, permission_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  assigned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  assigned_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  PRIMARY KEY (user_id, role_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_roles_role_id
+  ON user_roles (role_id);
+
+CREATE TABLE IF NOT EXISTS auth_audit_log (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  actor_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  target_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  action TEXT NOT NULL,
+  details JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_audit_log_target_user
+  ON auth_audit_log (target_user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_auth_audit_log_action
+  ON auth_audit_log (action, created_at DESC);
+
+-- Seed system roles. ON CONFLICT against the unique lower(name) index keeps
+-- this migration idempotent without depending on a UNIQUE constraint name.
+INSERT INTO roles (name, description, is_system)
+VALUES
+  ('admin', 'Full administrative access', TRUE),
+  ('analyst', 'Can query and manage saved content', TRUE),
+  ('viewer', 'Read-only access', TRUE)
+ON CONFLICT DO NOTHING;
+
+-- Seed an initial permission grid. AUTH-003 will map endpoints to these names.
+INSERT INTO permissions (name, description)
+VALUES
+  ('users.read', 'List and view users'),
+  ('users.write', 'Create, update, and delete users'),
+  ('roles.assign', 'Assign or revoke roles for users'),
+  ('data_sources.read', 'View data sources and schemas'),
+  ('data_sources.write', 'Create, update, delete data sources and import schemas'),
+  ('semantic.write', 'Edit semantic entities, metrics, and join policies'),
+  ('rag.write', 'Edit RAG notes and trigger reindex'),
+  ('providers.read', 'View LLM provider configuration'),
+  ('providers.write', 'Manage LLM provider configuration and routing'),
+  ('query.run', 'Run queries against data sources'),
+  ('saved_queries.read', 'View saved queries'),
+  ('saved_queries.write', 'Create, update, delete saved queries'),
+  ('observability.read', 'View observability metrics and release gates'),
+  ('observability.write', 'Submit release-gate reports and benchmark commands')
+ON CONFLICT DO NOTHING;
+
+-- Wire role -> permissions. Admin gets everything; analyst gets read + run +
+-- saved query authoring + semantic/rag edit; viewer gets read-only.
+WITH all_permissions AS (
+  SELECT id FROM permissions
+), admin_role AS (
+  SELECT id FROM roles WHERE lower(name) = 'admin'
+)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT admin_role.id, all_permissions.id FROM admin_role, all_permissions
+ON CONFLICT DO NOTHING;
+
+WITH analyst_role AS (
+  SELECT id FROM roles WHERE lower(name) = 'analyst'
+), analyst_permissions AS (
+  SELECT id FROM permissions WHERE name IN (
+    'data_sources.read',
+    'semantic.write',
+    'rag.write',
+    'providers.read',
+    'query.run',
+    'saved_queries.read',
+    'saved_queries.write',
+    'observability.read'
+  )
+)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT analyst_role.id, analyst_permissions.id FROM analyst_role, analyst_permissions
+ON CONFLICT DO NOTHING;
+
+WITH viewer_role AS (
+  SELECT id FROM roles WHERE lower(name) = 'viewer'
+), viewer_permissions AS (
+  SELECT id FROM permissions WHERE name IN (
+    'data_sources.read',
+    'providers.read',
+    'saved_queries.read',
+    'observability.read'
+  )
+)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT viewer_role.id, viewer_permissions.id FROM viewer_role, viewer_permissions
+ON CONFLICT DO NOTHING;

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -64,6 +64,84 @@ paths:
                 $ref: "#/components/schemas/AuthMeResponse"
         "401":
           description: No active session
+  /v1/admin/users:
+    get:
+      tags: [Admin]
+      summary: List users and their roles
+      description: Requires the `admin` role. Returns 401 when unauthenticated, 403 when authenticated without `admin`.
+      responses:
+        "200":
+          description: User list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserListResponse"
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+    post:
+      tags: [Admin]
+      summary: Create a user
+      description: |
+        Requires the `admin` role. If `roles` is omitted, the new user is
+        assigned the default role (`viewer`). The action is recorded in the
+        auth audit log.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAdminUserRequest"
+      responses:
+        "201":
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUser"
+        "400":
+          description: Invalid input
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+        "409":
+          description: Email already exists
+  /v1/admin/users/{userId}/roles:
+    post:
+      tags: [Admin]
+      summary: Assign and/or revoke roles for a user
+      description: |
+        Requires the `admin` role. `assign` and `revoke` are independent — pass
+        either or both. Each effective change is written to the auth audit log.
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateUserRolesRequest"
+      responses:
+        "200":
+          description: Updated user with applied changes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateUserRolesResponse"
+        "400":
+          description: Invalid input
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
   /v1/query/prompts/history:
     get:
       tags: [Query]
@@ -1075,6 +1153,91 @@ components:
           type: string
           format: date-time
           nullable: true
+    AdminUser:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        is_active:
+          type: boolean
+        last_login_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        roles:
+          type: array
+          items:
+            type: string
+    AdminUserListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdminUser"
+    CreateAdminUserRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        roles:
+          type: array
+          description: Role names to assign. Defaults to `viewer` when omitted or empty.
+          items:
+            type: string
+    UpdateUserRolesRequest:
+      type: object
+      description: At least one of `assign` or `revoke` must be a non-empty array.
+      properties:
+        assign:
+          type: array
+          items:
+            type: string
+        revoke:
+          type: array
+          items:
+            type: string
+    UpdateUserRolesResponse:
+      type: object
+      properties:
+        user:
+          $ref: "#/components/schemas/AdminUser"
+        assigned:
+          type: array
+          items:
+            type: string
+        revoked:
+          type: array
+          items:
+            type: string
+        skipped_assign:
+          type: array
+          description: Roles already held by the user — assignment was a no-op.
+          items:
+            type: string
+        skipped_revoke:
+          type: array
+          description: Roles not currently held — revocation was a no-op.
+          items:
+            type: string
     PromptHistoryItem:
       type: object
       properties:

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -145,6 +145,190 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List users and their roles
+         * @description Requires the `admin` role. Returns 401 when unauthenticated, 403 when authenticated without `admin`.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description User list */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminUserListResponse"];
+                    };
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create a user
+         * @description Requires the `admin` role. If `roles` is omitted, the new user is
+         *     assigned the default role (`viewer`). The action is recorded in the
+         *     auth audit log.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateAdminUserRequest"];
+                };
+            };
+            responses: {
+                /** @description User created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminUser"];
+                    };
+                };
+                /** @description Invalid input */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Email already exists */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/users/{userId}/roles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Assign and/or revoke roles for a user
+         * @description Requires the `admin` role. `assign` and `revoke` are independent — pass
+         *     either or both. Each effective change is written to the auth audit log.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateUserRolesRequest"];
+                };
+            };
+            responses: {
+                /** @description Updated user with applied changes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UpdateUserRolesResponse"];
+                    };
+                };
+                /** @description Invalid input */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description User not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/query/prompts/history": {
         parameters: {
             query?: never;
@@ -1858,6 +2042,44 @@ export interface components {
             user?: components["schemas"]["AuthUser"];
             /** Format: date-time */
             expires_at?: string | null;
+        };
+        AdminUser: {
+            id?: string;
+            email?: string;
+            display_name?: string | null;
+            is_active?: boolean;
+            /** Format: date-time */
+            last_login_at?: string | null;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            updated_at?: string;
+            roles?: string[];
+        };
+        AdminUserListResponse: {
+            items?: components["schemas"]["AdminUser"][];
+        };
+        CreateAdminUserRequest: {
+            /** Format: email */
+            email: string;
+            password: string;
+            display_name?: string | null;
+            /** @description Role names to assign. Defaults to `viewer` when omitted or empty. */
+            roles?: string[];
+        };
+        /** @description At least one of `assign` or `revoke` must be a non-empty array. */
+        UpdateUserRolesRequest: {
+            assign?: string[];
+            revoke?: string[];
+        };
+        UpdateUserRolesResponse: {
+            user?: components["schemas"]["AdminUser"];
+            assigned?: string[];
+            revoked?: string[];
+            /** @description Roles already held by the user — assignment was a no-op. */
+            skipped_assign?: string[];
+            /** @description Roles not currently held — revocation was a no-op. */
+            skipped_revoke?: string[];
         };
         PromptHistoryItem: {
             id: string;

--- a/scripts/create-user.js
+++ b/scripts/create-user.js
@@ -1,19 +1,27 @@
 #!/usr/bin/env node
-// AUTH-001: bootstrap a user account (e.g. the initial admin) without going
-// through the (not-yet-built) admin API. Reads DATABASE_URL from the env.
+// AUTH-001/AUTH-002: bootstrap a user account (e.g. the initial admin) without
+// going through the admin API. Reads DATABASE_URL from the env.
 //
 // Usage:
 //   node scripts/create-user.js --email alice@example.com --password 'hunter22ok'
 //   node scripts/create-user.js --email alice@example.com --password '...' --display-name 'Alice' --update-if-exists
+//   node scripts/create-user.js --email alice@example.com --password '...' --role analyst --role viewer
+//
+// Default role behavior:
+//   * If --role is supplied (one or more), exactly those roles are assigned.
+//   * If --role is not supplied AND no users exist yet, the new user gets the
+//     `admin` role so the system has an initial administrator.
+//   * Otherwise the new user gets the standard default role (`viewer`).
 
 const path = require("path");
 const readline = require("readline");
 
 const authService = require(path.resolve(__dirname, "../app/src/services/authService"));
+const roleService = require(path.resolve(__dirname, "../app/src/services/roleService"));
 const appDb = require(path.resolve(__dirname, "../app/src/lib/appDb"));
 
 function parseArgs(argv) {
-  const opts = { updateIfExists: false };
+  const opts = { updateIfExists: false, roles: [] };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     switch (arg) {
@@ -25,6 +33,9 @@ function parseArgs(argv) {
         break;
       case "--display-name":
         opts.displayName = argv[++i];
+        break;
+      case "--role":
+        opts.roles.push(argv[++i]);
         break;
       case "--update-if-exists":
         opts.updateIfExists = true;
@@ -46,6 +57,9 @@ function printHelp() {
     + `  --email <email>        Email address (required)\n`
     + `  --password <pw>        Password. If omitted, you'll be prompted.\n`
     + `  --display-name <name>  Optional display name\n`
+    + `  --role <name>          Role to assign. May be passed multiple times.\n`
+    + `                         Defaults to 'admin' if no users exist yet,\n`
+    + `                         otherwise 'viewer'.\n`
     + `  --update-if-exists     Reset password and display name if the user already exists\n`
     + `  -h, --help             Show this help\n`);
 }
@@ -116,15 +130,70 @@ async function main() {
       `,
       [passwordHash, opts.displayName || null, existing.id]
     );
+    if (opts.roles.length > 0) {
+      await applyRoles({ userId: existing.id, roleNames: opts.roles });
+    }
     process.stdout.write(`Updated user ${result.rows[0].email} (id=${result.rows[0].id}).\n`);
-  } else {
-    const created = await authService.createUser({
-      email: normalized,
-      password: opts.password,
-      displayName: opts.displayName
-    });
-    process.stdout.write(`Created user ${created.email} (id=${created.id}).\n`);
+    return;
   }
+
+  const userCountResult = await appDb.query("SELECT COUNT(*)::int AS count FROM users");
+  const hasExistingUsers = userCountResult.rows[0].count > 0;
+  const rolesToAssign = opts.roles.length > 0
+    ? opts.roles
+    : [hasExistingUsers ? roleService.DEFAULT_ROLE : "admin"];
+
+  const created = await appDb.withTransaction(async (client) => {
+    const insert = await client.query(
+      `
+        INSERT INTO users (email, password_hash, display_name)
+        VALUES ($1, $2, $3)
+        RETURNING id, email
+      `,
+      [normalized, authService.hashPassword(opts.password), opts.displayName || null]
+    );
+    const user = insert.rows[0];
+    await roleService.writeAuditEntry(client, {
+      actorUserId: null,
+      targetUserId: user.id,
+      action: "user.created",
+      details: { email: user.email, via: "scripts/create-user.js" }
+    });
+    await roleService.assignRolesByName(client, {
+      userId: user.id,
+      roleNames: rolesToAssign,
+      actorUserId: null
+    });
+    return user;
+  });
+
+  process.stdout.write(`Created user ${created.email} (id=${created.id}) with roles: ${rolesToAssign.join(", ")}.\n`);
+}
+
+async function applyRoles({ userId, roleNames }) {
+  const currentRoles = await roleService.listRoleNamesForUser(userId);
+  const desired = roleService.uniqueRoleNames(roleNames) || [];
+  const toAssign = desired.filter((name) => !currentRoles.includes(name));
+  const toRevoke = currentRoles.filter((name) => !desired.includes(name));
+  if (toAssign.length === 0 && toRevoke.length === 0) {
+    return;
+  }
+  await appDb.withTransaction(async (client) => {
+    if (toAssign.length > 0) {
+      await roleService.assignRolesByName(client, {
+        userId,
+        roleNames: toAssign,
+        actorUserId: null
+      });
+    }
+    if (toRevoke.length > 0) {
+      await roleService.revokeRolesByName(client, {
+        userId,
+        roleNames: toRevoke,
+        actorUserId: null
+      });
+    }
+  });
 }
 
 main()


### PR DESCRIPTION
Closes #22 — AUTH-002. Builds on #112 (AUTH-001).

## Summary
- Adds the role / permission / membership / audit data model on top of AUTH-001's `users` and `user_sessions` tables.
- Seeds the three system roles (`admin`, `analyst`, `viewer`) and a permission grid that AUTH-003 (#23) will map endpoints to.
- First admin-only endpoints: `GET /v1/admin/users`, `POST /v1/admin/users`, `POST /v1/admin/users/{id}/roles`.
- New `authGate.requireRole(...)` helper that wraps the session lookup + role check, returning 401 / 403. AUTH-003 will generalize this into per-route middleware.
- CLI bootstrap: `scripts/create-user.js` learned `--role` and now defaults to `admin` for the very first user, `viewer` thereafter — so a fresh deployment doesn't get stuck without an administrator.

## Acceptance criteria
- [x] Roles can be assigned/revoked for a user — `POST /v1/admin/users/{id}/roles` with `assign` / `revoke` arrays.
- [x] User-role membership is persisted and auditable — `auth_audit_log` records `user.created`, `role.assigned`, and `role.revoked` events with actor/target user IDs and details.
- [x] Default role assignment on user creation is enforced — `viewer` is applied when the caller omits `roles` (or the role array is empty); the bootstrap script applies `admin` for the very first user.

## Schema (`db/migrations/0015_auth_roles_and_permissions.sql`)
- `roles (id, name, description, is_system, created_at)`, unique `lower(name)` index.
- `permissions (id, name, description, created_at)`, unique `name`.
- `role_permissions (role_id, permission_id)` composite PK.
- `user_roles (user_id, role_id, assigned_at, assigned_by_user_id)` composite PK.
- `auth_audit_log (id, actor_user_id, target_user_id, action, details JSONB, created_at)` with indexes on `(target_user_id, created_at DESC)` and `(action, created_at DESC)`.
- Idempotent seeds for the three system roles and the AUTH-003 permission grid (admin = all, analyst = read + run + saved-query/semantic/rag write, viewer = read-only).

## Test plan
- [x] `DATABASE_URL=postgresql://test:test@localhost:5432/test npm test` → 69/69 passing (8 new tests cover migration shape, 401 vs 403, default role on create, explicit-role create, validation/duplicate/unknown-role, transactional assign/revoke with audit, idempotent re-runs, analyst-cannot-administer).
- [x] `npm --prefix frontend run lint` clean.
- [x] `npm --prefix frontend run build` clean.
- [ ] Manual: `npm run migrate`, `node scripts/create-user.js --email admin@example.com --password '<8+ chars>'` (now auto-promotes to admin), log in, then `curl --cookie 'rp_session=…' http://localhost:8080/v1/admin/users`.

## Out of scope (follow-ups)
- Endpoint-level enforcement for non-admin routes is **not** wired yet — that is AUTH-003 (#23). Today only the three admin endpoints check roles.
- Frontend permission-aware UI and admin screens land in AUTH-004 (#24) / AUTH-014 (#34).