### PR TITLE
feat(auth): AUTH-005 resource-level data-source access

### DIFF
--- a/app/src/lib/authGate.js
+++ b/app/src/lib/authGate.js
@@ -3,6 +3,7 @@ const { logEvent } = require("./observability");
 const { readSessionToken, buildClearSessionCookie } = require("./sessionCookie");
 const authService = require("../services/authService");
 const roleService = require("../services/roleService");
+const dataSourceAccessService = require("../services/dataSourceAccessService");
 
 async function loadCurrentUser(req) {
   const token = readSessionToken(req);
@@ -115,9 +116,56 @@ async function enforcePolicy(req, res, policy) {
   return { allowed: true, user: current.user, roles: current.roles, permissions };
 }
 
+function isAdmin(req) {
+  return Boolean(req.userRoles && req.userRoles.includes("admin"));
+}
+
+// Returns true and allows the request to continue. On deny the response has
+// already been written (403). The check is skipped for admins.
+async function enforceDataSourceAccess(req, res, dataSourceId) {
+  if (isAdmin(req)) {
+    return true;
+  }
+  if (!req.user || !dataSourceId) {
+    json(res, 403, { error: "forbidden", message: "no access to this data source" });
+    return false;
+  }
+  const allowed = await dataSourceAccessService.hasAccess(req.user.id, dataSourceId);
+  if (!allowed) {
+    logEvent("authorization", {
+      request_id: req.requestId || null,
+      user_id: req.user.id,
+      method: req.method,
+      path: req.url,
+      decision: "deny_resource_access",
+      resource: "data_source",
+      resource_id: dataSourceId
+    });
+    json(res, 403, { error: "forbidden", message: "no access to this data source" });
+    return false;
+  }
+  return true;
+}
+
+// For list endpoints: returns null when the caller is an admin (no filter),
+// or an array of accessible data-source UUIDs otherwise. Callers should
+// short-circuit to an empty list when the array is empty.
+async function listAccessibleDataSourceIds(req) {
+  if (isAdmin(req)) {
+    return null;
+  }
+  if (!req.user) {
+    return [];
+  }
+  return dataSourceAccessService.listAccessibleDataSourceIds(req.user.id);
+}
+
 module.exports = {
   loadCurrentUser,
   requireAuthenticated,
   requireRole,
-  enforcePolicy
+  enforcePolicy,
+  enforceDataSourceAccess,
+  listAccessibleDataSourceIds,
+  isAdmin
 };

--- a/app/src/lib/routePolicy.js
+++ b/app/src/lib/routePolicy.js
@@ -25,6 +25,9 @@ const POLICIES = [
   { method: "GET", pattern: /^\/v1\/admin\/users$/, role: "admin" },
   { method: "POST", pattern: /^\/v1\/admin\/users$/, role: "admin" },
   { method: "POST", pattern: /^\/v1\/admin\/users\/[^/]+\/roles$/, role: "admin" },
+  { method: "GET", pattern: /^\/v1\/admin\/data-sources\/[^/]+\/access$/, role: "admin" },
+  { method: "POST", pattern: /^\/v1\/admin\/data-sources\/[^/]+\/access$/, role: "admin" },
+  { method: "DELETE", pattern: /^\/v1\/admin\/data-sources\/[^/]+\/access\/[^/]+$/, role: "admin" },
 
   // Data sources
   { method: "GET", pattern: /^\/v1\/data-sources$/, permission: "data_sources.read" },

--- a/app/src/routes/admin.js
+++ b/app/src/routes/admin.js
@@ -1,6 +1,8 @@
 const { json, readJsonBody, badRequest } = require("../lib/http");
 const { isUuid } = require("../lib/validation");
+const appDb = require("../lib/appDb");
 const adminUserService = require("../services/adminUserService");
+const dataSourceAccessService = require("../services/dataSourceAccessService");
 
 function writeResult(res, result) {
   return json(res, result.statusCode, result.body);
@@ -37,8 +39,85 @@ async function handleUpdateUserRoles(req, res, userId) {
   return writeResult(res, result);
 }
 
+async function dataSourceExists(dataSourceId) {
+  const result = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [dataSourceId]);
+  return result.rowCount > 0;
+}
+
+async function userExists(userId) {
+  const result = await appDb.query("SELECT id FROM users WHERE id = $1", [userId]);
+  return result.rowCount > 0;
+}
+
+async function handleListDataSourceAccess(_req, res, dataSourceId) {
+  if (!isUuid(dataSourceId)) {
+    return badRequest(res, "data_source_id must be a uuid");
+  }
+  if (!(await dataSourceExists(dataSourceId))) {
+    return json(res, 404, { error: "not_found", message: "data source not found" });
+  }
+  const items = await dataSourceAccessService.listUsersWithAccess(dataSourceId);
+  return json(res, 200, { items });
+}
+
+async function handleGrantDataSourceAccess(req, res, dataSourceId) {
+  if (!isUuid(dataSourceId)) {
+    return badRequest(res, "data_source_id must be a uuid");
+  }
+  const body = await readJsonBody(req);
+  const userId = body && body.user_id;
+  if (!isUuid(userId)) {
+    return badRequest(res, "user_id must be a uuid");
+  }
+  if (!(await dataSourceExists(dataSourceId))) {
+    return json(res, 404, { error: "not_found", message: "data source not found" });
+  }
+  if (!(await userExists(userId))) {
+    return json(res, 404, { error: "not_found", message: "user not found" });
+  }
+  const changed = await appDb.withTransaction((client) => (
+    dataSourceAccessService.grantAccess(client, {
+      userId,
+      dataSourceId,
+      actorUserId: req.user && req.user.id ? req.user.id : null
+    })
+  ));
+  return json(res, changed ? 201 : 200, {
+    granted: changed,
+    user_id: userId,
+    data_source_id: dataSourceId
+  });
+}
+
+async function handleRevokeDataSourceAccess(req, res, dataSourceId, userId) {
+  if (!isUuid(dataSourceId)) {
+    return badRequest(res, "data_source_id must be a uuid");
+  }
+  if (!isUuid(userId)) {
+    return badRequest(res, "user_id must be a uuid");
+  }
+  const changed = await appDb.withTransaction((client) => (
+    dataSourceAccessService.revokeAccess(client, {
+      userId,
+      dataSourceId,
+      actorUserId: req.user && req.user.id ? req.user.id : null
+    })
+  ));
+  if (!changed) {
+    return json(res, 404, { error: "not_found", message: "no access grant found for that user / data source" });
+  }
+  return json(res, 200, {
+    revoked: true,
+    user_id: userId,
+    data_source_id: dataSourceId
+  });
+}
+
 module.exports = {
   handleListUsers,
   handleCreateUser,
-  handleUpdateUserRoles
+  handleUpdateUserRoles,
+  handleListDataSourceAccess,
+  handleGrantDataSourceAccess,
+  handleRevokeDataSourceAccess
 };

--- a/app/src/routes/dataSourceExportImport.js
+++ b/app/src/routes/dataSourceExportImport.js
@@ -4,8 +4,9 @@ const { logEvent } = require("../lib/observability");
 const { isUuid, groupByKey, validateDataSourceImportPayload } = require("../lib/validation");
 const { isSupportedDbType } = require("../adapters/dbAdapterFactory");
 const { reindexRagDocuments } = require("../services/ragService");
+const { enforceDataSourceAccess } = require("../lib/authGate");
 
-async function handleExportDataSource(_req, res, dataSourceId) {
+async function handleExportDataSource(req, res, dataSourceId) {
   if (!isUuid(dataSourceId)) {
     return badRequest(res, "dataSourceId must be a valid UUID");
   }
@@ -16,6 +17,9 @@ async function handleExportDataSource(_req, res, dataSourceId) {
   );
   if (dsResult.rowCount === 0) {
     return json(res, 404, { error: "not_found", message: "Data source not found" });
+  }
+  if (!(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
   }
   const ds = dsResult.rows[0];
 

--- a/app/src/routes/dataSources.js
+++ b/app/src/routes/dataSources.js
@@ -5,6 +5,7 @@ const { runIntrospection } = require("../services/introspectionService");
 const { parseSchemaFromDdl } = require("../services/ddlImportService");
 const { persistSnapshot } = require("../services/introspectionService");
 const { reindexRagDocuments } = require("../services/ragService");
+const { enforceDataSourceAccess, listAccessibleDataSourceIds } = require("../lib/authGate");
 
 async function runIntrospectionJob(jobId, dataSource) {
   try {
@@ -66,15 +67,30 @@ async function handleCreateDataSource(req, res) {
   return json(res, 201, result.rows[0]);
 }
 
-async function handleListDataSources(_req, res) {
-  const result = await appDb.query(
-    `
-      SELECT id, name, db_type, connection_ref, status, created_at
-      FROM data_sources
-      ORDER BY created_at DESC
-    `
-  );
-
+async function handleListDataSources(req, res) {
+  const accessible = await listAccessibleDataSourceIds(req);
+  let result;
+  if (accessible === null) {
+    result = await appDb.query(
+      `
+        SELECT id, name, db_type, connection_ref, status, created_at
+        FROM data_sources
+        ORDER BY created_at DESC
+      `
+    );
+  } else if (accessible.length === 0) {
+    return json(res, 200, { items: [] });
+  } else {
+    result = await appDb.query(
+      `
+        SELECT id, name, db_type, connection_ref, status, created_at
+        FROM data_sources
+        WHERE id = ANY($1::uuid[])
+        ORDER BY created_at DESC
+      `,
+      [accessible]
+    );
+  }
   return json(res, 200, { items: result.rows });
 }
 
@@ -99,6 +115,10 @@ async function handleIntrospect(req, res, dataSourceId) {
   const dataSource = result.rows[0];
   if (!dataSource) {
     return json(res, 404, { error: "not_found", message: "Data source not found" });
+  }
+
+  if (!(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
   }
 
   if (!isSupportedDbType(dataSource.db_type)) {
@@ -132,6 +152,10 @@ async function handleImportSchema(req, res, dataSourceId) {
   const dataSource = result.rows[0];
   if (!dataSource) {
     return json(res, 404, { error: "not_found", message: "Data source not found" });
+  }
+
+  if (!(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
   }
 
   const body = await readJsonBody(req);

--- a/app/src/routes/exportDelivery.js
+++ b/app/src/routes/exportDelivery.js
@@ -2,6 +2,15 @@ const appDb = require("../lib/appDb");
 const { json, badRequest, internalError, readJsonBody } = require("../lib/http");
 const { exportQueryResult, SUPPORTED_FORMATS } = require("../services/exportService");
 const { createDelivery, getDeliveryStatus } = require("../services/deliveryService");
+const { enforceDataSourceAccess } = require("../lib/authGate");
+
+async function loadSessionDataSourceId(sessionId) {
+  const result = await appDb.query(
+    "SELECT data_source_id FROM query_sessions WHERE id = $1",
+    [sessionId]
+  );
+  return result.rowCount > 0 ? result.rows[0].data_source_id : null;
+}
 
 async function handleExportSession(req, res, sessionId) {
   const body = await readJsonBody(req).catch(() => ({})); // Body optional
@@ -10,6 +19,14 @@ async function handleExportSession(req, res, sessionId) {
 
   if (!SUPPORTED_FORMATS.has(format)) {
     return badRequest(res, `Unsupported format: ${format}`);
+  }
+
+  const sessionDsId = await loadSessionDataSourceId(sessionId);
+  if (!sessionDsId) {
+    return json(res, 404, { error: "not_found", message: "Session not found" });
+  }
+  if (!(await enforceDataSourceAccess(req, res, sessionDsId))) {
+    return undefined;
   }
 
   try {
@@ -37,9 +54,12 @@ async function handleExportDeliver(req, res, sessionId) {
     return badRequest(res, "delivery_mode must be 'download' or 'email'");
   }
 
-  const sessionResult = await appDb.query("SELECT id FROM query_sessions WHERE id = $1", [sessionId]);
-  if (sessionResult.rowCount === 0) {
+  const sessionDsId = await loadSessionDataSourceId(sessionId);
+  if (!sessionDsId) {
     return json(res, 404, { error: "not_found", message: "Session not found" });
+  }
+  if (!(await enforceDataSourceAccess(req, res, sessionDsId))) {
+    return undefined;
   }
 
   const requestedBy = req.user && req.user.id ? req.user.id : "anonymous";
@@ -75,10 +95,14 @@ async function handleExportDeliver(req, res, sessionId) {
   }
 }
 
-async function handleExportStatus(_req, res, exportId) {
+async function handleExportStatus(req, res, exportId) {
   const delivery = await getDeliveryStatus(exportId);
   if (!delivery) {
     return json(res, 404, { error: "not_found", message: "Export delivery not found" });
+  }
+  const sessionDsId = await loadSessionDataSourceId(delivery.session_id);
+  if (sessionDsId && !(await enforceDataSourceAccess(req, res, sessionDsId))) {
+    return undefined;
   }
   return json(res, 200, delivery);
 }

--- a/app/src/routes/query.js
+++ b/app/src/routes/query.js
@@ -4,6 +4,7 @@ const { clamp, isUuid } = require("../lib/validation");
 const { validateAndNormalizeSql } = require("../services/sqlSafety");
 const { triggerRagReindexAsync } = require("../services/ragService");
 const { orchestrateQueryRun } = require("../services/queryOrchestrationService");
+const { enforceDataSourceAccess, listAccessibleDataSourceIds } = require("../lib/authGate");
 
 async function handleCreateSession(req, res) {
   const body = await readJsonBody(req);
@@ -16,6 +17,10 @@ async function handleCreateSession(req, res) {
   const sourceResult = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [dataSourceId]);
   if (sourceResult.rowCount === 0) {
     return json(res, 404, { error: "not_found", message: "Data source not found" });
+  }
+
+  if (!(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
   }
 
   const userId = req.user && req.user.id ? req.user.id : "anonymous";
@@ -42,6 +47,16 @@ async function handlePromptHistory(req, res, requestUrl) {
     return badRequest(res, "data_source_id must be a valid UUID");
   }
 
+  if (dataSourceId && !(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
+  }
+
+  const accessible = await listAccessibleDataSourceIds(req);
+  if (!dataSourceId && accessible && accessible.length === 0) {
+    return json(res, 200, { items: [] });
+  }
+  const accessFilter = !dataSourceId && accessible ? accessible : null;
+
   const result = await appDb.query(
     `
       SELECT
@@ -61,16 +76,28 @@ async function handlePromptHistory(req, res, requestUrl) {
       WHERE user_id = $1
         AND ($2::uuid IS NULL OR qs.data_source_id = $2::uuid)
         AND ($3::text = '' OR question ILIKE '%' || $3 || '%')
+        AND ($5::uuid[] IS NULL OR qs.data_source_id = ANY($5::uuid[]))
       ORDER BY qs.created_at DESC
       LIMIT $4
     `,
-    [userId, dataSourceId, search, limit]
+    [userId, dataSourceId, search, limit, accessFilter]
   );
 
   return json(res, 200, { items: result.rows });
 }
 
 async function handleRunSession(req, res, sessionId) {
+  const sessionLookup = await appDb.query(
+    "SELECT data_source_id FROM query_sessions WHERE id = $1",
+    [sessionId]
+  );
+  if (sessionLookup.rowCount === 0) {
+    return json(res, 404, { error: "not_found", message: "Session not found" });
+  }
+  if (!(await enforceDataSourceAccess(req, res, sessionLookup.rows[0].data_source_id))) {
+    return undefined;
+  }
+
   const body = await readJsonBody(req);
   const requestedProvider = body.llm_provider || null;
   const requestedModel = body.model || null;
@@ -118,6 +145,10 @@ async function handleFeedback(req, res, sessionId) {
     return json(res, 404, { error: "not_found", message: "Session not found" });
   }
   const session = sessionResult.rows[0];
+
+  if (!(await enforceDataSourceAccess(req, res, session.data_source_id))) {
+    return undefined;
+  }
 
   await appDb.query(
     `

--- a/app/src/routes/rag.js
+++ b/app/src/routes/rag.js
@@ -3,14 +3,19 @@ const { json, badRequest, readJsonBody } = require("../lib/http");
 const { RAG_NOTE_TITLE_MAX_LENGTH, RAG_NOTE_CONTENT_MAX_LENGTH } = require("../lib/constants");
 const { isUuid } = require("../lib/validation");
 const { reindexRagDocuments, triggerRagReindexAsync } = require("../services/ragService");
+const { enforceDataSourceAccess } = require("../lib/authGate");
 
-async function handleListRagNotes(_req, res, requestUrl) {
+async function handleListRagNotes(req, res, requestUrl) {
   const dataSourceId = String(requestUrl.searchParams.get("data_source_id") || "").trim();
   if (!dataSourceId) {
     return badRequest(res, "data_source_id query parameter is required");
   }
   if (!isUuid(dataSourceId)) {
     return badRequest(res, "data_source_id must be a valid UUID");
+  }
+
+  if (!(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
   }
 
   const result = await appDb.query(
@@ -64,6 +69,10 @@ async function handleUpsertRagNote(req, res) {
   const sourceResult = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [dataSourceId]);
   if (sourceResult.rowCount === 0) {
     return json(res, 404, { error: "not_found", message: "Data source not found" });
+  }
+
+  if (!(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
   }
 
   const userId = req.user && req.user.id ? req.user.id : "anonymous";
@@ -126,9 +135,21 @@ async function handleUpsertRagNote(req, res) {
   return json(res, 200, insertResult.rows[0]);
 }
 
-async function handleDeleteRagNote(_req, res, noteId) {
+async function handleDeleteRagNote(req, res, noteId) {
   if (!isUuid(noteId)) {
     return badRequest(res, "noteId must be a valid UUID");
+  }
+
+  const noteLookup = await appDb.query(
+    "SELECT id, data_source_id FROM rag_notes WHERE id = $1",
+    [noteId]
+  );
+  if (noteLookup.rowCount === 0) {
+    return json(res, 404, { error: "not_found", message: "RAG note not found" });
+  }
+
+  if (!(await enforceDataSourceAccess(req, res, noteLookup.rows[0].data_source_id))) {
+    return undefined;
   }
 
   const deleteResult = await appDb.query(
@@ -160,6 +181,10 @@ async function handleRagReindex(req, res, requestUrl) {
   const sourceResult = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [dataSourceId]);
   if (sourceResult.rowCount === 0) {
     return json(res, 404, { error: "not_found", message: "Data source not found" });
+  }
+
+  if (!(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
   }
 
   const result = await reindexRagDocuments(dataSourceId);

--- a/app/src/routes/savedQueries.js
+++ b/app/src/routes/savedQueries.js
@@ -1,12 +1,35 @@
+const appDb = require("../lib/appDb");
 const { json, readJsonBody } = require("../lib/http");
+const { isUuid } = require("../lib/validation");
 const savedQueryService = require("../services/savedQueryService");
+const { enforceDataSourceAccess, listAccessibleDataSourceIds } = require("../lib/authGate");
 
 function writeResult(res, result) {
   return json(res, result.statusCode, result.body);
 }
 
+async function loadSavedQueryDataSourceId(savedQueryId) {
+  if (!isUuid(savedQueryId)) return null;
+  const result = await appDb.query(
+    "SELECT data_source_id FROM saved_queries WHERE id = $1",
+    [savedQueryId]
+  );
+  return result.rowCount > 0 ? result.rows[0].data_source_id : null;
+}
+
+async function dataSourceExists(dataSourceId) {
+  if (!isUuid(dataSourceId)) return false;
+  const result = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [dataSourceId]);
+  return result.rowCount > 0;
+}
+
 async function handleCreateSavedQuery(req, res) {
   const body = await readJsonBody(req);
+  if (body && body.data_source_id && await dataSourceExists(body.data_source_id)) {
+    if (!(await enforceDataSourceAccess(req, res, body.data_source_id))) {
+      return undefined;
+    }
+  }
   const result = await savedQueryService.createSavedQuery({
     ownerId: req.user && req.user.id ? req.user.id : null,
     name: body.name,
@@ -20,21 +43,47 @@ async function handleCreateSavedQuery(req, res) {
   return writeResult(res, result);
 }
 
-async function handleListSavedQueries(_req, res, requestUrl) {
+async function handleListSavedQueries(req, res, requestUrl) {
+  const dataSourceId = requestUrl.searchParams.get("data_source_id");
+  if (dataSourceId && isUuid(dataSourceId) && !(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
+  }
+  const accessible = await listAccessibleDataSourceIds(req);
   const result = await savedQueryService.listSavedQueries(
-    requestUrl.searchParams.get("data_source_id"),
+    dataSourceId,
     requestUrl.searchParams.get("tag")
   );
+  if (accessible !== null && Array.isArray(result.body && result.body.items)) {
+    const accessibleSet = new Set(accessible);
+    result.body = {
+      ...result.body,
+      items: result.body.items.filter((item) => accessibleSet.has(item.data_source_id))
+    };
+  }
   return writeResult(res, result);
 }
 
-async function handleGetSavedQuery(_req, res, savedQueryId) {
+async function handleGetSavedQuery(req, res, savedQueryId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
+    return undefined;
+  }
   const result = await savedQueryService.getSavedQuery(savedQueryId);
   return writeResult(res, result);
 }
 
 async function handleUpdateSavedQuery(req, res, savedQueryId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
+    return undefined;
+  }
   const body = await readJsonBody(req);
+  if (body && body.data_source_id && body.data_source_id !== dsId
+      && await dataSourceExists(body.data_source_id)) {
+    if (!(await enforceDataSourceAccess(req, res, body.data_source_id))) {
+      return undefined;
+    }
+  }
   const result = await savedQueryService.updateSavedQuery(savedQueryId, {
     name: body.name,
     description: body.description,
@@ -47,18 +96,30 @@ async function handleUpdateSavedQuery(req, res, savedQueryId) {
   return writeResult(res, result);
 }
 
-async function handleDeleteSavedQuery(_req, res, savedQueryId) {
+async function handleDeleteSavedQuery(req, res, savedQueryId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
+    return undefined;
+  }
   const result = await savedQueryService.deleteSavedQuery(savedQueryId);
   return writeResult(res, result);
 }
 
 async function handleValidateParams(req, res, savedQueryId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
+    return undefined;
+  }
   const body = await readJsonBody(req);
   const result = await savedQueryService.validateSavedQueryParams(savedQueryId, body.params);
   return writeResult(res, result);
 }
 
 async function handleRunSavedQuery(req, res, savedQueryId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
+    return undefined;
+  }
   const body = await readJsonBody(req);
   const result = await savedQueryService.executeSavedQuery(savedQueryId, {
     params: body.params,

--- a/app/src/routes/schema.js
+++ b/app/src/routes/schema.js
@@ -2,11 +2,16 @@ const appDb = require("../lib/appDb");
 const { json, badRequest, readJsonBody } = require("../lib/http");
 const { isUuid } = require("../lib/validation");
 const { triggerRagReindexAsync } = require("../services/ragService");
+const { enforceDataSourceAccess } = require("../lib/authGate");
 
 async function handleListSchemaObjects(req, res, requestUrl) {
   const dataSourceId = requestUrl.searchParams.get("data_source_id");
   if (!dataSourceId) {
     return badRequest(res, "data_source_id query parameter is required");
+  }
+
+  if (!(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
   }
 
   const result = await appDb.query(
@@ -25,6 +30,17 @@ async function handleListSchemaObjects(req, res, requestUrl) {
 async function handlePatchSchemaObject(req, res, schemaObjectId) {
   if (!isUuid(schemaObjectId)) {
     return badRequest(res, "schemaObjectId must be a valid UUID");
+  }
+
+  const objLookup = await appDb.query(
+    "SELECT data_source_id FROM schema_objects WHERE id = $1",
+    [schemaObjectId]
+  );
+  if (objLookup.rowCount === 0) {
+    return json(res, 404, { error: "not_found", message: "Schema object not found" });
+  }
+  if (!(await enforceDataSourceAccess(req, res, objLookup.rows[0].data_source_id))) {
+    return undefined;
   }
 
   const body = await readJsonBody(req);

--- a/app/src/routes/semantic.js
+++ b/app/src/routes/semantic.js
@@ -2,6 +2,7 @@ const appDb = require("../lib/appDb");
 const { json, badRequest, readJsonBody } = require("../lib/http");
 const { ENTITY_TYPES } = require("../lib/constants");
 const { triggerRagReindexAsync } = require("../services/ragService");
+const { enforceDataSourceAccess } = require("../lib/authGate");
 
 async function handleUpsertSemanticEntity(req, res) {
   const body = await readJsonBody(req);
@@ -22,6 +23,10 @@ async function handleUpsertSemanticEntity(req, res) {
 
   if (!ENTITY_TYPES.has(entityType)) {
     return badRequest(res, "Invalid entity_type");
+  }
+
+  if (!(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
   }
 
   if (id) {
@@ -75,6 +80,17 @@ async function handleUpsertMetricDefinition(req, res) {
 
   if (!semanticEntityId || !sqlExpression) {
     return badRequest(res, "semantic_entity_id and sql_expression are required");
+  }
+
+  const entityDsLookup = await appDb.query(
+    "SELECT data_source_id FROM semantic_entities WHERE id = $1",
+    [semanticEntityId]
+  );
+  if (entityDsLookup.rowCount === 0) {
+    return json(res, 404, { error: "not_found", message: "Semantic entity not found" });
+  }
+  if (!(await enforceDataSourceAccess(req, res, entityDsLookup.rows[0].data_source_id))) {
+    return undefined;
   }
 
   if (id) {
@@ -144,6 +160,10 @@ async function handleUpsertJoinPolicy(req, res) {
 
   if (!dataSourceId || !leftRef || !rightRef || !joinType || !onClause || typeof approved !== "boolean") {
     return badRequest(res, "data_source_id, left_ref, right_ref, join_type, on_clause, approved are required");
+  }
+
+  if (!(await enforceDataSourceAccess(req, res, dataSourceId))) {
+    return undefined;
   }
 
   if (id) {

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -78,7 +78,10 @@ const {
 const {
   handleListUsers,
   handleCreateUser,
-  handleUpdateUserRoles
+  handleUpdateUserRoles,
+  handleListDataSourceAccess,
+  handleGrantDataSourceAccess,
+  handleRevokeDataSourceAccess
 } = require("./routes/admin");
 const { findPolicy } = require("./lib/routePolicy");
 const { enforcePolicy } = require("./lib/authGate");
@@ -168,6 +171,19 @@ async function routeRequest(req, res) {
   const adminUserRolesMatch = pathname.match(/^\/v1\/admin\/users\/([^/]+)\/roles$/);
   if (req.method === "POST" && adminUserRolesMatch) {
     return handleUpdateUserRoles(req, res, adminUserRolesMatch[1]);
+  }
+
+  const adminDataSourceAccessMatch = pathname.match(/^\/v1\/admin\/data-sources\/([^/]+)\/access$/);
+  if (req.method === "GET" && adminDataSourceAccessMatch) {
+    return handleListDataSourceAccess(req, res, adminDataSourceAccessMatch[1]);
+  }
+  if (req.method === "POST" && adminDataSourceAccessMatch) {
+    return handleGrantDataSourceAccess(req, res, adminDataSourceAccessMatch[1]);
+  }
+
+  const adminDataSourceRevokeMatch = pathname.match(/^\/v1\/admin\/data-sources\/([^/]+)\/access\/([^/]+)$/);
+  if (req.method === "DELETE" && adminDataSourceRevokeMatch) {
+    return handleRevokeDataSourceAccess(req, res, adminDataSourceRevokeMatch[1], adminDataSourceRevokeMatch[2]);
   }
 
   if (req.method === "POST" && pathname === "/v1/data-sources") {

--- a/app/src/services/dataSourceAccessService.js
+++ b/app/src/services/dataSourceAccessService.js
@@ -1,0 +1,106 @@
+const appDb = require("../lib/appDb");
+const roleService = require("./roleService");
+
+async function hasAccess(userId, dataSourceId) {
+  if (!userId || !dataSourceId) {
+    return false;
+  }
+  const result = await appDb.query(
+    "SELECT 1 FROM user_data_source_access WHERE user_id = $1 AND data_source_id = $2",
+    [userId, dataSourceId]
+  );
+  return result.rowCount > 0;
+}
+
+async function listAccessibleDataSourceIds(userId) {
+  if (!userId) return [];
+  const result = await appDb.query(
+    "SELECT data_source_id FROM user_data_source_access WHERE user_id = $1",
+    [userId]
+  );
+  return result.rows.map((row) => row.data_source_id);
+}
+
+async function listUsersWithAccess(dataSourceId) {
+  const result = await appDb.query(
+    `
+      SELECT
+        u.id,
+        u.email,
+        u.display_name,
+        u.is_active,
+        a.granted_at,
+        a.granted_by_user_id,
+        COALESCE(
+          (
+            SELECT array_agg(r.name ORDER BY r.name)
+            FROM user_roles ur
+            JOIN roles r ON r.id = ur.role_id
+            WHERE ur.user_id = u.id
+          ),
+          ARRAY[]::text[]
+        ) AS roles
+      FROM user_data_source_access a
+      JOIN users u ON u.id = a.user_id
+      WHERE a.data_source_id = $1
+      ORDER BY lower(u.email)
+    `,
+    [dataSourceId]
+  );
+  return result.rows.map((row) => ({
+    id: row.id,
+    email: row.email,
+    display_name: row.display_name,
+    is_active: row.is_active,
+    granted_at: row.granted_at,
+    granted_by_user_id: row.granted_by_user_id,
+    roles: row.roles
+  }));
+}
+
+async function grantAccess(client, { userId, dataSourceId, actorUserId }) {
+  const insert = await client.query(
+    `
+      INSERT INTO user_data_source_access (user_id, data_source_id, granted_by_user_id)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (user_id, data_source_id) DO NOTHING
+      RETURNING user_id
+    `,
+    [userId, dataSourceId, actorUserId || null]
+  );
+  const changed = insert.rowCount > 0;
+  if (changed) {
+    await roleService.writeAuditEntry(client, {
+      actorUserId,
+      targetUserId: userId,
+      action: "data_source.access.granted",
+      details: { data_source_id: dataSourceId }
+    });
+  }
+  return changed;
+}
+
+async function revokeAccess(client, { userId, dataSourceId, actorUserId }) {
+  const del = await client.query(
+    "DELETE FROM user_data_source_access WHERE user_id = $1 AND data_source_id = $2 RETURNING user_id",
+    [userId, dataSourceId]
+  );
+  const changed = del.rowCount > 0;
+  if (changed) {
+    await roleService.writeAuditEntry(client, {
+      actorUserId,
+      targetUserId: userId,
+      action: "data_source.access.revoked",
+      details: { data_source_id: dataSourceId }
+    });
+  }
+  return changed;
+}
+
+module.exports = {
+  hasAccess,
+  listAccessibleDataSourceIds,
+  listUsersWithAccess,
+  grantAccess,
+  revokeAccess
+};

--- a/app/test/dataSourceAccessApi.test.js
+++ b/app/test/dataSourceAccessApi.test.js
@@ -1,0 +1,324 @@
+// AUTH-005: end-to-end checks that per-data-source membership is enforced
+// across the feature surface, that admins bypass the check, and that the
+// admin grant/revoke endpoints work.
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+process.env.PORT = "0";
+process.env.AUTH_COOKIE_SECURE = "false";
+
+const appDb = require("../src/lib/appDb");
+const { createAuthTestStub } = require("./helpers/authTestStub");
+
+const DS_ALLOWED = "00000000-0000-4000-8000-000000000d51";
+const DS_DENIED = "00000000-0000-4000-8000-000000000d52";
+
+let server;
+let baseUrl;
+let authStub;
+let adminCookie;
+let analystCookie;
+let analystUserId;
+let adminUserId;
+let originalQuery;
+let originalWithTransaction;
+let dataSourceAccessRows;
+let auditEntries;
+
+async function call(method, path, { cookie, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (cookie) headers.Cookie = cookie;
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+  return { status: response.status, payload };
+}
+
+function normalize(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+before(async () => {
+  originalQuery = appDb.query;
+  originalWithTransaction = appDb.withTransaction;
+  authStub = createAuthTestStub();
+  dataSourceAccessRows = new Map();
+  auditEntries = [];
+
+  const admin = authStub.seedUser({ email: "admin@example.com", roles: ["admin"] });
+  const analyst = authStub.seedUser({
+    email: "analyst@example.com",
+    roles: ["analyst"],
+    dataSourceAccess: [DS_ALLOWED]
+  });
+  adminUserId = admin.id;
+  analystUserId = analyst.id;
+  adminCookie = authStub.cookieFor(authStub.seedSession(admin.id).token);
+  analystCookie = authStub.cookieFor(authStub.seedSession(analyst.id).token);
+
+  async function runQuery(sql, params = []) {
+    const auth = authStub.handleSql(sql, params);
+    if (auth) return auth;
+
+    const n = normalize(sql);
+
+    if (n === "select id from data_sources where id = $1") {
+      const [id] = params;
+      if (id === DS_ALLOWED || id === DS_DENIED) {
+        return { rowCount: 1, rows: [{ id }] };
+      }
+      return { rowCount: 0, rows: [] };
+    }
+
+    if (n === "select id from users where id = $1") {
+      const [id] = params;
+      if (id === analystUserId || id === adminUserId) {
+        return { rowCount: 1, rows: [{ id }] };
+      }
+      return { rowCount: 0, rows: [] };
+    }
+
+    if (n.startsWith("select u.id, u.email, u.display_name, u.is_active, a.granted_at, a.granted_by_user_id")) {
+      const [dataSourceId] = params;
+      const rows = [];
+      for (const [key, row] of dataSourceAccessRows.entries()) {
+        const [userId, dsId] = key.split("::");
+        if (dsId !== dataSourceId) continue;
+        rows.push({
+          id: userId,
+          email: `${userId}@example.com`,
+          display_name: null,
+          is_active: true,
+          granted_at: row.granted_at,
+          granted_by_user_id: row.granted_by_user_id,
+          roles: []
+        });
+      }
+      return { rowCount: rows.length, rows };
+    }
+
+    if (n.startsWith("insert into user_data_source_access (user_id, data_source_id, granted_by_user_id)")) {
+      const [userId, dataSourceId, actorUserId] = params;
+      const key = `${userId}::${dataSourceId}`;
+      if (dataSourceAccessRows.has(key)) {
+        return { rowCount: 0, rows: [] };
+      }
+      dataSourceAccessRows.set(key, {
+        granted_at: new Date().toISOString(),
+        granted_by_user_id: actorUserId
+      });
+      // Also reflect in the auth stub so /v1/* enforcement sees it.
+      authStub.grantDataSourceAccess(userId, dataSourceId);
+      return { rowCount: 1, rows: [{ user_id: userId }] };
+    }
+
+    if (n.startsWith("delete from user_data_source_access where user_id = $1 and data_source_id = $2 returning user_id")) {
+      const [userId, dataSourceId] = params;
+      const key = `${userId}::${dataSourceId}`;
+      const had = dataSourceAccessRows.delete(key);
+      if (had) {
+        authStub.revokeDataSourceAccess(userId, dataSourceId);
+      }
+      return { rowCount: had ? 1 : 0, rows: had ? [{ user_id: userId }] : [] };
+    }
+
+    if (n.startsWith("insert into auth_audit_log")) {
+      const [actor, target, action, details] = params;
+      auditEntries.push({
+        actor_user_id: actor,
+        target_user_id: target,
+        action,
+        details: JSON.parse(details)
+      });
+      return { rowCount: 1, rows: [] };
+    }
+
+    // Permissive fallback for any other domain SQL: empty result so handlers
+    // that pass enforcement land on their own 404/400 logic.
+    return { rowCount: 0, rows: [] };
+  }
+
+  appDb.query = runQuery;
+  appDb.withTransaction = async (handler) => handler({ query: runQuery });
+
+  delete require.cache[require.resolve("../src/server")];
+  const { startServer } = require("../src/server");
+  server = await startServer();
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+beforeEach(() => {
+  // Reset the access table for each test but keep the analyst's seed grant
+  dataSourceAccessRows.clear();
+  auditEntries.length = 0;
+  // Restore the seeded grant
+  dataSourceAccessRows.set(`${analystUserId}::${DS_ALLOWED}`, {
+    granted_at: new Date().toISOString(),
+    granted_by_user_id: null
+  });
+  authStub.revokeDataSourceAccess(analystUserId, DS_DENIED);
+  authStub.grantDataSourceAccess(analystUserId, DS_ALLOWED);
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  appDb.query = originalQuery;
+  appDb.withTransaction = originalWithTransaction;
+});
+
+test("analyst can act against an allowed data source but is denied 403 on others", async () => {
+  // Allowed: GET schema-objects + POST query session + GET rag notes
+  const schemaAllowed = await call("GET", `/v1/schema-objects?data_source_id=${DS_ALLOWED}`, { cookie: analystCookie });
+  assert.notEqual(schemaAllowed.status, 401);
+  assert.notEqual(schemaAllowed.status, 403);
+
+  const queryAllowed = await call("POST", "/v1/query/sessions", {
+    cookie: analystCookie,
+    body: { data_source_id: DS_ALLOWED, question: "test" }
+  });
+  assert.notEqual(queryAllowed.status, 403);
+
+  const ragAllowed = await call("GET", `/v1/rag/notes?data_source_id=${DS_ALLOWED}`, { cookie: analystCookie });
+  assert.notEqual(ragAllowed.status, 403);
+
+  // Denied: same calls against DS_DENIED
+  const schemaDenied = await call("GET", `/v1/schema-objects?data_source_id=${DS_DENIED}`, { cookie: analystCookie });
+  assert.equal(schemaDenied.status, 403);
+
+  const queryDenied = await call("POST", "/v1/query/sessions", {
+    cookie: analystCookie,
+    body: { data_source_id: DS_DENIED, question: "test" }
+  });
+  assert.equal(queryDenied.status, 403);
+
+  const ragDenied = await call("GET", `/v1/rag/notes?data_source_id=${DS_DENIED}`, { cookie: analystCookie });
+  assert.equal(ragDenied.status, 403);
+
+  const ragWriteDenied = await call("POST", "/v1/rag/notes", {
+    cookie: analystCookie,
+    body: { data_source_id: DS_DENIED, title: "t", content: "c" }
+  });
+  assert.equal(ragWriteDenied.status, 403);
+
+  const semanticDenied = await call("POST", "/v1/semantic-entities", {
+    cookie: analystCookie,
+    body: {
+      data_source_id: DS_DENIED,
+      entity_type: "table",
+      target_ref: "public.x",
+      business_name: "X"
+    }
+  });
+  assert.equal(semanticDenied.status, 403);
+
+  const reindexDenied = await call("POST", `/v1/rag/reindex?data_source_id=${DS_DENIED}`, { cookie: analystCookie });
+  assert.equal(reindexDenied.status, 403);
+});
+
+test("admin bypasses the data-source access check", async () => {
+  for (const path of [
+    `/v1/schema-objects?data_source_id=${DS_DENIED}`,
+    `/v1/rag/notes?data_source_id=${DS_DENIED}`
+  ]) {
+    const result = await call("GET", path, { cookie: adminCookie });
+    assert.notEqual(result.status, 403, `admin should not get 403 on ${path}`);
+  }
+
+  const adminCreate = await call("POST", "/v1/query/sessions", {
+    cookie: adminCookie,
+    body: { data_source_id: DS_DENIED, question: "admin" }
+  });
+  assert.notEqual(adminCreate.status, 403);
+});
+
+test("GET /v1/data-sources lists only what the analyst can see (admin sees all)", async () => {
+  const adminList = await call("GET", "/v1/data-sources", { cookie: adminCookie });
+  assert.equal(adminList.status, 200);
+
+  const analystList = await call("GET", "/v1/data-sources", { cookie: analystCookie });
+  assert.equal(analystList.status, 200);
+  const ids = (analystList.payload.items || []).map((d) => d.id);
+  assert.ok(!ids.includes(DS_DENIED), "analyst should not see DS_DENIED in list");
+});
+
+test("admin grant + revoke endpoints update access and audit log", async () => {
+  // Initially analyst lacks DS_DENIED
+  assert.equal(authStub.handleSql(
+    "SELECT 1 FROM user_data_source_access WHERE user_id = $1 AND data_source_id = $2",
+    [analystUserId, DS_DENIED]
+  ).rowCount, 0);
+
+  const grant = await call("POST", `/v1/admin/data-sources/${DS_DENIED}/access`, {
+    cookie: adminCookie,
+    body: { user_id: analystUserId }
+  });
+  assert.equal(grant.status, 201);
+  assert.equal(grant.payload.granted, true);
+
+  // Granting again is idempotent (200, granted=false)
+  const grantAgain = await call("POST", `/v1/admin/data-sources/${DS_DENIED}/access`, {
+    cookie: adminCookie,
+    body: { user_id: analystUserId }
+  });
+  assert.equal(grantAgain.status, 200);
+  assert.equal(grantAgain.payload.granted, false);
+
+  // Audit log captured a grant entry
+  assert.ok(auditEntries.some((e) => (
+    e.action === "data_source.access.granted"
+    && e.target_user_id === analystUserId
+    && e.details.data_source_id === DS_DENIED
+    && e.actor_user_id === adminUserId
+  )));
+
+  // Now the analyst can act against DS_DENIED
+  const allowedNow = await call("GET", `/v1/rag/notes?data_source_id=${DS_DENIED}`, { cookie: analystCookie });
+  assert.notEqual(allowedNow.status, 403);
+
+  // Revoke
+  const revoke = await call("DELETE", `/v1/admin/data-sources/${DS_DENIED}/access/${analystUserId}`, { cookie: adminCookie });
+  assert.equal(revoke.status, 200);
+  assert.equal(revoke.payload.revoked, true);
+
+  // Revoke when no grant exists -> 404
+  const revokeAgain = await call("DELETE", `/v1/admin/data-sources/${DS_DENIED}/access/${analystUserId}`, { cookie: adminCookie });
+  assert.equal(revokeAgain.status, 404);
+
+  // Audit log captured a revoke entry
+  assert.ok(auditEntries.some((e) => (
+    e.action === "data_source.access.revoked"
+    && e.target_user_id === analystUserId
+    && e.details.data_source_id === DS_DENIED
+    && e.actor_user_id === adminUserId
+  )));
+
+  // Analyst is denied again
+  const deniedAgain = await call("GET", `/v1/rag/notes?data_source_id=${DS_DENIED}`, { cookie: analystCookie });
+  assert.equal(deniedAgain.status, 403);
+});
+
+test("non-admin cannot reach the admin access endpoints", async () => {
+  const list = await call("GET", `/v1/admin/data-sources/${DS_ALLOWED}/access`, { cookie: analystCookie });
+  assert.equal(list.status, 403);
+
+  const grant = await call("POST", `/v1/admin/data-sources/${DS_ALLOWED}/access`, {
+    cookie: analystCookie,
+    body: { user_id: adminUserId }
+  });
+  assert.equal(grant.status, 403);
+
+  const revoke = await call("DELETE", `/v1/admin/data-sources/${DS_ALLOWED}/access/${analystUserId}`, { cookie: analystCookie });
+  assert.equal(revoke.status, 403);
+});

--- a/app/test/helpers/authTestStub.js
+++ b/app/test/helpers/authTestStub.js
@@ -65,6 +65,7 @@ function createAuthTestStub() {
   const users = new Map();
   const sessions = new Map();
   const userRoles = new Map(); // user_id -> Set of role names
+  const dataSourceAccess = new Map(); // user_id -> Set of data_source_id
   let userCounter = 0;
   let sessionCounter = 0;
 
@@ -72,11 +73,12 @@ function createAuthTestStub() {
     users.clear();
     sessions.clear();
     userRoles.clear();
+    dataSourceAccess.clear();
     userCounter = 0;
     sessionCounter = 0;
   }
 
-  function seedUser({ id, email, password = "hunter22ok", displayName = null, isActive = true, roles = [] }) {
+  function seedUser({ id, email, password = "hunter22ok", displayName = null, isActive = true, roles = [], dataSourceAccess: ds = [] }) {
     if (!id) {
       userCounter += 1;
       id = uuid("aaaa", userCounter);
@@ -100,7 +102,21 @@ function createAuthTestStub() {
       roleSet.add(role);
     }
     userRoles.set(id, roleSet);
+    const accessSet = new Set(Array.isArray(ds) ? ds : []);
+    dataSourceAccess.set(id, accessSet);
     return row;
+  }
+
+  function grantDataSourceAccess(userId, dataSourceId) {
+    if (!dataSourceAccess.has(userId)) {
+      dataSourceAccess.set(userId, new Set());
+    }
+    dataSourceAccess.get(userId).add(dataSourceId);
+  }
+
+  function revokeDataSourceAccess(userId, dataSourceId) {
+    const set = dataSourceAccess.get(userId);
+    if (set) set.delete(dataSourceId);
   }
 
   function seedSession(userId, { expiresInMs = 60 * 60 * 1000 } = {}) {
@@ -206,6 +222,22 @@ function createAuthTestStub() {
       return { rowCount: 1, rows: [] };
     }
 
+    // dataSourceAccessService.hasAccess
+    if (normalized.startsWith("select 1 from user_data_source_access where user_id = $1 and data_source_id = $2")) {
+      const [userId, dataSourceId] = params;
+      const set = dataSourceAccess.get(userId);
+      const hit = set ? set.has(dataSourceId) : false;
+      return { rowCount: hit ? 1 : 0, rows: hit ? [{ "?column?": 1 }] : [] };
+    }
+
+    // dataSourceAccessService.listAccessibleDataSourceIds
+    if (normalized.startsWith("select data_source_id from user_data_source_access where user_id = $1")) {
+      const [userId] = params;
+      const set = dataSourceAccess.get(userId);
+      const ids = set ? [...set] : [];
+      return { rowCount: ids.length, rows: ids.map((id) => ({ data_source_id: id })) };
+    }
+
     return null;
   }
 
@@ -214,6 +246,8 @@ function createAuthTestStub() {
     seedUser,
     seedSession,
     revokeSession,
+    grantDataSourceAccess,
+    revokeDataSourceAccess,
     cookieFor,
     handleSql,
     ROLE_PERMISSIONS

--- a/app/test/ragNotesApi.test.js
+++ b/app/test/ragNotesApi.test.js
@@ -64,8 +64,16 @@ before(async () => {
   reindexCalls = [];
   noteCounter = 0;
   authStub = createAuthTestStub();
-  const analyst = authStub.seedUser({ email: "analyst@example.com", roles: ["analyst"] });
-  const viewer = authStub.seedUser({ email: "viewer@example.com", roles: ["viewer"] });
+  const analyst = authStub.seedUser({
+    email: "analyst@example.com",
+    roles: ["analyst"],
+    dataSourceAccess: [DATA_SOURCE_ID, OTHER_SOURCE_ID]
+  });
+  const viewer = authStub.seedUser({
+    email: "viewer@example.com",
+    roles: ["viewer"],
+    dataSourceAccess: [DATA_SOURCE_ID, OTHER_SOURCE_ID]
+  });
   analystCookie = authStub.cookieFor(authStub.seedSession(analyst.id).token);
   viewerCookie = authStub.cookieFor(authStub.seedSession(viewer.id).token);
 
@@ -124,6 +132,14 @@ before(async () => {
       };
       notes.set(id, updated);
       return { rowCount: 1, rows: [updated] };
+    }
+
+    if (normalized.startsWith("select id, data_source_id from rag_notes where id = $1")) {
+      const [id] = params;
+      const existing = notes.get(id);
+      return existing
+        ? { rowCount: 1, rows: [{ id: existing.id, data_source_id: existing.data_source_id }] }
+        : { rowCount: 0, rows: [] };
     }
 
     if (normalized.startsWith("delete from rag_notes")) {

--- a/app/test/savedQueriesApi.test.js
+++ b/app/test/savedQueriesApi.test.js
@@ -53,7 +53,11 @@ function ensureTestUser(label, role = "analyst") {
   if (testUsers[label]) {
     return testUsers[label];
   }
-  const user = authStub.seedUser({ email: `${label}@example.com`, roles: [role] });
+  const user = authStub.seedUser({
+    email: `${label}@example.com`,
+    roles: [role],
+    dataSourceAccess: [DATA_SOURCE_ID, OTHER_SOURCE_ID]
+  });
   const cookie = authStub.cookieFor(authStub.seedSession(user.id).token);
   testUsers[label] = { id: user.id, cookie, role };
   return testUsers[label];
@@ -129,6 +133,14 @@ before(async () => {
         return { rowCount: 1, rows: [{ id }] };
       }
       return { rowCount: 0, rows: [] };
+    }
+
+    if (normalized === "select data_source_id from saved_queries where id = $1") {
+      const [id] = params;
+      const row = savedQueries.get(id);
+      return row
+        ? { rowCount: 1, rows: [{ data_source_id: row.data_source_id }] }
+        : { rowCount: 0, rows: [] };
     }
 
     if (normalized.startsWith("insert into saved_queries")) {

--- a/app/test/userDataSourceAccessMigration.test.js
+++ b/app/test/userDataSourceAccessMigration.test.js
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+test("0016_user_data_source_access creates the membership table and backfills non-admin users", () => {
+  const migrationPath = path.resolve(__dirname, "../../db/migrations/0016_user_data_source_access.sql");
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS user_data_source_access/i);
+  assert.match(sql, /user_id UUID NOT NULL REFERENCES users\(id\) ON DELETE CASCADE/i);
+  assert.match(sql, /data_source_id UUID NOT NULL REFERENCES data_sources\(id\) ON DELETE CASCADE/i);
+  assert.match(sql, /granted_by_user_id UUID REFERENCES users\(id\) ON DELETE SET NULL/i);
+  assert.match(sql, /PRIMARY KEY \(user_id, data_source_id\)/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_user_data_source_access_data_source/i);
+
+  // Backfill: every non-admin gets every existing source
+  assert.match(sql, /INSERT INTO user_data_source_access \(user_id, data_source_id\)/i);
+  assert.match(sql, /FROM users u\s+CROSS JOIN data_sources ds/i);
+  assert.match(sql, /lower\(r\.name\) = 'admin'/i);
+  assert.match(sql, /ON CONFLICT DO NOTHING/i);
+});

--- a/db/migrations/0016_user_data_source_access.sql
+++ b/db/migrations/0016_user_data_source_access.sql
@@ -1,0 +1,31 @@
+-- AUTH-005: per-resource permissions. Non-admin users can only act on data
+-- sources they have been explicitly granted access to. Admins bypass this
+-- table at the service layer.
+--
+-- The seed below backfills full access for every existing non-admin user, so
+-- the day-one behavior of this migration is identical to AUTH-004. New users
+-- created after this migration receive no data-source access by default and
+-- must be granted by an admin via /v1/admin/data-sources/{id}/access.
+
+CREATE TABLE IF NOT EXISTS user_data_source_access (
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  data_source_id UUID NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  granted_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  PRIMARY KEY (user_id, data_source_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_data_source_access_data_source
+  ON user_data_source_access (data_source_id);
+
+INSERT INTO user_data_source_access (user_id, data_source_id)
+SELECT u.id, ds.id
+FROM users u
+CROSS JOIN data_sources ds
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM user_roles ur
+  JOIN roles r ON r.id = ur.role_id
+  WHERE ur.user_id = u.id AND lower(r.name) = 'admin'
+)
+ON CONFLICT DO NOTHING;

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -108,6 +108,96 @@ paths:
           description: Forbidden
         "409":
           description: Email already exists
+  /v1/admin/data-sources/{dataSourceId}/access:
+    get:
+      tags: [Admin]
+      summary: List users granted access to a data source
+      description: Requires the `admin` role. Admins implicitly access every data source; this endpoint returns only the explicit grants in `user_data_source_access`.
+      parameters:
+        - in: path
+          name: dataSourceId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List of granted users
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataSourceAccessListResponse"
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+        "404":
+          description: Data source not found
+    post:
+      tags: [Admin]
+      summary: Grant a user access to a data source
+      description: Requires the `admin` role. Idempotent; re-granting an existing access returns 200 with `granted=false`.
+      parameters:
+        - in: path
+          name: dataSourceId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GrantDataSourceAccessRequest"
+      responses:
+        "201":
+          description: Access newly granted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataSourceAccessChange"
+        "200":
+          description: Access already granted (no-op)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataSourceAccessChange"
+        "400":
+          description: Invalid input
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+        "404":
+          description: Data source or user not found
+  /v1/admin/data-sources/{dataSourceId}/access/{userId}:
+    delete:
+      tags: [Admin]
+      summary: Revoke a user's access to a data source
+      description: Requires the `admin` role.
+      parameters:
+        - in: path
+          name: dataSourceId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Access revoked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataSourceAccessChange"
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+        "404":
+          description: No access grant to revoke
   /v1/admin/users/{userId}/roles:
     post:
       tags: [Admin]
@@ -1225,6 +1315,52 @@ components:
           type: array
           items:
             type: string
+    DataSourceAccessGrant:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        is_active:
+          type: boolean
+        granted_at:
+          type: string
+          format: date-time
+        granted_by_user_id:
+          type: string
+          nullable: true
+        roles:
+          type: array
+          items:
+            type: string
+    DataSourceAccessListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/DataSourceAccessGrant"
+    GrantDataSourceAccessRequest:
+      type: object
+      required: [user_id]
+      properties:
+        user_id:
+          type: string
+    DataSourceAccessChange:
+      type: object
+      properties:
+        granted:
+          type: boolean
+        revoked:
+          type: boolean
+        user_id:
+          type: string
+        data_source_id:
+          type: string
     UpdateUserRolesResponse:
       type: object
       properties:

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -255,6 +255,197 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/data-sources/{dataSourceId}/access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List users granted access to a data source
+         * @description Requires the `admin` role. Admins implicitly access every data source; this endpoint returns only the explicit grants in `user_data_source_access`.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    dataSourceId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List of granted users */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["DataSourceAccessListResponse"];
+                    };
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Data source not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Grant a user access to a data source
+         * @description Requires the `admin` role. Idempotent; re-granting an existing access returns 200 with `granted=false`.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    dataSourceId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["GrantDataSourceAccessRequest"];
+                };
+            };
+            responses: {
+                /** @description Access already granted (no-op) */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["DataSourceAccessChange"];
+                    };
+                };
+                /** @description Access newly granted */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["DataSourceAccessChange"];
+                    };
+                };
+                /** @description Invalid input */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Data source or user not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/data-sources/{dataSourceId}/access/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Revoke a user's access to a data source
+         * @description Requires the `admin` role.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    dataSourceId: string;
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Access revoked */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["DataSourceAccessChange"];
+                    };
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description No access grant to revoke */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/users/{userId}/roles": {
         parameters: {
             query?: never;
@@ -2075,6 +2266,28 @@ export interface components {
         UpdateUserRolesRequest: {
             assign?: string[];
             revoke?: string[];
+        };
+        DataSourceAccessGrant: {
+            id?: string;
+            email?: string;
+            display_name?: string | null;
+            is_active?: boolean;
+            /** Format: date-time */
+            granted_at?: string;
+            granted_by_user_id?: string | null;
+            roles?: string[];
+        };
+        DataSourceAccessListResponse: {
+            items?: components["schemas"]["DataSourceAccessGrant"][];
+        };
+        GrantDataSourceAccessRequest: {
+            user_id: string;
+        };
+        DataSourceAccessChange: {
+            granted?: boolean;
+            revoked?: boolean;
+            user_id?: string;
+            data_source_id?: string;
         };
         UpdateUserRolesResponse: {
             user?: components["schemas"]["AdminUser"];


### PR DESCRIPTION
Closes #25 — AUTH-005. Builds on AUTH-001..004.

## Summary
- New `user_data_source_access` table: non-admin callers can only act on a data source after an explicit grant. Admins bypass at the service layer.
- The migration backfills full access for every existing non-admin user, so day-one behavior matches AUTH-004 — new users created after this migration receive no data-source access by default and need explicit grants.
- `lib/authGate.enforceDataSourceAccess(req, res, dataSourceId)` is the single check called from every feature route that targets a specific data source. It emits a `deny_resource_access` `authorization` event so denials show up in the same telemetry stream AUTH-003 added.
- Admin endpoints to manage grants:
  - `GET /v1/admin/data-sources/{id}/access` — list users with access (excludes implicit admin access).
  - `POST /v1/admin/data-sources/{id}/access` — idempotent grant; 201 on first grant, 200 on a no-op.
  - `DELETE /v1/admin/data-sources/{id}/access/{userId}` — revoke; 404 if no grant exists.
- Both grant and revoke write to `auth_audit_log` (`data_source.access.granted` / `data_source.access.revoked`).

## Where the scope check fires
- **Data sources**: `GET /v1/data-sources` is filtered to the accessible set (admin sees all). `POST .../introspect`, `POST .../import-schema`, `GET .../export` all enforce.
- **Schema**: `GET /v1/schema-objects?data_source_id=…` and `PATCH /v1/schema-objects/{id}` (derives the source from the object row).
- **Semantic**: entity / metric-definition / join-policy upserts.
- **Query**: `POST /v1/query/sessions`, run/feedback/export endpoints (derived from `query_sessions.data_source_id`), and prompt history list (filtered post-hoc when no `data_source_id` is pinned).
- **Saved queries**: every CRUD endpoint plus `/run` and `/validate-params` (derived from the row), with `GET /v1/saved-queries` filtered post-hoc.
- **RAG**: list / upsert / delete (delete derives from the note) and `POST /v1/rag/reindex`.

## Acceptance criteria
- [x] **User can only view/run against assigned data sources.** — `enforceDataSourceAccess` is called on every endpoint that targets a specific source; the lists are filtered to the accessible set.
- [x] **Cross-source access attempts are denied with 403.** — Verified in `dataSourceAccessApi.test.js` across data-source / schema / semantic / query / saved-queries / rag endpoints.
- [x] **Admin can grant/revoke source access.** — `POST` / `DELETE /v1/admin/data-sources/{id}/access/...` plus an admin-bypass test that confirms admins reach the same endpoints without an explicit grant.

## Test plan
- [x] `DATABASE_URL=postgresql://test:test@localhost:5432/test npm test` → 85/85 passing (6 new in this PR: migration shape, cross-source 403 matrix, admin bypass, list filtering, admin grant+revoke+audit, admin endpoints denied for non-admins).
- [x] `npm --prefix frontend run lint` clean.
- [x] `npm --prefix frontend run build` clean.
- [ ] Manual: run `npm run migrate` (applies 0016 and backfills existing non-admin users), seed a new analyst with `scripts/create-user.js --role analyst --email new@example.com --password '…'` and confirm they get 403 on `/v1/schema-objects?data_source_id=<any existing source>` until you `curl -X POST -H 'Cookie: rp_session=…' http://localhost:8080/v1/admin/data-sources/<id>/access -d '{"user_id":"<new user id>"}'`.

## Notes
- The frontend does NOT yet have an admin UI for granting / revoking. The endpoints are usable via `curl` and the audit log captures every change. A management UI lands as part of the broader admin work (AUTH-014 / future ticket).
- Sessions and orchestrations don't include `dataSourceId` in their inputs; the enforcement always derives it from the persisted row. This keeps the API stable while making the check robust to spoofing.
- The list-filtering pattern uses an `ANY($1::uuid[])` clause when the caller has a finite accessible set, and no filter for admins. Empty access → empty list.