### PR TITLE
feat(auth): AUTH-004 frontend route guards and permission-aware UI

### DIFF
--- a/app/src/routes/auth.js
+++ b/app/src/routes/auth.js
@@ -5,6 +5,7 @@ const {
   readSessionToken
 } = require("../lib/sessionCookie");
 const authService = require("../services/authService");
+const roleService = require("../services/roleService");
 
 function clientAddress(req) {
   const forwarded = req.headers["x-forwarded-for"];
@@ -17,7 +18,7 @@ function clientAddress(req) {
   return req.socket && req.socket.remoteAddress ? req.socket.remoteAddress : null;
 }
 
-function publicUser(user) {
+function publicUser(user, { roles = [], permissions = [] } = {}) {
   if (!user) {
     return null;
   }
@@ -27,8 +28,18 @@ function publicUser(user) {
     display_name: user.display_name,
     is_active: user.is_active,
     last_login_at: user.last_login_at,
-    created_at: user.created_at
+    created_at: user.created_at,
+    roles,
+    permissions
   };
+}
+
+async function loadAuthorization(userId) {
+  const [roles, permissions] = await Promise.all([
+    roleService.listRoleNamesForUser(userId),
+    roleService.listPermissionNamesForUser(userId)
+  ]);
+  return { roles, permissions };
 }
 
 async function handleLogin(req, res) {
@@ -51,9 +62,10 @@ async function handleLogin(req, res) {
     return json(res, 401, { error: "invalid_credentials" });
   }
 
+  const authz = await loadAuthorization(result.user.id);
   res.setHeader("Set-Cookie", buildSessionCookie(result.token, result.expiresAt));
   return json(res, 200, {
-    user: publicUser(result.user),
+    user: publicUser(result.user, authz),
     expires_at: result.expiresAt
   });
 }
@@ -78,8 +90,9 @@ async function handleMe(req, res) {
     return json(res, 401, { error: "unauthenticated" });
   }
   authService.touchSession(session.sessionId).catch(() => {});
+  const authz = await loadAuthorization(session.user.id);
   return json(res, 200, {
-    user: publicUser(session.user),
+    user: publicUser(session.user, authz),
     expires_at: session.expiresAt
   });
 }

--- a/app/test/authApi.test.js
+++ b/app/test/authApi.test.js
@@ -14,6 +14,7 @@ let users;
 let sessions;
 let userIdCounter;
 let sessionIdCounter;
+let userRoleAssignments;
 let originalQuery;
 
 function uuid(prefix, counter) {
@@ -34,7 +35,13 @@ function normalizeSql(sql) {
   return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
-function seedUser({ email, password, displayName = null, isActive = true }) {
+const ROLE_PERMISSIONS = {
+  admin: ["users.read", "users.write", "data_sources.read", "data_sources.write"],
+  analyst: ["data_sources.read", "saved_queries.read", "saved_queries.write", "query.run"],
+  viewer: ["data_sources.read", "saved_queries.read"]
+};
+
+function seedUser({ email, password, displayName = null, isActive = true, roles = [] }) {
   const row = {
     id: nextUserId(),
     email,
@@ -46,6 +53,7 @@ function seedUser({ email, password, displayName = null, isActive = true }) {
     updated_at: new Date().toISOString()
   };
   users.set(row.id, row);
+  userRoleAssignments.set(row.id, [...roles]);
   return row;
 }
 
@@ -89,6 +97,7 @@ before(async () => {
   originalQuery = appDb.query;
   users = new Map();
   sessions = new Map();
+  userRoleAssignments = new Map();
   userIdCounter = 0;
   sessionIdCounter = 0;
 
@@ -202,6 +211,36 @@ before(async () => {
       return { rowCount: user ? 1 : 0, rows: [] };
     }
 
+    if (normalized.startsWith(
+      "select r.id, r.name, r.description, r.is_system, ur.assigned_at from user_roles ur join roles r on r.id = ur.role_id where ur.user_id = $1 order by r.name"
+    )) {
+      const [userId] = params;
+      const assigned = userRoleAssignments.get(userId) || [];
+      const rows = [...assigned].sort().map((name, idx) => ({
+        id: `00000000-0000-4000-8000-cccc${String(idx + 1).padStart(8, "0")}`,
+        name,
+        description: `${name} role`,
+        is_system: true,
+        assigned_at: new Date().toISOString()
+      }));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith(
+      "select distinct p.name from user_roles ur join role_permissions rp on rp.role_id = ur.role_id join permissions p on p.id = rp.permission_id where ur.user_id = $1 order by p.name"
+    )) {
+      const [userId] = params;
+      const assigned = userRoleAssignments.get(userId) || [];
+      const out = new Set();
+      for (const role of assigned) {
+        for (const perm of ROLE_PERMISSIONS[role] || []) {
+          out.add(perm);
+        }
+      }
+      const sorted = [...out].sort();
+      return { rowCount: sorted.length, rows: sorted.map((name) => ({ name })) };
+    }
+
     throw new Error(`Unexpected SQL in auth test stub: ${normalized}`);
   };
 
@@ -214,6 +253,7 @@ before(async () => {
 beforeEach(() => {
   users.clear();
   sessions.clear();
+  userRoleAssignments.clear();
   userIdCounter = 0;
   sessionIdCounter = 0;
 });
@@ -226,7 +266,12 @@ after(async () => {
 });
 
 test("login → me → logout happy path", async () => {
-  seedUser({ email: "alice@example.com", password: "hunter22ok", displayName: "Alice" });
+  seedUser({
+    email: "alice@example.com",
+    password: "hunter22ok",
+    displayName: "Alice",
+    roles: ["analyst"]
+  });
 
   const login = await api("POST", "/v1/auth/login", {
     email: "Alice@Example.com",
@@ -235,6 +280,11 @@ test("login → me → logout happy path", async () => {
   assert.equal(login.status, 200);
   assert.equal(login.payload.user.email, "alice@example.com");
   assert.equal(login.payload.user.display_name, "Alice");
+  assert.deepEqual(login.payload.user.roles, ["analyst"]);
+  assert.deepEqual(
+    login.payload.user.permissions,
+    ["data_sources.read", "query.run", "saved_queries.read", "saved_queries.write"]
+  );
   assert.ok(login.payload.expires_at);
   assert.ok(login.setCookie);
   assert.match(login.setCookie, /HttpOnly/);
@@ -247,6 +297,11 @@ test("login → me → logout happy path", async () => {
   const me = await api("GET", "/v1/auth/me", undefined, { cookie });
   assert.equal(me.status, 200);
   assert.equal(me.payload.user.email, "alice@example.com");
+  assert.deepEqual(me.payload.user.roles, ["analyst"]);
+  assert.deepEqual(
+    me.payload.user.permissions,
+    ["data_sources.read", "query.run", "saved_queries.read", "saved_queries.write"]
+  );
 
   const logout = await api("POST", "/v1/auth/logout", undefined, { cookie });
   assert.equal(logout.status, 200);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1144,6 +1144,16 @@ components:
         created_at:
           type: string
           format: date-time
+        roles:
+          type: array
+          description: System role names the user holds (e.g. `admin`, `analyst`, `viewer`).
+          items:
+            type: string
+        permissions:
+          type: array
+          description: Effective permission names granted by the user's roles. The frontend uses this list to gate UI affordances.
+          items:
+            type: string
     AuthMeResponse:
       type: object
       properties:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,13 +34,48 @@ function App() {
           >
             <Route path="/" element={<Dashboard />} />
             <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/queries" element={<SavedQueries />} />
-            <Route path="/query" element={<QueryWorkspace />} />
-            <Route path="/data-sources" element={<DataSources />} />
-            <Route path="/schema" element={<SchemaExplorer />} />
+            <Route
+              path="/queries"
+              element={(
+                <RequireAuth permission="saved_queries.read">
+                  <SavedQueries />
+                </RequireAuth>
+              )}
+            />
+            <Route
+              path="/query"
+              element={(
+                <RequireAuth permission="query.run">
+                  <QueryWorkspace />
+                </RequireAuth>
+              )}
+            />
+            <Route
+              path="/data-sources"
+              element={(
+                <RequireAuth permission="data_sources.read">
+                  <DataSources />
+                </RequireAuth>
+              )}
+            />
+            <Route
+              path="/schema"
+              element={(
+                <RequireAuth permission="data_sources.read">
+                  <SchemaExplorer />
+                </RequireAuth>
+              )}
+            />
             <Route path="/observability" element={<Navigate to="/dashboard?tab=observability" replace />} />
             <Route path="/release-gates" element={<Navigate to="/dashboard?tab=release-gates" replace />} />
-            <Route path="/llm-providers" element={<LLMProviders />} />
+            <Route
+              path="/llm-providers"
+              element={(
+                <RequireAuth permission="providers.read">
+                  <LLMProviders />
+                </RequireAuth>
+              )}
+            />
             <Route path="/settings" element={<Settings />} />
             <Route path="/folders" element={<ComingSoon />} />
             <Route path="/favorites" element={<ComingSoon />} />

--- a/frontend/src/components/Auth/Forbidden.tsx
+++ b/frontend/src/components/Auth/Forbidden.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom';
+import { ShieldAlert } from 'lucide-react';
+
+interface ForbiddenProps {
+    reason?: string;
+}
+
+export function Forbidden({ reason }: ForbiddenProps) {
+    return (
+        <div className="flex flex-col items-center justify-center h-full min-h-[60vh] px-6 text-center">
+            <ShieldAlert className="text-oxblood mb-4" size={48} />
+            <h1 className="text-xl font-semibold text-gray-800 mb-2">You don't have access to this page</h1>
+            <p className="text-sm text-gray-600 max-w-md mb-4">
+                {reason || 'Your account does not have the required permissions.'} Contact an administrator if you believe this is a mistake.
+            </p>
+            <Link
+                to="/dashboard"
+                className="text-sm font-medium text-oxblood hover:underline"
+            >
+                Back to dashboard
+            </Link>
+        </div>
+    );
+}

--- a/frontend/src/components/Auth/RequireAuth.tsx
+++ b/frontend/src/components/Auth/RequireAuth.tsx
@@ -1,13 +1,16 @@
 import type { ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
+import { Forbidden } from './Forbidden';
 import { useAuth } from '../../hooks/useAuth';
 
 interface RequireAuthProps {
     children?: ReactNode;
+    permission?: string;
+    role?: string;
 }
 
-export function RequireAuth({ children }: RequireAuthProps) {
-    const { status } = useAuth();
+export function RequireAuth({ children, permission, role }: RequireAuthProps) {
+    const { status, hasPermission, hasRole } = useAuth();
     const location = useLocation();
 
     if (status === 'unknown') {
@@ -21,6 +24,13 @@ export function RequireAuth({ children }: RequireAuthProps) {
     if (status === 'unauthenticated') {
         const redirectTo = `${location.pathname}${location.search}${location.hash}`;
         return <Navigate to="/login" replace state={{ from: redirectTo }} />;
+    }
+
+    if (role && !hasRole(role)) {
+        return <Forbidden reason={`This page requires the ${role} role.`} />;
+    }
+    if (permission && !hasPermission(permission)) {
+        return <Forbidden reason={`This page requires the ${permission} permission.`} />;
     }
 
     return <>{children}</>;

--- a/frontend/src/components/DataSources/RagNotesDialog.tsx
+++ b/frontend/src/components/DataSources/RagNotesDialog.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { FileText, Loader2, Pencil, Plus, Trash2, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { client } from '../../lib/api/client';
+import { useAuth } from '../../hooks/useAuth';
 import type { components } from '../../lib/api/types';
 
 type RagNote = components['schemas']['RagNoteResponse'];
@@ -19,6 +20,8 @@ export const RagNotesDialog: React.FC<RagNotesDialogProps> = ({
     dataSourceName,
     onClose
 }) => {
+    const { hasPermission } = useAuth();
+    const canEdit = hasPermission('rag.write');
     const [items, setItems] = useState<RagNote[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [loadError, setLoadError] = useState<string | null>(null);
@@ -173,13 +176,15 @@ export const RagNotesDialog: React.FC<RagNotesDialogProps> = ({
                     <div className="border-r border-gray-200 p-4 min-h-0 overflow-y-auto">
                         <div className="flex items-center justify-between mb-3">
                             <h3 className="font-medium text-gray-900">Notes</h3>
-                            <button
-                                onClick={resetForm}
-                                className="inline-flex items-center gap-1 text-sm px-2 py-1 rounded bg-oxblood/5 text-oxblood-deep hover:bg-oxblood/10"
-                            >
-                                <Plus size={14} />
-                                New
-                            </button>
+                            {canEdit && (
+                                <button
+                                    onClick={resetForm}
+                                    className="inline-flex items-center gap-1 text-sm px-2 py-1 rounded bg-oxblood/5 text-oxblood-deep hover:bg-oxblood/10"
+                                >
+                                    <Plus size={14} />
+                                    New
+                                </button>
+                            )}
                         </div>
 
                         {isLoading ? (
@@ -211,22 +216,24 @@ export const RagNotesDialog: React.FC<RagNotesDialogProps> = ({
                                                     {note.content}
                                                 </p>
                                             </div>
-                                            <div className="flex items-center gap-1 shrink-0">
-                                                <button
-                                                    onClick={() => handleEdit(note)}
-                                                    className="text-gray-500 hover:text-oxblood"
-                                                    title="Edit note"
-                                                >
-                                                    <Pencil size={14} />
-                                                </button>
-                                                <button
-                                                    onClick={() => void handleDelete(note)}
-                                                    className="text-gray-500 hover:text-red-600"
-                                                    title="Delete note"
-                                                >
-                                                    <Trash2 size={14} />
-                                                </button>
-                                            </div>
+                                            {canEdit && (
+                                                <div className="flex items-center gap-1 shrink-0">
+                                                    <button
+                                                        onClick={() => handleEdit(note)}
+                                                        className="text-gray-500 hover:text-oxblood"
+                                                        title="Edit note"
+                                                    >
+                                                        <Pencil size={14} />
+                                                    </button>
+                                                    <button
+                                                        onClick={() => void handleDelete(note)}
+                                                        className="text-gray-500 hover:text-red-600"
+                                                        title="Delete note"
+                                                    >
+                                                        <Trash2 size={14} />
+                                                    </button>
+                                                </div>
+                                            )}
                                         </div>
                                     </div>
                                 ))}
@@ -235,42 +242,54 @@ export const RagNotesDialog: React.FC<RagNotesDialogProps> = ({
                     </div>
 
                     <div className="p-4 min-h-0 overflow-y-auto">
-                        <h3 className="font-medium text-gray-900 mb-3">
-                            {editingId ? 'Edit note' : 'Create note'}
-                        </h3>
+                        {canEdit ? (
+                            <>
+                                <h3 className="font-medium text-gray-900 mb-3">
+                                    {editingId ? 'Edit note' : 'Create note'}
+                                </h3>
 
-                        <form id="rag-notes-form" onSubmit={handleSave} className="flex flex-col gap-3 h-full">
-                            <div className="flex-1">
-                                <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
-                                <input
-                                    type="text"
-                                    maxLength={200}
-                                    value={title}
-                                    onChange={(e) => setTitle(e.target.value)}
-                                    placeholder="e.g. Revenue policy assumptions"
-                                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
-                                />
-                            </div>
+                                <form id="rag-notes-form" onSubmit={handleSave} className="flex flex-col gap-3 h-full">
+                                    <div className="flex-1">
+                                        <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+                                        <input
+                                            type="text"
+                                            maxLength={200}
+                                            value={title}
+                                            onChange={(e) => setTitle(e.target.value)}
+                                            placeholder="e.g. Revenue policy assumptions"
+                                            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                                        />
+                                    </div>
 
-                            <div className="flex-1 flex flex-col">
-                                <label className="block text-sm font-medium text-gray-700 mb-1">Content</label>
-                                <textarea
-                                    value={content}
-                                    onChange={(e) => setContent(e.target.value)}
-                                    maxLength={20000}
-                                    placeholder="Plain text instructions and constraints for the assistant."
-                                    className="w-full min-h-[240px] rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
-                                />
-                                <p className="text-xs text-gray-500 mt-2">
-                                    Reindexing runs automatically after create, update, or delete.
-                                </p>
+                                    <div className="flex-1 flex flex-col">
+                                        <label className="block text-sm font-medium text-gray-700 mb-1">Content</label>
+                                        <textarea
+                                            value={content}
+                                            onChange={(e) => setContent(e.target.value)}
+                                            maxLength={20000}
+                                            placeholder="Plain text instructions and constraints for the assistant."
+                                            className="w-full min-h-[240px] rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                                        />
+                                        <p className="text-xs text-gray-500 mt-2">
+                                            Reindexing runs automatically after create, update, or delete.
+                                        </p>
+                                    </div>
+                                </form>
+                            </>
+                        ) : (
+                            <div className="h-full flex flex-col items-center justify-center text-center text-sm text-gray-500 gap-2">
+                                <FileText className="opacity-30" size={28} />
+                                <p>You don't have permission to edit RAG notes.</p>
+                                <p className="text-xs">Ask an administrator to grant the <code>rag.write</code> permission.</p>
                             </div>
-                        </form>
+                        )}
                     </div>
                 </div>
 
                 <div className="border-t p-4 flex items-center justify-between bg-gray-50">
-                    <p className="text-xs text-gray-500">Buttons stay anchored while content scrolls.</p>
+                    <p className="text-xs text-gray-500">
+                        {canEdit ? 'Buttons stay anchored while content scrolls.' : 'Read-only view.'}
+                    </p>
                     <div className="flex items-center gap-2">
                         <button
                             type="button"
@@ -280,7 +299,7 @@ export const RagNotesDialog: React.FC<RagNotesDialogProps> = ({
                         >
                             Close
                         </button>
-                        {editingId ? (
+                        {canEdit && editingId ? (
                             <button
                                 type="button"
                                 onClick={resetForm}
@@ -290,14 +309,16 @@ export const RagNotesDialog: React.FC<RagNotesDialogProps> = ({
                                 Cancel edit
                             </button>
                         ) : null}
-                        <button
-                            form="rag-notes-form"
-                            type="submit"
-                            disabled={isSaving}
-                            className="px-3 py-2 text-sm bg-oxblood text-white rounded hover:bg-oxblood-deep disabled:opacity-60"
-                        >
-                            {isSaving ? 'Saving...' : editingId ? 'Update note' : 'Create note'}
-                        </button>
+                        {canEdit && (
+                            <button
+                                form="rag-notes-form"
+                                type="submit"
+                                disabled={isSaving}
+                                className="px-3 py-2 text-sm bg-oxblood text-white rounded hover:bg-oxblood-deep disabled:opacity-60"
+                            >
+                                {isSaving ? 'Saving...' : editingId ? 'Update note' : 'Create note'}
+                            </button>
+                        )}
                     </div>
                 </div>
             </div>

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -16,20 +16,29 @@ import {
     FolderClosed,
 } from 'lucide-react';
 import { useDataSource } from '../../hooks/useDataSource';
+import { useAuth } from '../../hooks/useAuth';
 import { WorkspaceActionsProvider } from '../../contexts/WorkspaceActionsContext';
 import { useWorkspaceActions } from '../../contexts/useWorkspaceActions';
 import appLogo from '../../assets/report-pilot.png';
 
-const PRIMARY_NAV = [
+type NavEntry = {
+    path: string;
+    label: string;
+    icon: typeof Home;
+    stub?: boolean;
+    permission?: string;
+};
+
+const PRIMARY_NAV: NavEntry[] = [
     { path: '/dashboard', label: 'Home', icon: Home },
-    { path: '/queries', label: 'Queries', icon: Terminal },
-    { path: '/data-sources', label: 'Datasets', icon: Database },
+    { path: '/queries', label: 'Queries', icon: Terminal, permission: 'saved_queries.read' },
+    { path: '/data-sources', label: 'Datasets', icon: Database, permission: 'data_sources.read' },
     { path: '/folders', label: 'Folders', icon: FolderClosed, stub: true },
     { path: '/favorites', label: 'Favorites', icon: Star, stub: true },
     { path: '/recent', label: 'Recent', icon: History, stub: true },
 ];
 
-const FOOTER_NAV = [
+const FOOTER_NAV: NavEntry[] = [
     { path: '/docs', label: 'Documentation', icon: BookOpen, stub: true },
     { path: '/settings', label: 'Settings', icon: SettingsIcon },
 ];
@@ -159,16 +168,24 @@ function HeaderInner() {
 
 function AppShellInner() {
     const navigate = useNavigate();
+    const { hasPermission } = useAuth();
+    const canRunQueries = hasPermission('query.run');
+
     const NewQueryButton = useMemo(() => (
         <button
             type="button"
             onClick={() => navigate('/query')}
-            className="flex w-full items-center justify-center gap-2 rounded bg-oxblood py-2 text-sm font-medium text-white transition-colors hover:bg-oxblood-soft"
+            disabled={!canRunQueries}
+            title={canRunQueries ? undefined : 'Requires the query.run permission'}
+            className="flex w-full items-center justify-center gap-2 rounded bg-oxblood py-2 text-sm font-medium text-white transition-colors hover:bg-oxblood-soft disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-oxblood"
         >
             <Plus size={16} />
             New Query
         </button>
-    ), [navigate]);
+    ), [canRunQueries, navigate]);
+
+    const primaryNav = PRIMARY_NAV.filter((item) => !item.permission || hasPermission(item.permission));
+    const footerNav = FOOTER_NAV.filter((item) => !item.permission || hasPermission(item.permission));
 
     return (
         <div className="flex h-screen w-screen overflow-hidden">
@@ -186,13 +203,13 @@ function AppShellInner() {
                 <div className="mb-6 px-4">{NewQueryButton}</div>
 
                 <nav className="flex-1 space-y-1 overflow-y-auto px-2">
-                    {PRIMARY_NAV.map((item) => (
+                    {primaryNav.map((item) => (
                         <NavItem key={item.path} to={item.path} label={item.label} Icon={item.icon} stub={item.stub} />
                     ))}
                 </nav>
 
                 <div className="mt-auto space-y-1 border-t border-white/5 px-2 pt-3">
-                    {FOOTER_NAV.map((item) => (
+                    {footerNav.map((item) => (
                         <NavItem key={item.path} to={item.path} label={item.label} Icon={item.icon} stub={item.stub} />
                     ))}
                 </div>

--- a/frontend/src/components/Schema/SchemaObjectList.tsx
+++ b/frontend/src/components/Schema/SchemaObjectList.tsx
@@ -4,6 +4,7 @@ import type { components } from '../../lib/api/types';
 import { SemanticEditorDialog } from '../../components/Semantic/SemanticEditorDialog';
 import { client } from '../../lib/api/client';
 import { toast } from 'sonner';
+import { useAuth } from '../../hooks/useAuth';
 
 type SchemaObject = components['schemas']['SchemaObject'];
 
@@ -14,6 +15,8 @@ interface SchemaObjectListProps {
 }
 
 export const SchemaObjectList: React.FC<SchemaObjectListProps> = ({ objects, filter, dataSourceId }) => {
+    const { hasPermission } = useAuth();
+    const canEditSemantic = hasPermission('semantic.write');
     const [selectedObject, setSelectedObject] = useState<SchemaObject | null>(null);
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [localObjects, setLocalObjects] = useState<SchemaObject[]>(objects);
@@ -116,22 +119,32 @@ export const SchemaObjectList: React.FC<SchemaObjectListProps> = ({ objects, fil
                                 </td>
                                 <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                                     <div className="flex items-center justify-end gap-3">
-                                        <button
-                                            onClick={() => handleToggleIgnored(obj)}
-                                            disabled={pendingIds.has(obj.id)}
-                                            className={`disabled:opacity-50 ${obj.is_ignored ? 'text-red-600 hover:text-red-700' : 'text-gray-500 hover:text-oxblood'}`}
-                                            title={obj.is_ignored ? 'Hidden from queries (click to enable)' : 'Visible to queries (click to hide)'}
-                                            aria-label={obj.is_ignored ? `Enable ${obj.schema_name}.${obj.object_name}` : `Hide ${obj.schema_name}.${obj.object_name}`}
-                                        >
-                                            {obj.is_ignored ? <EyeOff size={16} /> : <Eye size={16} />}
-                                        </button>
-                                        <button
-                                            onClick={() => handleEnrich(obj)}
-                                            className="text-oxblood hover:text-oxblood-deep flex items-center gap-1"
-                                        >
-                                            <Sparkles size={14} />
-                                            Enrich
-                                        </button>
+                                        {canEditSemantic ? (
+                                            <>
+                                                <button
+                                                    onClick={() => handleToggleIgnored(obj)}
+                                                    disabled={pendingIds.has(obj.id)}
+                                                    className={`disabled:opacity-50 ${obj.is_ignored ? 'text-red-600 hover:text-red-700' : 'text-gray-500 hover:text-oxblood'}`}
+                                                    title={obj.is_ignored ? 'Hidden from queries (click to enable)' : 'Visible to queries (click to hide)'}
+                                                    aria-label={obj.is_ignored ? `Enable ${obj.schema_name}.${obj.object_name}` : `Hide ${obj.schema_name}.${obj.object_name}`}
+                                                >
+                                                    {obj.is_ignored ? <EyeOff size={16} /> : <Eye size={16} />}
+                                                </button>
+                                                <button
+                                                    onClick={() => handleEnrich(obj)}
+                                                    className="text-oxblood hover:text-oxblood-deep flex items-center gap-1"
+                                                >
+                                                    <Sparkles size={14} />
+                                                    Enrich
+                                                </button>
+                                            </>
+                                        ) : (
+                                            obj.is_ignored ? (
+                                                <span className="inline-flex items-center gap-1 text-xs text-red-500" title="Hidden from queries">
+                                                    <EyeOff size={14} /> Hidden
+                                                </span>
+                                            ) : null
+                                        )}
                                     </div>
                                 </td>
                             </tr>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -54,9 +54,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
     }, []);
 
+    const roles = useMemo(() => user?.roles ?? [], [user]);
+    const permissions = useMemo(() => user?.permissions ?? [], [user]);
+
+    const hasRole = useCallback(
+        (role: string) => roles.includes(role),
+        [roles],
+    );
+    const hasPermission = useCallback(
+        (permission: string) => permissions.includes(permission),
+        [permissions],
+    );
+
     const value = useMemo(
-        () => ({ status, user, expiresAt, login, logout, refresh }),
-        [status, user, expiresAt, login, logout, refresh],
+        () => ({
+            status,
+            user,
+            expiresAt,
+            roles,
+            permissions,
+            hasRole,
+            hasPermission,
+            login,
+            logout,
+            refresh,
+        }),
+        [status, user, expiresAt, roles, permissions, hasRole, hasPermission, login, logout, refresh],
     );
 
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/contexts/authContextValue.ts
+++ b/frontend/src/contexts/authContextValue.ts
@@ -9,6 +9,10 @@ export interface AuthContextValue {
     status: AuthStatus;
     user: AuthUser | null;
     expiresAt: string | null;
+    roles: string[];
+    permissions: string[];
+    hasRole: (role: string) => boolean;
+    hasPermission: (permission: string) => boolean;
     login: (email: string, password: string) => Promise<{ ok: true } | { ok: false; message: string }>;
     logout: () => Promise<void>;
     refresh: () => Promise<void>;

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -2037,6 +2037,10 @@ export interface components {
             last_login_at?: string | null;
             /** Format: date-time */
             created_at?: string;
+            /** @description System role names the user holds (e.g. `admin`, `analyst`, `viewer`). */
+            roles?: string[];
+            /** @description Effective permission names granted by the user's roles. The frontend uses this list to gate UI affordances. */
+            permissions?: string[];
         };
         AuthMeResponse: {
             user?: components["schemas"]["AuthUser"];

--- a/frontend/src/pages/DataSources.tsx
+++ b/frontend/src/pages/DataSources.tsx
@@ -6,11 +6,15 @@ import { client } from '../lib/api/client';
 import { readSqlFile } from '../lib/readSqlFile';
 import { AddDataSourceDialog } from '../components/DataSources/AddDataSourceDialog';
 import { RagNotesDialog } from '../components/DataSources/RagNotesDialog';
+import { useAuth } from '../hooks/useAuth';
 import type { components } from '../lib/api/types';
 
 type DataSource = components['schemas']['DataSourceListResponse']['items'][number];
 
 export const DataSources: React.FC = () => {
+    const { hasPermission } = useAuth();
+    const canManage = hasPermission('data_sources.write');
+    const canReindex = hasPermission('rag.write');
     const [dataSources, setDataSources] = useState<DataSource[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
@@ -190,13 +194,15 @@ export const DataSources: React.FC = () => {
                     <h1 className="text-2xl font-bold text-gray-900">Data Sources</h1>
                     <p className="text-gray-500 mt-1">Manage database connections and configurations.</p>
                 </div>
-                <button
-                    onClick={() => setIsAddDialogOpen(true)}
-                    className="flex items-center gap-2 bg-oxblood text-white px-4 py-2 rounded-md hover:bg-oxblood-deep transition"
-                >
-                    <Plus size={18} />
-                    Add Data Source
-                </button>
+                {canManage && (
+                    <button
+                        onClick={() => setIsAddDialogOpen(true)}
+                        className="flex items-center gap-2 bg-oxblood text-white px-4 py-2 rounded-md hover:bg-oxblood-deep transition"
+                    >
+                        <Plus size={18} />
+                        Add Data Source
+                    </button>
+                )}
             </div>
 
             <div className="bg-white rounded-lg shadow border border-gray-200 flex-1 overflow-hidden flex flex-col">
@@ -220,13 +226,19 @@ export const DataSources: React.FC = () => {
                         <div className="flex flex-col items-center justify-center h-64 text-gray-500">
                             <Database size={48} className="mb-4 opacity-20" />
                             <p className="text-lg font-medium">No data sources found</p>
-                            <p className="text-sm">Add your first database connection to get started.</p>
-                            <button
-                                onClick={() => setIsAddDialogOpen(true)}
-                                className="mt-4 text-oxblood hover:underline"
-                            >
-                                Add Data Source
-                            </button>
+                            <p className="text-sm">
+                                {canManage
+                                    ? 'Add your first database connection to get started.'
+                                    : 'No data sources are available to you yet.'}
+                            </p>
+                            {canManage && (
+                                <button
+                                    onClick={() => setIsAddDialogOpen(true)}
+                                    className="mt-4 text-oxblood hover:underline"
+                                >
+                                    Add Data Source
+                                </button>
+                            )}
                         </div>
                     ) : (
                         dataSources.map((ds) => (
@@ -251,52 +263,58 @@ export const DataSources: React.FC = () => {
                                     {ds.created_at ? format(new Date(ds.created_at), 'MMM d, yyyy') : '-'}
                                 </div>
                                 <div className="col-span-2 flex items-center justify-end gap-2">
-                                    <button
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            handleIntrospect(ds);
-                                        }}
-                                        disabled={introspectingIds.has(ds.id)}
-                                        className="text-gray-500 hover:text-oxblood disabled:opacity-50 disabled:cursor-not-allowed"
-                                        title="Introspect Schema"
-                                    >
-                                        <RefreshCw size={16} className={introspectingIds.has(ds.id) ? 'animate-spin text-oxblood' : ''} />
-                                    </button>
-                                    <button
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            handleImportSchema(ds.id);
-                                        }}
-                                        disabled={importingIds.has(ds.id)}
-                                        className="text-gray-500 hover:text-green-600 disabled:opacity-50 disabled:cursor-not-allowed"
-                                        title="Import Schema (DDL file)"
-                                    >
-                                        <Upload size={16} className={importingIds.has(ds.id) ? 'animate-pulse text-green-500' : ''} />
-                                    </button>
-                                    <button
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            handleReindex(ds.id, ds.name);
-                                        }}
-                                        className="text-gray-500 hover:text-purple-600"
-                                        title="Reindex RAG Documents"
-                                    >
-                                        <Sparkles size={16} />
-                                    </button>
+                                    {canManage && (
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleIntrospect(ds);
+                                            }}
+                                            disabled={introspectingIds.has(ds.id)}
+                                            className="text-gray-500 hover:text-oxblood disabled:opacity-50 disabled:cursor-not-allowed"
+                                            title="Introspect Schema"
+                                        >
+                                            <RefreshCw size={16} className={introspectingIds.has(ds.id) ? 'animate-spin text-oxblood' : ''} />
+                                        </button>
+                                    )}
+                                    {canManage && (
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleImportSchema(ds.id);
+                                            }}
+                                            disabled={importingIds.has(ds.id)}
+                                            className="text-gray-500 hover:text-green-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                                            title="Import Schema (DDL file)"
+                                        >
+                                            <Upload size={16} className={importingIds.has(ds.id) ? 'animate-pulse text-green-500' : ''} />
+                                        </button>
+                                    )}
+                                    {canReindex && (
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleReindex(ds.id, ds.name);
+                                            }}
+                                            className="text-gray-500 hover:text-purple-600"
+                                            title="Reindex RAG Documents"
+                                        >
+                                            <Sparkles size={16} />
+                                        </button>
+                                    )}
                                     <button
                                         onClick={(e) => {
                                             e.stopPropagation();
                                             setRagNotesSource(ds);
                                         }}
                                         className="text-xs px-2 py-0.5 rounded bg-indigo-50 text-indigo-700 hover:bg-indigo-100"
-                                        title="Manage RAG Notes"
+                                        title="RAG Notes"
                                     >
                                         <span className="inline-flex items-center gap-1">
                                             <FileText size={12} />
                                             RAG Notes
                                         </span>
                                     </button>
-                                    {deleteConfirmId === ds.id ? (
+                                    {canManage && (deleteConfirmId === ds.id ? (
                                         <span className="flex items-center gap-1">
                                             <button
                                                 onClick={(e) => {
@@ -328,7 +346,7 @@ export const DataSources: React.FC = () => {
                                         >
                                             <Trash2 size={16} />
                                         </button>
-                                    )}
+                                    ))}
                                 </div>
                             </div>
                         ))

--- a/frontend/src/pages/LLMProviders.tsx
+++ b/frontend/src/pages/LLMProviders.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import { client } from '../lib/api/client';
 import { AddProviderDialog } from '../components/Providers/AddProviderDialog';
 import { EditProviderApiKeyDialog } from '../components/Providers/EditProviderApiKeyDialog';
+import { useAuth } from '../hooks/useAuth';
 
 interface LlmProvider {
     id: string;
@@ -32,6 +33,8 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 };
 
 export const LLMProviders: React.FC = () => {
+    const { hasPermission } = useAuth();
+    const canManage = hasPermission('providers.write');
     const [providers, setProviders] = useState<LlmProvider[]>([]);
     const [healthMap, setHealthMap] = useState<Record<string, ProviderHealth>>({});
     const [isLoading, setIsLoading] = useState(true);
@@ -131,13 +134,15 @@ export const LLMProviders: React.FC = () => {
                     <h1 className="text-2xl font-bold text-gray-900">LLM Providers</h1>
                     <p className="text-gray-500 mt-1">Manage AI model providers and API configurations.</p>
                 </div>
-                <button
-                    onClick={() => setIsAddDialogOpen(true)}
-                    className="flex items-center gap-2 bg-oxblood text-white px-4 py-2 rounded-md hover:bg-oxblood-deep transition"
-                >
-                    <Plus size={18} />
-                    Add Provider
-                </button>
+                {canManage && (
+                    <button
+                        onClick={() => setIsAddDialogOpen(true)}
+                        className="flex items-center gap-2 bg-oxblood text-white px-4 py-2 rounded-md hover:bg-oxblood-deep transition"
+                    >
+                        <Plus size={18} />
+                        Add Provider
+                    </button>
+                )}
             </div>
 
             <div className="bg-white rounded-lg shadow border border-gray-200 flex-1 overflow-hidden flex flex-col">
@@ -162,13 +167,19 @@ export const LLMProviders: React.FC = () => {
                         <div className="flex flex-col items-center justify-center h-64 text-gray-500">
                             <Server size={48} className="mb-4 opacity-20" />
                             <p className="text-lg font-medium">No providers configured</p>
-                            <p className="text-sm">Add your first LLM provider to get started.</p>
-                            <button
-                                onClick={() => setIsAddDialogOpen(true)}
-                                className="mt-4 text-oxblood hover:underline"
-                            >
-                                Add Provider
-                            </button>
+                            <p className="text-sm">
+                                {canManage
+                                    ? 'Add your first LLM provider to get started.'
+                                    : 'Ask an administrator to configure an LLM provider.'}
+                            </p>
+                            {canManage && (
+                                <button
+                                    onClick={() => setIsAddDialogOpen(true)}
+                                    className="mt-4 text-oxblood hover:underline"
+                                >
+                                    Add Provider
+                                </button>
+                            )}
                         </div>
                     ) : (
                         providers.map((p) => (
@@ -201,27 +212,31 @@ export const LLMProviders: React.FC = () => {
                                     {p.created_at ? format(new Date(p.created_at), 'MMM d, yyyy') : '-'}
                                 </div>
                                 <div className="col-span-2 flex items-center justify-end gap-2">
-                                    <button
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            setApiKeyDialogProvider(p);
-                                        }}
-                                        className="text-gray-500 hover:text-oxblood"
-                                        title="Edit API key"
-                                    >
-                                        <Key size={16} />
-                                    </button>
-                                    <button
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            handleToggleEnabled(p);
-                                        }}
-                                        disabled={togglingIds.has(p.id)}
-                                        className={`text-gray-500 disabled:opacity-50 disabled:cursor-not-allowed ${p.enabled ? 'hover:text-red-600' : 'hover:text-green-600'}`}
-                                        title={p.enabled ? 'Disable provider' : 'Enable provider'}
-                                    >
-                                        {p.enabled ? <PowerOff size={16} /> : <Power size={16} />}
-                                    </button>
+                                    {canManage && (
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                setApiKeyDialogProvider(p);
+                                            }}
+                                            className="text-gray-500 hover:text-oxblood"
+                                            title="Edit API key"
+                                        >
+                                            <Key size={16} />
+                                        </button>
+                                    )}
+                                    {canManage && (
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleToggleEnabled(p);
+                                            }}
+                                            disabled={togglingIds.has(p.id)}
+                                            className={`text-gray-500 disabled:opacity-50 disabled:cursor-not-allowed ${p.enabled ? 'hover:text-red-600' : 'hover:text-green-600'}`}
+                                            title={p.enabled ? 'Disable provider' : 'Enable provider'}
+                                        >
+                                            {p.enabled ? <PowerOff size={16} /> : <Power size={16} />}
+                                        </button>
+                                    )}
                                 </div>
                             </div>
                         ))

--- a/frontend/src/pages/SavedQueries.tsx
+++ b/frontend/src/pages/SavedQueries.tsx
@@ -16,6 +16,7 @@ import {
     Trash2,
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { useAuth } from '../hooks/useAuth';
 import { useDataSource } from '../hooks/useDataSource';
 import { useSavedQueries } from '../hooks/useSavedQueries';
 import { SaveQueryDialog, type SaveQueryDialogValues } from '../components/Query/SaveQueryDialog';
@@ -33,6 +34,8 @@ function formatDate(value: string) {
 
 export const SavedQueries = () => {
     const navigate = useNavigate();
+    const { hasPermission } = useAuth();
+    const canWriteSavedQueries = hasPermission('saved_queries.write');
     const { dataSources, selectedDataSourceId } = useDataSource();
     const {
         savedQueries,
@@ -362,33 +365,35 @@ export const SavedQueries = () => {
                                 <div className="flex h-10 w-10 items-center justify-center rounded border border-outline-variant bg-amber-accent/20">
                                     <span className="font-mono text-sm font-bold text-on-primary-fixed">SQL</span>
                                 </div>
-                                <div className="flex gap-1">
-                                    <button
-                                        type="button"
-                                        onClick={() => void handleDuplicate(selectedQuery)}
-                                        disabled={pendingId === selectedQuery.id}
-                                        className="rounded border border-transparent p-1.5 text-slate-500 hover:border-outline-variant hover:bg-surface-container-low hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
-                                        title="Duplicate"
-                                    >
-                                        {pendingId === selectedQuery.id ? <Loader2 size={16} className="animate-spin" /> : <Copy size={16} />}
-                                    </button>
-                                    <button
-                                        type="button"
-                                        onClick={() => setEditing(selectedQuery)}
-                                        className="rounded border border-transparent p-1.5 text-slate-500 hover:border-outline-variant hover:bg-surface-container-low hover:text-on-surface"
-                                        title="Edit metadata"
-                                    >
-                                        <Pencil size={16} />
-                                    </button>
-                                    <button
-                                        type="button"
-                                        onClick={() => setConfirmDeleteId(selectedQuery.id)}
-                                        className="rounded border border-transparent p-1.5 text-slate-500 hover:border-red-200 hover:bg-red-50 hover:text-red-600"
-                                        title="Delete"
-                                    >
-                                        <Trash2 size={16} />
-                                    </button>
-                                </div>
+                                {canWriteSavedQueries && (
+                                    <div className="flex gap-1">
+                                        <button
+                                            type="button"
+                                            onClick={() => void handleDuplicate(selectedQuery)}
+                                            disabled={pendingId === selectedQuery.id}
+                                            className="rounded border border-transparent p-1.5 text-slate-500 hover:border-outline-variant hover:bg-surface-container-low hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
+                                            title="Duplicate"
+                                        >
+                                            {pendingId === selectedQuery.id ? <Loader2 size={16} className="animate-spin" /> : <Copy size={16} />}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => setEditing(selectedQuery)}
+                                            className="rounded border border-transparent p-1.5 text-slate-500 hover:border-outline-variant hover:bg-surface-container-low hover:text-on-surface"
+                                            title="Edit metadata"
+                                        >
+                                            <Pencil size={16} />
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => setConfirmDeleteId(selectedQuery.id)}
+                                            className="rounded border border-transparent p-1.5 text-slate-500 hover:border-red-200 hover:bg-red-50 hover:text-red-600"
+                                            title="Delete"
+                                        >
+                                            <Trash2 size={16} />
+                                        </button>
+                                    </div>
+                                )}
                             </div>
                             <h2 className="mb-2 text-lg font-semibold leading-tight text-on-surface">{selectedQuery.name}</h2>
                             {selectedQuery.description && (

--- a/frontend/src/pages/SchemaExplorer.tsx
+++ b/frontend/src/pages/SchemaExplorer.tsx
@@ -3,12 +3,15 @@ import { Database, Search, RefreshCw, Layers, Link as LinkIcon } from 'lucide-re
 import { client } from '../lib/api/client';
 import { SchemaObjectList } from '../components/Schema/SchemaObjectList';
 import { JoinPolicyDialog } from '../components/Semantic/JoinPolicyDialog';
+import { useAuth } from '../hooks/useAuth';
 import type { components } from '../lib/api/types';
 
 type DataSource = components['schemas']['DataSourceListResponse']['items'][number];
 type SchemaObject = components['schemas']['SchemaObject'];
 
 export const SchemaExplorer: React.FC = () => {
+    const { hasPermission } = useAuth();
+    const canEditSemantic = hasPermission('semantic.write');
     const [dataSources, setDataSources] = useState<DataSource[]>([]);
     const [selectedDataSourceId, setSelectedDataSourceId] = useState<string>('');
     const [schemaObjects, setSchemaObjects] = useState<SchemaObject[]>([]);
@@ -74,14 +77,16 @@ export const SchemaExplorer: React.FC = () => {
                     <h1 className="text-2xl font-bold text-gray-900">Schema Explorer</h1>
                     <p className="text-gray-500 mt-1">Browse tables and views in your data sources.</p>
                 </div>
-                <button
-                    onClick={() => setIsJoinDialogOpen(true)}
-                    className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-oxblood"
-                    disabled={!selectedDataSourceId}
-                >
-                    <LinkIcon className="-ml-1 mr-2 h-4 w-4" aria-hidden="true" />
-                    Join Policies
-                </button>
+                {canEditSemantic && (
+                    <button
+                        onClick={() => setIsJoinDialogOpen(true)}
+                        className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-oxblood"
+                        disabled={!selectedDataSourceId}
+                    >
+                        <LinkIcon className="-ml-1 mr-2 h-4 w-4" aria-hidden="true" />
+                        Join Policies
+                    </button>
+                )}
             </div>
 
             <div className="flex flex-col gap-4 flex-1 overflow-hidden">


### PR DESCRIPTION
Closes #24 — AUTH-004. Builds on #112 (AUTH-001), #113 (AUTH-002), #114 (AUTH-003).

## Summary
- `/v1/auth/me` and `/v1/auth/login` now return the caller's `roles` and effective `permissions` on the `AuthUser` payload. The frontend uses that list to decide what to render.
- `AuthContext` exposes `roles`, `permissions`, `hasRole`, `hasPermission`. Refreshing the session re-fetches both, so permission changes take effect after re-auth.
- `RequireAuth` learned `permission` / `role` props. When the user is authenticated but lacks the requirement, it renders a new `Forbidden` view instead of routing to `/login` — direct URL navigation to a restricted page no longer succeeds.
- Per-route requirements wired in `App.tsx`: `/queries` (`saved_queries.read`), `/query` (`query.run`), `/data-sources` & `/schema` (`data_sources.read`), `/llm-providers` (`providers.read`).
- Sidebar nav entries hide themselves when the user lacks the matching permission. The "New Query" CTA is disabled with a tooltip for users without `query.run`.
- Action buttons across pages are hidden for users who would just get a 403:
  - **DataSources**: Add / Introspect / Import-Schema / Delete gated on `data_sources.write`; Reindex on `rag.write`; RAG Notes button stays visible for read-only access.
  - **LLMProviders**: Add Provider / Edit Key / Enable-Disable gated on `providers.write`.
  - **SchemaExplorer & SchemaObjectList**: Join Policies, Enrich, and toggle-visibility gated on `semantic.write`.
  - **SavedQueries**: Duplicate / Edit / Delete gated on `saved_queries.write`.
  - **RagNotesDialog**: New / Edit / Delete and the editor pane gated on `rag.write`; the list remains visible read-only.

## Acceptance criteria
- [x] **Unauthorized actions are not visible or are disabled with explanation.** — Buttons are hidden when the user lacks the permission; the Forbidden view and the "New Query" disabled-tooltip both explain *why*.
- [x] **Direct URL navigation to restricted routes is blocked.** — `RequireAuth permission="…"` renders the Forbidden view for direct visits to restricted pages.
- [x] **Permission changes are reflected after re-auth/refresh.** — The auth context re-derives `roles`/`permissions` from each `/v1/auth/me` response (called on mount and after login/logout). Re-logging in picks up role changes; in-session changes show up on the next `refresh()`.

## Test plan
- [x] `DATABASE_URL=postgresql://test:test@localhost:5432/test npm test` → 79/79 passing (backend `authApi.test.js` updated to assert the new roles/permissions payload).
- [x] `npm --prefix frontend run lint` clean.
- [x] `npm --prefix frontend run build` clean.
- [x] Manual: seed three users (`admin`, `analyst`, `viewer`) with `scripts/create-user.js`. Verify:
  - admin sees every nav entry, can Add Data Source / Add Provider / Edit RAG notes.
  - analyst can save queries and edit semantic/rag, but Add Data Source / Add Provider are hidden.
  - viewer can navigate to DataSources / SavedQueries / LLM Providers (read-only), but `/query` shows Forbidden, and write affordances disappear.
  - Visiting `/llm-providers` as a user without `providers.read` lands on Forbidden, not the page.

## Notes
- The Forbidden view is rendered inline by `RequireAuth` (no extra route) so the URL bar still reflects what the user attempted. It links back to `/dashboard`.
- This PR does NOT add resource-scoped (per-data-source) UI gating — that's AUTH-005 (#25). Today, viewer sees every data source they're authenticated to read.
- Sidebar permission gating is plumbed through but only the `permission`-tagged entries (Queries / Datasets) have a meaningful effect in the current role grid. Future roles can hide entries without touching the layout.