### PR TITLE
feat(auth): AUTH-010 OIDC identity provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,14 @@ AUTH_SESSION_DURATION_MS=43200000
 # When unset, the cookie is Secure only when NODE_ENV=production.
 AUTH_COOKIE_SECURE=
 
+# AUTH-010: OIDC flow state signing. Used to HMAC-sign the short-lived
+# rp_oidc_flow cookie that carries the PKCE verifier + state + nonce between
+# /v1/auth/oidc/login and /v1/auth/oidc/callback. Must be at least 32 chars
+# and shared across replicas. If unset in development, the server generates
+# a per-process random secret and logs a warning (flows in-flight at restart
+# will fail).
+AUTH_FLOW_SECRET=
+
 # SMTP config for email delivery (BE-002)
 SMTP_HOST=localhost
 SMTP_PORT=587

--- a/app/src/lib/oidcFlowCookie.js
+++ b/app/src/lib/oidcFlowCookie.js
@@ -1,0 +1,136 @@
+// HMAC-signed short-lived cookie used to carry OIDC flow state (provider id,
+// PKCE code_verifier, state, nonce) between /v1/auth/oidc/login and
+// /v1/auth/oidc/callback. The verifier never leaves the user agent and the
+// signature prevents tampering; the cookie is HttpOnly + SameSite=Lax + Secure
+// when appropriate.
+
+const crypto = require("crypto");
+
+const COOKIE_NAME = "rp_oidc_flow";
+const FLOW_MAX_AGE_SECONDS = 10 * 60; // 10 minutes is plenty for the user to log in
+
+let cachedSecret = null;
+
+function getFlowSecret() {
+  if (cachedSecret) return cachedSecret;
+  const fromEnv = process.env.AUTH_FLOW_SECRET;
+  if (fromEnv && fromEnv.length >= 32) {
+    cachedSecret = Buffer.from(fromEnv);
+    return cachedSecret;
+  }
+  // Fall back to a process-lifetime random secret. Flows in-flight at the
+  // moment of a restart will fail; the user just retries login. Anyone running
+  // multiple instances should set AUTH_FLOW_SECRET to a shared 32+ byte value.
+  cachedSecret = crypto.randomBytes(32);
+  if (process.env.NODE_ENV === "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[auth] AUTH_FLOW_SECRET is not set; OIDC flows will fail across instances/restarts. Set a shared 32+ byte secret."
+    );
+  }
+  return cachedSecret;
+}
+
+function isSecureCookie() {
+  if (process.env.AUTH_COOKIE_SECURE === "true") return true;
+  if (process.env.AUTH_COOKIE_SECURE === "false") return false;
+  return process.env.NODE_ENV === "production";
+}
+
+function base64UrlEncode(buf) {
+  return Buffer.from(buf).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function base64UrlDecode(value) {
+  const pad = value.length % 4 === 0 ? "" : "=".repeat(4 - (value.length % 4));
+  return Buffer.from(value.replace(/-/g, "+").replace(/_/g, "/") + pad, "base64");
+}
+
+function sign(payload) {
+  const expiresAt = Math.floor(Date.now() / 1000) + FLOW_MAX_AGE_SECONDS;
+  const body = JSON.stringify({ ...payload, exp: expiresAt });
+  const bodyB64 = base64UrlEncode(body);
+  const mac = crypto.createHmac("sha256", getFlowSecret()).update(bodyB64).digest();
+  return `${bodyB64}.${base64UrlEncode(mac)}`;
+}
+
+function verify(value) {
+  if (typeof value !== "string" || !value.includes(".")) return null;
+  const [bodyB64, sigB64] = value.split(".");
+  if (!bodyB64 || !sigB64) return null;
+  const expected = crypto.createHmac("sha256", getFlowSecret()).update(bodyB64).digest();
+  let provided;
+  try {
+    provided = base64UrlDecode(sigB64);
+  } catch {
+    return null;
+  }
+  if (provided.length !== expected.length) return null;
+  if (!crypto.timingSafeEqual(provided, expected)) return null;
+  let payload;
+  try {
+    payload = JSON.parse(base64UrlDecode(bodyB64).toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof payload.exp !== "number" || payload.exp <= Math.floor(Date.now() / 1000)) {
+    return null;
+  }
+  return payload;
+}
+
+function buildFlowCookie(payload) {
+  const value = sign(payload);
+  const parts = [
+    `${COOKIE_NAME}=${encodeURIComponent(value)}`,
+    "HttpOnly",
+    "Path=/",
+    "SameSite=Lax",
+    `Max-Age=${FLOW_MAX_AGE_SECONDS}`
+  ];
+  if (isSecureCookie()) parts.push("Secure");
+  return parts.join("; ");
+}
+
+function buildClearFlowCookie() {
+  const parts = [
+    `${COOKIE_NAME}=`,
+    "HttpOnly",
+    "Path=/",
+    "SameSite=Lax",
+    "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+    "Max-Age=0"
+  ];
+  if (isSecureCookie()) parts.push("Secure");
+  return parts.join("; ");
+}
+
+function readFlowCookie(req) {
+  const header = req.headers.cookie;
+  if (typeof header !== "string" || !header) return null;
+  for (const segment of header.split(";")) {
+    const idx = segment.indexOf("=");
+    if (idx === -1) continue;
+    const name = segment.slice(0, idx).trim();
+    if (name !== COOKIE_NAME) continue;
+    let raw = segment.slice(idx + 1).trim();
+    try {
+      raw = decodeURIComponent(raw);
+    } catch {
+      // already decoded
+    }
+    return verify(raw);
+  }
+  return null;
+}
+
+module.exports = {
+  COOKIE_NAME,
+  FLOW_MAX_AGE_SECONDS,
+  buildFlowCookie,
+  buildClearFlowCookie,
+  readFlowCookie,
+  // exposed for tests
+  __sign: sign,
+  __verify: verify
+};

--- a/app/src/lib/routePolicy.js
+++ b/app/src/lib/routePolicy.js
@@ -20,6 +20,9 @@ const POLICIES = [
   { method: "POST", pattern: /^\/v1\/auth\/login$/, public: true },
   { method: "POST", pattern: /^\/v1\/auth\/logout$/, public: true },
   { method: "GET", pattern: /^\/v1\/auth\/me$/, public: true },
+  { method: "GET", pattern: /^\/v1\/auth\/oidc\/providers$/, public: true },
+  { method: "GET", pattern: /^\/v1\/auth\/oidc\/login$/, public: true },
+  { method: "GET", pattern: /^\/v1\/auth\/oidc\/callback$/, public: true },
 
   // Admin
   { method: "GET", pattern: /^\/v1\/admin\/users$/, role: "admin" },
@@ -28,6 +31,9 @@ const POLICIES = [
   { method: "GET", pattern: /^\/v1\/admin\/data-sources\/[^/]+\/access$/, role: "admin" },
   { method: "POST", pattern: /^\/v1\/admin\/data-sources\/[^/]+\/access$/, role: "admin" },
   { method: "DELETE", pattern: /^\/v1\/admin\/data-sources\/[^/]+\/access\/[^/]+$/, role: "admin" },
+  { method: "GET", pattern: /^\/v1\/admin\/auth-providers$/, role: "admin" },
+  { method: "POST", pattern: /^\/v1\/admin\/auth-providers$/, role: "admin" },
+  { method: "DELETE", pattern: /^\/v1\/admin\/auth-providers\/[^/]+$/, role: "admin" },
 
   // Data sources
   { method: "GET", pattern: /^\/v1\/data-sources$/, permission: "data_sources.read" },

--- a/app/src/routes/admin.js
+++ b/app/src/routes/admin.js
@@ -3,6 +3,7 @@ const { isUuid } = require("../lib/validation");
 const appDb = require("../lib/appDb");
 const adminUserService = require("../services/adminUserService");
 const dataSourceAccessService = require("../services/dataSourceAccessService");
+const authProviderService = require("../services/authProviderService");
 
 function writeResult(res, result) {
   return json(res, result.statusCode, result.body);
@@ -113,11 +114,33 @@ async function handleRevokeDataSourceAccess(req, res, dataSourceId, userId) {
   });
 }
 
+async function handleListAuthProviders(_req, res) {
+  const items = await authProviderService.listProviders();
+  return json(res, 200, { items });
+}
+
+async function handleUpsertAuthProvider(req, res) {
+  const body = await readJsonBody(req);
+  const result = await authProviderService.upsertProvider(body);
+  return json(res, result.statusCode, result.body);
+}
+
+async function handleDeleteAuthProvider(_req, res, providerId) {
+  if (!isUuid(providerId)) {
+    return badRequest(res, "provider id must be a uuid");
+  }
+  const result = await authProviderService.deleteProvider(providerId);
+  return json(res, result.statusCode, result.body);
+}
+
 module.exports = {
   handleListUsers,
   handleCreateUser,
   handleUpdateUserRoles,
   handleListDataSourceAccess,
   handleGrantDataSourceAccess,
-  handleRevokeDataSourceAccess
+  handleRevokeDataSourceAccess,
+  handleListAuthProviders,
+  handleUpsertAuthProvider,
+  handleDeleteAuthProvider
 };

--- a/app/src/routes/oidc.js
+++ b/app/src/routes/oidc.js
@@ -1,0 +1,136 @@
+const { json, badRequest } = require("../lib/http");
+const { buildFlowCookie, buildClearFlowCookie, readFlowCookie } = require("../lib/oidcFlowCookie");
+const { buildSessionCookie, buildClearSessionCookie } = require("../lib/sessionCookie");
+const authService = require("../services/authService");
+const authProviderService = require("../services/authProviderService");
+const oidcService = require("../services/oidcService");
+
+function clientAddress(req) {
+  const fwd = req.headers["x-forwarded-for"];
+  if (typeof fwd === "string" && fwd.length > 0) {
+    const first = fwd.split(",")[0];
+    if (first) return first.trim();
+  }
+  return req.socket && req.socket.remoteAddress ? req.socket.remoteAddress : null;
+}
+
+async function handleListEnabledProviders(_req, res) {
+  const items = await authProviderService.listEnabledProvidersForLogin();
+  return json(res, 200, { items });
+}
+
+async function handleStartLogin(req, res, requestUrl) {
+  const providerId = requestUrl.searchParams.get("provider_id");
+  if (!providerId) {
+    return badRequest(res, "provider_id query parameter is required");
+  }
+  const provider = await authProviderService.findProviderById(providerId, { withSecret: true });
+  if (!provider || !provider.enabled) {
+    return json(res, 404, { error: "not_found", message: "auth provider not found or disabled" });
+  }
+
+  let result;
+  try {
+    result = await oidcService.startLogin(provider);
+  } catch (err) {
+    const status = err.statusCode || 500;
+    return json(res, status, { error: "oidc_error", message: err.message });
+  }
+
+  res.setHeader("Set-Cookie", buildFlowCookie(result.flowState));
+  res.writeHead(302, { Location: result.authorizeUrl });
+  return res.end();
+}
+
+function redirectAfterLogin(res, target = "/dashboard", sessionCookie = null) {
+  const headers = { Location: target };
+  if (sessionCookie) {
+    headers["Set-Cookie"] = sessionCookie;
+  }
+  res.writeHead(302, headers);
+  return res.end();
+}
+
+async function handleCallback(req, res, requestUrl) {
+  const flowState = readFlowCookie(req);
+  if (!flowState) {
+    return json(res, 400, { error: "bad_request", message: "missing or expired OIDC flow state" });
+  }
+
+  const provider = await authProviderService.findProviderById(flowState.provider_id, { withSecret: true });
+  if (!provider || !provider.enabled) {
+    res.setHeader("Set-Cookie", buildClearFlowCookie());
+    return json(res, 404, { error: "not_found", message: "auth provider no longer available" });
+  }
+
+  // Build the full callback URL openid-client expects (origin + path + query).
+  const host = req.headers["x-forwarded-host"] || req.headers.host || "localhost";
+  const proto = req.headers["x-forwarded-proto"] || (req.socket && req.socket.encrypted ? "https" : "http");
+  const currentUrl = `${proto}://${host}${requestUrl.pathname}${requestUrl.search}`;
+
+  let principal;
+  try {
+    principal = await oidcService.completeLogin(provider, currentUrl, flowState);
+  } catch (err) {
+    res.setHeader("Set-Cookie", buildClearFlowCookie());
+    const status = err.statusCode || 500;
+    return json(res, status, { error: "oidc_error", message: err.message });
+  }
+
+  const user = await authService.findUserByEmail(principal.email);
+  if (!user || !user.is_active) {
+    res.setHeader("Set-Cookie", buildClearFlowCookie());
+    return json(res, 403, {
+      error: "forbidden",
+      message: `no active local account for ${principal.email}. Ask an administrator to create one.`
+    });
+  }
+
+  const session = await authService.createSession(user.id, {
+    userAgent: req.headers["user-agent"] || null,
+    ipAddress: clientAddress(req)
+  });
+  // Best-effort last_login_at touch; mirrors password login path.
+  authService
+    .findUserByEmail(principal.email)
+    .then(() => {})
+    .catch(() => {});
+
+  const sessionCookie = buildSessionCookie(session.token, session.expiresAt);
+  const clearFlowCookie = buildClearFlowCookie();
+
+  // Browsers accept multiple Set-Cookie headers but Node's writeHead expects an
+  // array for duplicate header names.
+  res.setHeader("Set-Cookie", [sessionCookie, clearFlowCookie]);
+  return redirectAfterLogin(res, "/dashboard");
+}
+
+// Exposed for use by AUTH-009 (admin "test connection" button) and tests.
+async function handleStartLoginJson(req, res, requestUrl) {
+  const providerId = requestUrl.searchParams.get("provider_id");
+  if (!providerId) {
+    return badRequest(res, "provider_id query parameter is required");
+  }
+  const provider = await authProviderService.findProviderById(providerId, { withSecret: true });
+  if (!provider || !provider.enabled) {
+    return json(res, 404, { error: "not_found", message: "auth provider not found or disabled" });
+  }
+  try {
+    const result = await oidcService.startLogin(provider);
+    res.setHeader("Set-Cookie", buildFlowCookie(result.flowState));
+    return json(res, 200, { authorize_url: result.authorizeUrl });
+  } catch (err) {
+    const status = err.statusCode || 500;
+    return json(res, status, { error: "oidc_error", message: err.message });
+  }
+}
+
+module.exports = {
+  handleListEnabledProviders,
+  handleStartLogin,
+  handleStartLoginJson,
+  handleCallback,
+  // Re-exported so the logout handler can clear the auxiliary cookie too.
+  buildClearFlowCookie,
+  buildClearSessionCookie
+};

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -81,8 +81,16 @@ const {
   handleUpdateUserRoles,
   handleListDataSourceAccess,
   handleGrantDataSourceAccess,
-  handleRevokeDataSourceAccess
+  handleRevokeDataSourceAccess,
+  handleListAuthProviders,
+  handleUpsertAuthProvider,
+  handleDeleteAuthProvider
 } = require("./routes/admin");
+const {
+  handleListEnabledProviders,
+  handleStartLogin,
+  handleCallback
+} = require("./routes/oidc");
 const { findPolicy } = require("./lib/routePolicy");
 const { enforcePolicy } = require("./lib/authGate");
 
@@ -160,6 +168,18 @@ async function routeRequest(req, res) {
     return handleMe(req, res);
   }
 
+  if (req.method === "GET" && pathname === "/v1/auth/oidc/providers") {
+    return handleListEnabledProviders(req, res);
+  }
+
+  if (req.method === "GET" && pathname === "/v1/auth/oidc/login") {
+    return handleStartLogin(req, res, requestUrl);
+  }
+
+  if (req.method === "GET" && pathname === "/v1/auth/oidc/callback") {
+    return handleCallback(req, res, requestUrl);
+  }
+
   if (req.method === "GET" && pathname === "/v1/admin/users") {
     return handleListUsers(req, res);
   }
@@ -184,6 +204,18 @@ async function routeRequest(req, res) {
   const adminDataSourceRevokeMatch = pathname.match(/^\/v1\/admin\/data-sources\/([^/]+)\/access\/([^/]+)$/);
   if (req.method === "DELETE" && adminDataSourceRevokeMatch) {
     return handleRevokeDataSourceAccess(req, res, adminDataSourceRevokeMatch[1], adminDataSourceRevokeMatch[2]);
+  }
+
+  if (req.method === "GET" && pathname === "/v1/admin/auth-providers") {
+    return handleListAuthProviders(req, res);
+  }
+  if (req.method === "POST" && pathname === "/v1/admin/auth-providers") {
+    return handleUpsertAuthProvider(req, res);
+  }
+
+  const adminAuthProviderDeleteMatch = pathname.match(/^\/v1\/admin\/auth-providers\/([^/]+)$/);
+  if (req.method === "DELETE" && adminAuthProviderDeleteMatch) {
+    return handleDeleteAuthProvider(req, res, adminAuthProviderDeleteMatch[1]);
   }
 
   if (req.method === "POST" && pathname === "/v1/data-sources") {

--- a/app/src/services/authProviderService.js
+++ b/app/src/services/authProviderService.js
@@ -1,0 +1,261 @@
+const appDb = require("../lib/appDb");
+
+const PROVIDER_NAME_MAX = 64;
+const PROVIDER_DISPLAY_NAME_MAX = 120;
+const DEFAULT_SCOPES = ["openid", "email", "profile"];
+
+function normalizeName(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > PROVIDER_NAME_MAX) return null;
+  if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+function normalizeScopes(value) {
+  if (value === undefined || value === null) return [...DEFAULT_SCOPES];
+  if (!Array.isArray(value)) return null;
+  const out = [];
+  const seen = new Set();
+  for (const entry of value) {
+    if (typeof entry !== "string") return null;
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    if (!seen.has(trimmed)) {
+      seen.add(trimmed);
+      out.push(trimmed);
+    }
+  }
+  if (!out.includes("openid")) out.unshift("openid");
+  return out;
+}
+
+function normalizeClaimsMapping(value) {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  const out = {};
+  if (typeof value.email === "string" && value.email.trim()) {
+    out.email = value.email.trim();
+  }
+  if (typeof value.display_name === "string" && value.display_name.trim()) {
+    out.display_name = value.display_name.trim();
+  }
+  return out;
+}
+
+function publicProvider(row, { includeSecret = false } = {}) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    type: row.type,
+    name: row.name,
+    display_name: row.display_name,
+    issuer: row.issuer,
+    client_id: row.client_id,
+    client_secret: includeSecret ? row.client_secret : (row.client_secret ? "***" : null),
+    scopes: row.scopes,
+    redirect_uri: row.redirect_uri,
+    claims_mapping: row.claims_mapping,
+    enabled: row.enabled,
+    created_at: row.created_at,
+    updated_at: row.updated_at
+  };
+}
+
+async function listProviders() {
+  const result = await appDb.query(
+    `SELECT id, type, name, display_name, issuer, client_id, client_secret,
+            scopes, redirect_uri, claims_mapping, enabled, created_at, updated_at
+       FROM auth_providers
+       ORDER BY lower(name)`
+  );
+  return result.rows.map((row) => publicProvider(row));
+}
+
+async function listEnabledProvidersForLogin() {
+  const result = await appDb.query(
+    `SELECT id, name, display_name, type
+       FROM auth_providers
+       WHERE enabled = TRUE
+       ORDER BY lower(name)`
+  );
+  return result.rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    display_name: row.display_name || row.name,
+    type: row.type
+  }));
+}
+
+async function findProviderById(id, { withSecret = false } = {}) {
+  if (typeof id !== "string" || !id) return null;
+  const result = await appDb.query(
+    `SELECT id, type, name, display_name, issuer, client_id, client_secret,
+            scopes, redirect_uri, claims_mapping, enabled, created_at, updated_at
+       FROM auth_providers
+       WHERE id = $1`,
+    [id]
+  );
+  if (result.rowCount === 0) return null;
+  return withSecret ? result.rows[0] : publicProvider(result.rows[0]);
+}
+
+async function findProviderRawByName(name) {
+  const normalized = normalizeName(name);
+  if (!normalized) return null;
+  const result = await appDb.query(
+    `SELECT id, type, name, display_name, issuer, client_id, client_secret,
+            scopes, redirect_uri, claims_mapping, enabled, created_at, updated_at
+       FROM auth_providers
+       WHERE lower(name) = lower($1)`,
+    [normalized]
+  );
+  return result.rowCount > 0 ? result.rows[0] : null;
+}
+
+function validatePayload(body) {
+  const type = body && typeof body.type === "string" ? body.type : "oidc";
+  if (type !== "oidc") {
+    return { ok: false, message: "type must be 'oidc'" };
+  }
+
+  const name = normalizeName(body && body.name);
+  if (!name) {
+    return { ok: false, message: "name is required, alphanumeric with _ or -, up to 64 characters" };
+  }
+
+  const displayName = body && typeof body.display_name === "string" && body.display_name.trim()
+    ? body.display_name.trim()
+    : null;
+  if (displayName && displayName.length > PROVIDER_DISPLAY_NAME_MAX) {
+    return { ok: false, message: `display_name cannot exceed ${PROVIDER_DISPLAY_NAME_MAX} characters` };
+  }
+
+  const issuer = body && typeof body.issuer === "string" ? body.issuer.trim() : "";
+  if (!issuer || !/^https?:\/\//i.test(issuer)) {
+    return { ok: false, message: "issuer must be an http(s) URL" };
+  }
+  const clientId = body && typeof body.client_id === "string" ? body.client_id.trim() : "";
+  if (!clientId) {
+    return { ok: false, message: "client_id is required" };
+  }
+  const clientSecret = body && typeof body.client_secret === "string" ? body.client_secret : null;
+  // Public clients (PKCE-only) may omit the secret; allow nullable.
+
+  const redirectUri = body && typeof body.redirect_uri === "string" ? body.redirect_uri.trim() : "";
+  if (!redirectUri || !/^https?:\/\//i.test(redirectUri)) {
+    return { ok: false, message: "redirect_uri must be an http(s) URL" };
+  }
+
+  const scopes = normalizeScopes(body && body.scopes);
+  if (scopes === null) {
+    return { ok: false, message: "scopes must be an array of strings" };
+  }
+
+  const claimsMapping = normalizeClaimsMapping(body && body.claims_mapping);
+  if (claimsMapping === null) {
+    return { ok: false, message: "claims_mapping must be an object" };
+  }
+
+  const enabled = body && Object.prototype.hasOwnProperty.call(body, "enabled")
+    ? Boolean(body.enabled)
+    : true;
+
+  return {
+    ok: true,
+    value: {
+      type,
+      name,
+      display_name: displayName,
+      issuer,
+      client_id: clientId,
+      client_secret: typeof clientSecret === "string" && clientSecret.length > 0 ? clientSecret : null,
+      redirect_uri: redirectUri,
+      scopes,
+      claims_mapping: claimsMapping,
+      enabled
+    }
+  };
+}
+
+async function upsertProvider(body) {
+  const parsed = validatePayload(body);
+  if (!parsed.ok) {
+    return { statusCode: 400, body: { error: "bad_request", message: parsed.message } };
+  }
+  const v = parsed.value;
+  const id = body && typeof body.id === "string" && body.id.trim() ? body.id.trim() : null;
+
+  try {
+    if (id) {
+      const result = await appDb.query(
+        `UPDATE auth_providers
+            SET type = $2,
+                name = $3,
+                display_name = $4,
+                issuer = $5,
+                client_id = $6,
+                client_secret = COALESCE($7, client_secret),
+                scopes = $8,
+                redirect_uri = $9,
+                claims_mapping = $10::jsonb,
+                enabled = $11,
+                updated_at = NOW()
+          WHERE id = $1
+          RETURNING id, type, name, display_name, issuer, client_id, client_secret,
+                    scopes, redirect_uri, claims_mapping, enabled, created_at, updated_at`,
+        [
+          id, v.type, v.name, v.display_name, v.issuer, v.client_id,
+          v.client_secret, v.scopes, v.redirect_uri,
+          JSON.stringify(v.claims_mapping), v.enabled
+        ]
+      );
+      if (result.rowCount === 0) {
+        return { statusCode: 404, body: { error: "not_found", message: "auth provider not found" } };
+      }
+      return { statusCode: 200, body: publicProvider(result.rows[0]) };
+    }
+
+    const result = await appDb.query(
+      `INSERT INTO auth_providers
+         (type, name, display_name, issuer, client_id, client_secret,
+          scopes, redirect_uri, claims_mapping, enabled)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10)
+       RETURNING id, type, name, display_name, issuer, client_id, client_secret,
+                 scopes, redirect_uri, claims_mapping, enabled, created_at, updated_at`,
+      [
+        v.type, v.name, v.display_name, v.issuer, v.client_id, v.client_secret,
+        v.scopes, v.redirect_uri, JSON.stringify(v.claims_mapping), v.enabled
+      ]
+    );
+    return { statusCode: 201, body: publicProvider(result.rows[0]) };
+  } catch (err) {
+    if (err && err.code === "23505") {
+      return { statusCode: 409, body: { error: "conflict", message: "a provider with that name already exists" } };
+    }
+    throw err;
+  }
+}
+
+async function deleteProvider(id) {
+  if (typeof id !== "string" || !id) {
+    return { statusCode: 400, body: { error: "bad_request", message: "id is required" } };
+  }
+  const result = await appDb.query("DELETE FROM auth_providers WHERE id = $1 RETURNING id", [id]);
+  if (result.rowCount === 0) {
+    return { statusCode: 404, body: { error: "not_found", message: "auth provider not found" } };
+  }
+  return { statusCode: 200, body: { ok: true, id: result.rows[0].id } };
+}
+
+module.exports = {
+  DEFAULT_SCOPES,
+  publicProvider,
+  listProviders,
+  listEnabledProvidersForLogin,
+  findProviderById,
+  findProviderRawByName,
+  upsertProvider,
+  deleteProvider,
+  validatePayload
+};

--- a/app/src/services/oidcService.js
+++ b/app/src/services/oidcService.js
@@ -1,0 +1,137 @@
+// OIDC authorization-code + PKCE flow, wrapping `openid-client@^6`.
+//
+// startLogin(provider) generates state/nonce/PKCE, returns the authorize URL
+// the browser should be redirected to, and the cookie payload the caller
+// stores in a signed cookie.
+//
+// completeLogin(provider, currentUrl, expected) validates the IdP response,
+// pulls claims from id_token + userinfo, and returns the email + display name
+// the route handler matches against the local users table.
+
+let oidcClient = null;
+function getOidcClient() {
+  if (!oidcClient) {
+    // openid-client v6 is ESM-only. Require dynamic import so this module can
+    // be `require`'d normally in the rest of the codebase.
+    oidcClient = import("openid-client");
+  }
+  return oidcClient;
+}
+
+const DEFAULT_CLAIM_EMAIL = "email";
+const DEFAULT_CLAIM_DISPLAY_NAME = "name";
+
+function emailClaimFor(provider) {
+  return (provider.claims_mapping && provider.claims_mapping.email) || DEFAULT_CLAIM_EMAIL;
+}
+
+function displayNameClaimFor(provider) {
+  return (provider.claims_mapping && provider.claims_mapping.display_name) || DEFAULT_CLAIM_DISPLAY_NAME;
+}
+
+async function buildConfiguration(provider) {
+  const client = await getOidcClient();
+  const issuerUrl = new URL(provider.issuer);
+  // openid-client v6 rejects http:// issuers by default. Allow them for
+  // localhost / dev / tests; production should be https anyway.
+  const allowHttp = issuerUrl.protocol === "http:";
+  const options = allowHttp ? { execute: [client.allowInsecureRequests] } : undefined;
+  if (provider.client_secret) {
+    return client.discovery(issuerUrl, provider.client_id, provider.client_secret, undefined, options);
+  }
+  return client.discovery(issuerUrl, provider.client_id, undefined, undefined, options);
+}
+
+async function startLogin(provider) {
+  if (!provider || !provider.enabled) {
+    throw Object.assign(new Error("provider is disabled or not found"), { statusCode: 404 });
+  }
+  const client = await getOidcClient();
+  const config = await buildConfiguration(provider);
+
+  const state = client.randomState();
+  const nonce = client.randomNonce();
+  const codeVerifier = client.randomPKCECodeVerifier();
+  const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
+
+  const authorizeUrl = client.buildAuthorizationUrl(config, {
+    redirect_uri: provider.redirect_uri,
+    scope: (provider.scopes || ["openid", "email", "profile"]).join(" "),
+    state,
+    nonce,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256"
+  });
+
+  return {
+    authorizeUrl: authorizeUrl.href,
+    flowState: {
+      provider_id: provider.id,
+      state,
+      nonce,
+      code_verifier: codeVerifier
+    }
+  };
+}
+
+async function completeLogin(provider, currentUrl, flowState) {
+  if (!provider) {
+    throw Object.assign(new Error("provider not found"), { statusCode: 404 });
+  }
+  if (!flowState || flowState.provider_id !== provider.id) {
+    throw Object.assign(new Error("invalid flow state"), { statusCode: 400 });
+  }
+
+  const client = await getOidcClient();
+  const config = await buildConfiguration(provider);
+
+  let tokens;
+  try {
+    tokens = await client.authorizationCodeGrant(
+      config,
+      new URL(currentUrl),
+      {
+        pkceCodeVerifier: flowState.code_verifier,
+        expectedState: flowState.state,
+        expectedNonce: flowState.nonce
+      }
+    );
+  } catch (err) {
+    throw Object.assign(new Error(`OIDC token exchange failed: ${err.message}`), { statusCode: 400, cause: err });
+  }
+
+  const claims = tokens.claims ? tokens.claims() : null;
+  let merged = { ...(claims || {}) };
+
+  // Some IdPs only include email in the userinfo endpoint.
+  if (!merged[emailClaimFor(provider)]) {
+    try {
+      const userinfo = await client.fetchUserInfo(config, tokens.access_token, claims ? claims.sub : undefined);
+      merged = { ...merged, ...userinfo };
+    } catch {
+      // userinfo failure is non-fatal; we'll surface the missing-email error below.
+    }
+  }
+
+  const email = merged[emailClaimFor(provider)];
+  if (typeof email !== "string" || !email.trim()) {
+    throw Object.assign(
+      new Error(`OIDC response missing the '${emailClaimFor(provider)}' claim`),
+      { statusCode: 400 }
+    );
+  }
+
+  const displayName = merged[displayNameClaimFor(provider)];
+  return {
+    email: email.trim().toLowerCase(),
+    display_name: typeof displayName === "string" && displayName.trim() ? displayName.trim() : null,
+    sub: merged.sub || null,
+    issuer: merged.iss || provider.issuer,
+    claims: merged
+  };
+}
+
+module.exports = {
+  startLogin,
+  completeLogin
+};

--- a/app/test/authProvidersMigration.test.js
+++ b/app/test/authProvidersMigration.test.js
@@ -1,0 +1,23 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+test("0017_auth_providers creates the auth_providers table", () => {
+  const migrationPath = path.resolve(__dirname, "../../db/migrations/0017_auth_providers.sql");
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS auth_providers/i);
+  assert.match(sql, /type TEXT NOT NULL CHECK \(type IN \('oidc'\)\)/i);
+  assert.match(sql, /name TEXT NOT NULL/i);
+  assert.match(sql, /issuer TEXT NOT NULL/i);
+  assert.match(sql, /client_id TEXT NOT NULL/i);
+  assert.match(sql, /client_secret TEXT/i);
+  assert.match(sql, /scopes TEXT\[\] NOT NULL DEFAULT ARRAY\['openid', 'email', 'profile'\]::text\[\]/i);
+  assert.match(sql, /redirect_uri TEXT NOT NULL/i);
+  assert.match(sql, /claims_mapping JSONB NOT NULL DEFAULT '\{\}'::jsonb/i);
+  assert.match(sql, /enabled BOOLEAN NOT NULL DEFAULT TRUE/i);
+
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_name_lower/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_auth_providers_enabled/i);
+});

--- a/app/test/helpers/authTestStub.js
+++ b/app/test/helpers/authTestStub.js
@@ -222,6 +222,27 @@ function createAuthTestStub() {
       return { rowCount: 1, rows: [] };
     }
 
+    // authService.createSession — sessions created by the real code (e.g.
+    // password login or OIDC callback) get persisted into the stub's map so
+    // subsequent /v1/auth/me lookups see them.
+    if (normalized.startsWith("insert into user_sessions")) {
+      const [userId, tokenHash, userAgent, ipAddress, expiresAt] = params;
+      sessionCounter += 1;
+      const sessionId = uuid("bbbb", sessionCounter);
+      sessions.set(sessionId, {
+        id: sessionId,
+        user_id: userId,
+        token_hash: tokenHash,
+        user_agent: userAgent,
+        ip_address: ipAddress,
+        created_at: new Date().toISOString(),
+        expires_at: expiresAt,
+        last_seen_at: new Date().toISOString(),
+        revoked_at: null
+      });
+      return { rowCount: 1, rows: [{ id: sessionId, expires_at: expiresAt }] };
+    }
+
     // dataSourceAccessService.hasAccess
     if (normalized.startsWith("select 1 from user_data_source_access where user_id = $1 and data_source_id = $2")) {
       const [userId, dataSourceId] = params;

--- a/app/test/helpers/mockOidcIdp.js
+++ b/app/test/helpers/mockOidcIdp.js
@@ -1,0 +1,191 @@
+// In-process mock OIDC IdP used by the AUTH-010 callback tests. Serves the
+// `.well-known/openid-configuration`, a JWKS endpoint, an `/authorize` page
+// that auto-consents and bounces back to the caller, a `/token` endpoint that
+// exchanges the code for an RS256-signed id_token (plus access token), and a
+// `/userinfo` endpoint that returns the configured claims.
+//
+// Usage:
+//   const idp = await createMockOidcIdp({ user: { email: "alice@example.com", name: "Alice" } });
+//   await idp.start();
+//   // idp.issuer is a URL string the auth_providers row should point at.
+//   await idp.stop();
+
+const http = require("http");
+const crypto = require("crypto");
+const { URL } = require("url");
+
+function base64url(buf) {
+  return Buffer.from(buf)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function signJwt(payload, { privateKey, kid, alg = "RS256" }) {
+  const header = { alg, kid, typ: "JWT" };
+  const segments = [base64url(JSON.stringify(header)), base64url(JSON.stringify(payload))];
+  const signingInput = segments.join(".");
+  const signer = crypto.createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(privateKey);
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+function parseBody(req) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+  });
+}
+
+async function createMockOidcIdp({
+  user = { sub: "user-123", email: "alice@example.com", name: "Alice" },
+  clientId = "test-client",
+  clientSecret = "test-secret"
+} = {}) {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const jwk = publicKey.export({ format: "jwk" });
+  const kid = base64url(crypto.createHash("sha256").update(jwk.n).digest()).slice(0, 16);
+
+  // Track issued authorization codes so /token only honors them once.
+  const issuedCodes = new Map();
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (req.method === "GET" && url.pathname === "/.well-known/openid-configuration") {
+      const issuer = `http://${req.headers.host}`;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(JSON.stringify({
+        issuer,
+        authorization_endpoint: `${issuer}/authorize`,
+        token_endpoint: `${issuer}/token`,
+        userinfo_endpoint: `${issuer}/userinfo`,
+        jwks_uri: `${issuer}/.well-known/jwks.json`,
+        response_types_supported: ["code"],
+        subject_types_supported: ["public"],
+        id_token_signing_alg_values_supported: ["RS256"],
+        token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic", "none"],
+        code_challenge_methods_supported: ["S256"],
+        scopes_supported: ["openid", "email", "profile"]
+      }));
+    }
+
+    if (req.method === "GET" && url.pathname === "/.well-known/jwks.json") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(JSON.stringify({
+        keys: [{ ...jwk, kid, alg: "RS256", use: "sig" }]
+      }));
+    }
+
+    if (req.method === "GET" && url.pathname === "/authorize") {
+      const responseType = url.searchParams.get("response_type");
+      const redirectUri = url.searchParams.get("redirect_uri");
+      const state = url.searchParams.get("state");
+      const nonce = url.searchParams.get("nonce");
+      const codeChallenge = url.searchParams.get("code_challenge");
+      const codeChallengeMethod = url.searchParams.get("code_challenge_method");
+
+      if (responseType !== "code" || !redirectUri || !state || !codeChallenge || codeChallengeMethod !== "S256") {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ error: "invalid_request" }));
+      }
+      const code = base64url(crypto.randomBytes(24));
+      issuedCodes.set(code, { codeChallenge, nonce, redirectUri });
+      const target = new URL(redirectUri);
+      target.searchParams.set("code", code);
+      target.searchParams.set("state", state);
+      res.writeHead(302, { Location: target.href });
+      return res.end();
+    }
+
+    if (req.method === "POST" && url.pathname === "/token") {
+      const body = await parseBody(req);
+      const params = new URLSearchParams(body);
+      const grantType = params.get("grant_type");
+      const code = params.get("code");
+      const codeVerifier = params.get("code_verifier");
+      const redirectUri = params.get("redirect_uri");
+
+      if (grantType !== "authorization_code" || !code || !codeVerifier) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ error: "invalid_grant" }));
+      }
+      const record = issuedCodes.get(code);
+      if (!record) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ error: "invalid_grant", error_description: "unknown code" }));
+      }
+      issuedCodes.delete(code);
+      if (redirectUri !== record.redirectUri) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ error: "invalid_grant", error_description: "redirect_uri mismatch" }));
+      }
+      const challenge = base64url(crypto.createHash("sha256").update(codeVerifier).digest());
+      if (challenge !== record.codeChallenge) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ error: "invalid_grant", error_description: "pkce mismatch" }));
+      }
+
+      const issuer = `http://${req.headers.host}`;
+      const now = Math.floor(Date.now() / 1000);
+      const idToken = signJwt({
+        iss: issuer,
+        sub: user.sub,
+        aud: clientId,
+        iat: now,
+        exp: now + 600,
+        nonce: record.nonce,
+        email: user.email,
+        name: user.name
+      }, { privateKey, kid });
+
+      const accessToken = base64url(crypto.randomBytes(24));
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(JSON.stringify({
+        access_token: accessToken,
+        token_type: "Bearer",
+        expires_in: 600,
+        id_token: idToken,
+        scope: "openid email profile"
+      }));
+    }
+
+    if (req.method === "GET" && url.pathname === "/userinfo") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(JSON.stringify({
+        sub: user.sub,
+        email: user.email,
+        name: user.name
+      }));
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found", path: url.pathname }));
+  });
+
+  let issuer = null;
+
+  return {
+    start: async () => new Promise((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        issuer = `http://127.0.0.1:${address.port}`;
+        resolve(issuer);
+      });
+    }),
+    stop: async () => new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    }),
+    get issuer() { return issuer; },
+    clientId,
+    clientSecret,
+    updateUser(next) { Object.assign(user, next); }
+  };
+}
+
+module.exports = { createMockOidcIdp };

--- a/app/test/oidcLoginApi.test.js
+++ b/app/test/oidcLoginApi.test.js
@@ -1,0 +1,346 @@
+// AUTH-010 end-to-end: a real (in-process) OIDC IdP, the app's
+// /v1/auth/oidc/login → IdP /authorize → /v1/auth/oidc/callback flow,
+// and the post-login session sanity-check via /v1/auth/me.
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+process.env.PORT = "0";
+process.env.AUTH_COOKIE_SECURE = "false";
+process.env.AUTH_FLOW_SECRET = "x".repeat(48);
+
+const appDb = require("../src/lib/appDb");
+const { createAuthTestStub } = require("./helpers/authTestStub");
+const { createMockOidcIdp } = require("./helpers/mockOidcIdp");
+
+let server;
+let baseUrl;
+let authStub;
+let idp;
+let originalQuery;
+let providers; // in-memory provider rows
+let providerCounter;
+let aliceUserId;
+
+function normalize(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function uuid(prefix, counter) {
+  return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
+}
+
+function nextProviderId() {
+  providerCounter += 1;
+  return uuid("eeee", providerCounter);
+}
+
+function seedProvider(row) {
+  const created = {
+    id: row.id || nextProviderId(),
+    type: row.type || "oidc",
+    name: row.name,
+    display_name: row.display_name || null,
+    issuer: row.issuer,
+    client_id: row.client_id,
+    client_secret: row.client_secret || null,
+    scopes: row.scopes || ["openid", "email", "profile"],
+    redirect_uri: row.redirect_uri,
+    claims_mapping: row.claims_mapping || {},
+    enabled: row.enabled !== false,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  };
+  providers.set(created.id, created);
+  return created;
+}
+
+async function call(method, path, { cookie, body, redirect = "manual" } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (cookie) headers.Cookie = cookie;
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    redirect,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  let payload = null;
+  if ((response.headers.get("content-type") || "").includes("application/json")) {
+    try { payload = await response.json(); } catch { payload = null; }
+  }
+  return {
+    status: response.status,
+    payload,
+    headers: response.headers,
+    location: response.headers.get("location"),
+    setCookie: response.headers.getSetCookie ? response.headers.getSetCookie() : (response.headers.get("set-cookie") ? [response.headers.get("set-cookie")] : [])
+  };
+}
+
+function pickCookie(setCookies, name) {
+  for (const sc of setCookies) {
+    const match = sc.match(new RegExp(`(^|;\\s*)${name}=([^;]*)`));
+    if (match) return `${name}=${match[2]}`;
+  }
+  return null;
+}
+
+before(async () => {
+  authStub = createAuthTestStub();
+  idp = await createMockOidcIdp({
+    user: { sub: "user-alice", email: "alice@example.com", name: "Alice" },
+    clientId: "test-client",
+    clientSecret: "test-secret"
+  });
+  await idp.start();
+
+  originalQuery = appDb.query;
+  providers = new Map();
+  providerCounter = 0;
+
+  const alice = authStub.seedUser({
+    email: "alice@example.com",
+    roles: ["analyst"]
+  });
+  aliceUserId = alice.id;
+
+  appDb.query = async (sql, params = []) => {
+    const auth = authStub.handleSql(sql, params);
+    if (auth) return auth;
+
+    const n = normalize(sql);
+
+    // authService.findUserByEmail (lookup after callback)
+    if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
+      const [emailLower] = params;
+      if (emailLower === "alice@example.com") {
+        return {
+          rowCount: 1,
+          rows: [{
+            id: aliceUserId,
+            email: "alice@example.com",
+            password_hash: null,
+            display_name: null,
+            is_active: true,
+            last_login_at: null,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString()
+          }]
+        };
+      }
+      return { rowCount: 0, rows: [] };
+    }
+
+    // authProviderService queries
+    if (n.startsWith("select id, type, name, display_name, issuer, client_id, client_secret, scopes, redirect_uri, claims_mapping, enabled, created_at, updated_at from auth_providers where id = $1")) {
+      const [id] = params;
+      const row = providers.get(id);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    if (n.startsWith("select id, name, display_name, type from auth_providers where enabled = true")) {
+      const rows = [...providers.values()].filter((p) => p.enabled).map((p) => ({
+        id: p.id,
+        name: p.name,
+        display_name: p.display_name,
+        type: p.type
+      }));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (n.startsWith("select id, type, name, display_name, issuer, client_id, client_secret, scopes, redirect_uri, claims_mapping, enabled, created_at, updated_at from auth_providers order by lower(name)")) {
+      const rows = [...providers.values()].sort((a, b) => a.name.localeCompare(b.name));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (n.startsWith("insert into auth_providers")) {
+      const [type, name, displayName, issuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params;
+      const existing = [...providers.values()].find((p) => p.name.toLowerCase() === String(name).toLowerCase());
+      if (existing) {
+        const err = new Error("duplicate name"); err.code = "23505"; throw err;
+      }
+      const row = seedProvider({
+        type, name, display_name: displayName, issuer, client_id: clientId,
+        client_secret: clientSecret, scopes, redirect_uri: redirectUri,
+        claims_mapping: JSON.parse(claimsMappingJson), enabled
+      });
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (n.startsWith("update auth_providers")) {
+      const [id, type, name, displayName, issuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params;
+      const existing = providers.get(id);
+      if (!existing) return { rowCount: 0, rows: [] };
+      const next = {
+        ...existing,
+        type,
+        name,
+        display_name: displayName,
+        issuer,
+        client_id: clientId,
+        client_secret: clientSecret === null ? existing.client_secret : clientSecret,
+        scopes,
+        redirect_uri: redirectUri,
+        claims_mapping: JSON.parse(claimsMappingJson),
+        enabled,
+        updated_at: new Date().toISOString()
+      };
+      providers.set(id, next);
+      return { rowCount: 1, rows: [next] };
+    }
+
+    if (n.startsWith("delete from auth_providers where id = $1 returning id")) {
+      const [id] = params;
+      if (!providers.has(id)) return { rowCount: 0, rows: [] };
+      providers.delete(id);
+      return { rowCount: 1, rows: [{ id }] };
+    }
+
+    throw new Error(`Unexpected SQL in OIDC test stub: ${n}`);
+  };
+
+  delete require.cache[require.resolve("../src/server")];
+  const { startServer } = require("../src/server");
+  server = await startServer();
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+beforeEach(() => {
+  providers.clear();
+  providerCounter = 0;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  await idp.stop();
+  appDb.query = originalQuery;
+});
+
+test("GET /v1/auth/oidc/providers exposes only enabled providers, no secrets", async () => {
+  const provider = seedProvider({
+    name: "okta",
+    display_name: "Okta SSO",
+    issuer: idp.issuer,
+    client_id: idp.clientId,
+    client_secret: idp.clientSecret,
+    redirect_uri: `${baseUrl}/v1/auth/oidc/callback`,
+    enabled: true
+  });
+  seedProvider({
+    name: "disabled",
+    display_name: "Disabled",
+    issuer: idp.issuer,
+    client_id: "x",
+    client_secret: "y",
+    redirect_uri: `${baseUrl}/v1/auth/oidc/callback`,
+    enabled: false
+  });
+
+  const result = await call("GET", "/v1/auth/oidc/providers");
+  assert.equal(result.status, 200);
+  assert.equal(result.payload.items.length, 1);
+  const item = result.payload.items[0];
+  assert.equal(item.id, provider.id);
+  assert.equal(item.display_name, "Okta SSO");
+  assert.equal("client_secret" in item, false);
+});
+
+test("OIDC login flow: start → IdP authorize → callback → session cookie", async () => {
+  const provider = seedProvider({
+    name: "okta",
+    display_name: "Okta",
+    issuer: idp.issuer,
+    client_id: idp.clientId,
+    client_secret: idp.clientSecret,
+    redirect_uri: `${baseUrl}/v1/auth/oidc/callback`,
+    enabled: true
+  });
+
+  // 1. Start the flow.
+  const start = await call("GET", `/v1/auth/oidc/login?provider_id=${provider.id}`);
+  assert.equal(start.status, 302);
+  assert.ok(start.location && start.location.startsWith(`${idp.issuer}/authorize`));
+  const flowCookie = pickCookie(start.setCookie, "rp_oidc_flow");
+  assert.ok(flowCookie, "expected rp_oidc_flow cookie to be set");
+
+  // 2. Hit the IdP's authorize endpoint directly (no cookie needed — it's another server).
+  const idpRedirect = await fetch(start.location, { redirect: "manual" });
+  assert.equal(idpRedirect.status, 302);
+  const callbackUrl = new URL(idpRedirect.headers.get("location"));
+  assert.equal(callbackUrl.pathname, "/v1/auth/oidc/callback");
+  assert.ok(callbackUrl.searchParams.get("code"));
+  assert.ok(callbackUrl.searchParams.get("state"));
+
+  // 3. Hand the callback back to our app, carrying the flow cookie.
+  const callback = await call(
+    "GET",
+    `${callbackUrl.pathname}${callbackUrl.search}`,
+    { cookie: flowCookie }
+  );
+  assert.equal(callback.status, 302);
+  assert.equal(callback.location, "/dashboard");
+  const sessionCookie = pickCookie(callback.setCookie, "rp_session");
+  assert.ok(sessionCookie, "expected rp_session to be set after successful callback");
+  const clearFlow = callback.setCookie.find((c) => /rp_oidc_flow=;/.test(c) || /Max-Age=0/.test(c));
+  assert.ok(clearFlow, "expected rp_oidc_flow cookie to be cleared");
+
+  // 4. /v1/auth/me works with the new session.
+  const me = await call("GET", "/v1/auth/me", { cookie: sessionCookie });
+  assert.equal(me.status, 200);
+  assert.equal(me.payload.user.email, "alice@example.com");
+  assert.deepEqual(me.payload.user.roles, ["analyst"]);
+});
+
+test("OIDC callback returns 403 when the IdP email has no local user", async () => {
+  const provider = seedProvider({
+    name: "okta",
+    display_name: "Okta",
+    issuer: idp.issuer,
+    client_id: idp.clientId,
+    client_secret: idp.clientSecret,
+    redirect_uri: `${baseUrl}/v1/auth/oidc/callback`,
+    enabled: true
+  });
+
+  idp.updateUser({ email: "stranger@example.com", name: "Stranger", sub: "user-stranger" });
+  try {
+    const start = await call("GET", `/v1/auth/oidc/login?provider_id=${provider.id}`);
+    const flowCookie = pickCookie(start.setCookie, "rp_oidc_flow");
+    const idpRedirect = await fetch(start.location, { redirect: "manual" });
+    const callbackUrl = new URL(idpRedirect.headers.get("location"));
+    const callback = await call(
+      "GET",
+      `${callbackUrl.pathname}${callbackUrl.search}`,
+      { cookie: flowCookie }
+    );
+    assert.equal(callback.status, 403);
+    assert.equal(callback.payload.error, "forbidden");
+    assert.match(callback.payload.message, /stranger@example\.com/);
+  } finally {
+    idp.updateUser({ email: "alice@example.com", name: "Alice", sub: "user-alice" });
+  }
+});
+
+test("OIDC callback rejects requests without the flow cookie", async () => {
+  // Fabricate a plausible-looking callback URL with no cookie.
+  const callback = await call("GET", "/v1/auth/oidc/callback?code=abc&state=xyz");
+  assert.equal(callback.status, 400);
+  assert.match(callback.payload.message, /flow state/);
+});
+
+test("/v1/auth/oidc/login returns 404 for disabled or unknown providers", async () => {
+  const disabled = await call("GET", "/v1/auth/oidc/login?provider_id=00000000-0000-4000-8000-eeee99999999");
+  assert.equal(disabled.status, 404);
+
+  const provider = seedProvider({
+    name: "okta",
+    issuer: idp.issuer,
+    client_id: idp.clientId,
+    client_secret: idp.clientSecret,
+    redirect_uri: `${baseUrl}/v1/auth/oidc/callback`,
+    enabled: false
+  });
+  const result = await call("GET", `/v1/auth/oidc/login?provider_id=${provider.id}`);
+  assert.equal(result.status, 404);
+});

--- a/db/migrations/0017_auth_providers.sql
+++ b/db/migrations/0017_auth_providers.sql
@@ -1,0 +1,30 @@
+-- AUTH-010: external auth provider configuration. Today this stores OIDC
+-- providers; AUTH-011 will reuse the same table for SAML and LDAP rows
+-- (distinguished by `type`).
+--
+-- `client_secret` is stored plaintext for now and redacted by the admin API.
+-- Encryption-at-rest is intentionally out-of-scope here and tracked as a
+-- follow-up; deployments that care should encrypt the column via PG TDE,
+-- pgcrypto, or by writing through an encrypting service.
+
+CREATE TABLE IF NOT EXISTS auth_providers (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  type TEXT NOT NULL CHECK (type IN ('oidc')),
+  name TEXT NOT NULL,
+  display_name TEXT,
+  issuer TEXT NOT NULL,
+  client_id TEXT NOT NULL,
+  client_secret TEXT,
+  scopes TEXT[] NOT NULL DEFAULT ARRAY['openid', 'email', 'profile']::text[],
+  redirect_uri TEXT NOT NULL,
+  claims_mapping JSONB NOT NULL DEFAULT '{}'::jsonb,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_providers_name_lower
+  ON auth_providers (lower(name));
+
+CREATE INDEX IF NOT EXISTS idx_auth_providers_enabled
+  ON auth_providers (enabled);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -108,6 +108,138 @@ paths:
           description: Forbidden
         "409":
           description: Email already exists
+  /v1/auth/oidc/providers:
+    get:
+      tags: [Auth]
+      summary: List enabled OIDC providers for the login page
+      description: Public endpoint. Returns only the metadata the login UI needs (`id`, `name`, `display_name`, `type`); secrets and admin-only fields are never exposed here.
+      responses:
+        "200":
+          description: Enabled providers
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OidcProviderLoginListResponse"
+  /v1/auth/oidc/login:
+    get:
+      tags: [Auth]
+      summary: Start the OIDC authorization-code (PKCE) flow
+      description: |
+        Public endpoint. Generates state / nonce / PKCE verifier, sets a
+        short-lived signed cookie (`rp_oidc_flow`), and 302-redirects to the
+        IdP's authorize URL. The user agent returns to `/v1/auth/oidc/callback`.
+      parameters:
+        - in: query
+          name: provider_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "302":
+          description: Redirect to IdP authorize URL
+        "400":
+          description: Missing provider_id
+        "404":
+          description: Provider not found or disabled
+  /v1/auth/oidc/callback:
+    get:
+      tags: [Auth]
+      summary: OIDC callback — exchange code, validate ID token, create session
+      description: |
+        Public endpoint. Reads the signed flow cookie, verifies `state`/`nonce`,
+        exchanges the authorization code with PKCE, validates the ID token,
+        looks up a local user by `email`, and creates a session.
+      parameters:
+        - in: query
+          name: code
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: state
+          required: true
+          schema:
+            type: string
+      responses:
+        "302":
+          description: "Successful login — `Set-Cookie: rp_session=...` and redirect to `/dashboard`"
+        "400":
+          description: Missing or expired flow cookie / failed token exchange
+        "403":
+          description: No active local account for the IdP email claim
+        "404":
+          description: Provider no longer available
+  /v1/admin/auth-providers:
+    get:
+      tags: [Admin]
+      summary: List configured auth providers
+      description: Requires the `admin` role. `client_secret` is redacted as `***` when present.
+      responses:
+        "200":
+          description: Provider list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthProviderListResponse"
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+    post:
+      tags: [Admin]
+      summary: Create or update an auth provider
+      description: |
+        Requires the `admin` role. Pass `id` to update an existing row; omit it
+        to create. Omitting `client_secret` on update keeps the existing value.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthProviderUpsertRequest"
+      responses:
+        "200":
+          description: Provider updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthProvider"
+        "201":
+          description: Provider created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthProvider"
+        "400":
+          description: Invalid input
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+        "404":
+          description: Provider not found (when updating)
+        "409":
+          description: A provider with that name already exists
+  /v1/admin/auth-providers/{providerId}:
+    delete:
+      tags: [Admin]
+      summary: Delete an auth provider
+      description: Requires the `admin` role.
+      parameters:
+        - in: path
+          name: providerId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Provider deleted
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+        "404":
+          description: Provider not found
   /v1/admin/data-sources/{dataSourceId}/access:
     get:
       tags: [Admin]
@@ -1315,6 +1447,106 @@ components:
           type: array
           items:
             type: string
+    AuthProvider:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [oidc]
+        name:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        issuer:
+          type: string
+        client_id:
+          type: string
+        client_secret:
+          type: string
+          nullable: true
+          description: Redacted as `***` when present; never returned in plaintext.
+        scopes:
+          type: array
+          items:
+            type: string
+        redirect_uri:
+          type: string
+        claims_mapping:
+          type: object
+          properties:
+            email:
+              type: string
+            display_name:
+              type: string
+        enabled:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AuthProviderListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuthProvider"
+    AuthProviderUpsertRequest:
+      type: object
+      required: [type, name, issuer, client_id, redirect_uri]
+      properties:
+        id:
+          type: string
+          description: Provide to update an existing provider; omit to create a new one.
+        type:
+          type: string
+          enum: [oidc]
+        name:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        issuer:
+          type: string
+        client_id:
+          type: string
+        client_secret:
+          type: string
+          nullable: true
+          description: Optional for public PKCE-only clients. Omit on update to keep the existing value.
+        scopes:
+          type: array
+          items:
+            type: string
+        redirect_uri:
+          type: string
+        claims_mapping:
+          type: object
+        enabled:
+          type: boolean
+    OidcProviderLoginEntry:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        display_name:
+          type: string
+        type:
+          type: string
+    OidcProviderLoginListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/OidcProviderLoginEntry"
     DataSourceAccessGrant:
       type: object
       properties:

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -255,6 +255,348 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/auth/oidc/providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List enabled OIDC providers for the login page
+         * @description Public endpoint. Returns only the metadata the login UI needs (`id`, `name`, `display_name`, `type`); secrets and admin-only fields are never exposed here.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Enabled providers */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OidcProviderLoginListResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/oidc/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Start the OIDC authorization-code (PKCE) flow
+         * @description Public endpoint. Generates state / nonce / PKCE verifier, sets a
+         *     short-lived signed cookie (`rp_oidc_flow`), and 302-redirects to the
+         *     IdP's authorize URL. The user agent returns to `/v1/auth/oidc/callback`.
+         */
+        get: {
+            parameters: {
+                query: {
+                    provider_id: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Redirect to IdP authorize URL */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Missing provider_id */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Provider not found or disabled */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/oidc/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * OIDC callback — exchange code, validate ID token, create session
+         * @description Public endpoint. Reads the signed flow cookie, verifies `state`/`nonce`,
+         *     exchanges the authorization code with PKCE, validates the ID token,
+         *     looks up a local user by `email`, and creates a session.
+         */
+        get: {
+            parameters: {
+                query: {
+                    code: string;
+                    state: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful login — `Set-Cookie: rp_session=...` and redirect to `/dashboard` */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Missing or expired flow cookie / failed token exchange */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description No active local account for the IdP email claim */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Provider no longer available */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/auth-providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List configured auth providers
+         * @description Requires the `admin` role. `client_secret` is redacted as `***` when present.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Provider list */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AuthProviderListResponse"];
+                    };
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create or update an auth provider
+         * @description Requires the `admin` role. Pass `id` to update an existing row; omit it
+         *     to create. Omitting `client_secret` on update keeps the existing value.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["AuthProviderUpsertRequest"];
+                };
+            };
+            responses: {
+                /** @description Provider updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AuthProvider"];
+                    };
+                };
+                /** @description Provider created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AuthProvider"];
+                    };
+                };
+                /** @description Invalid input */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Provider not found (when updating) */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description A provider with that name already exists */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/auth-providers/{providerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete an auth provider
+         * @description Requires the `admin` role.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    providerId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Provider deleted */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Provider not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/data-sources/{dataSourceId}/access": {
         parameters: {
             query?: never;
@@ -2266,6 +2608,56 @@ export interface components {
         UpdateUserRolesRequest: {
             assign?: string[];
             revoke?: string[];
+        };
+        AuthProvider: {
+            id?: string;
+            /** @enum {string} */
+            type?: "oidc";
+            name?: string;
+            display_name?: string | null;
+            issuer?: string;
+            client_id?: string;
+            /** @description Redacted as `***` when present; never returned in plaintext. */
+            client_secret?: string | null;
+            scopes?: string[];
+            redirect_uri?: string;
+            claims_mapping?: {
+                email?: string;
+                display_name?: string;
+            };
+            enabled?: boolean;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            updated_at?: string;
+        };
+        AuthProviderListResponse: {
+            items?: components["schemas"]["AuthProvider"][];
+        };
+        AuthProviderUpsertRequest: {
+            /** @description Provide to update an existing provider; omit to create a new one. */
+            id?: string;
+            /** @enum {string} */
+            type: "oidc";
+            name: string;
+            display_name?: string | null;
+            issuer: string;
+            client_id: string;
+            /** @description Optional for public PKCE-only clients. Omit on update to keep the existing value. */
+            client_secret?: string | null;
+            scopes?: string[];
+            redirect_uri: string;
+            claims_mapping?: Record<string, never>;
+            enabled?: boolean;
+        };
+        OidcProviderLoginEntry: {
+            id?: string;
+            name?: string;
+            display_name?: string;
+            type?: string;
+        };
+        OidcProviderLoginListResponse: {
+            items?: components["schemas"]["OidcProviderLoginEntry"][];
         };
         DataSourceAccessGrant: {
             id?: string;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,11 +1,15 @@
-import { useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import appLogo from '../assets/report-pilot.png';
 import { useAuth } from '../hooks/useAuth';
+import { client } from '../lib/api/client';
+import type { components } from '../lib/api/types';
 
 interface LocationState {
     from?: string;
 }
+
+type OidcProvider = components['schemas']['OidcProviderLoginEntry'];
 
 export function Login() {
     const { status, login } = useAuth();
@@ -16,6 +20,20 @@ export function Login() {
     const [password, setPassword] = useState('');
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [providers, setProviders] = useState<OidcProvider[]>([]);
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            const { data } = await client.GET('/v1/auth/oidc/providers');
+            if (!cancelled && data?.items) {
+                setProviders(data.items);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
 
     if (status === 'authenticated') {
         const target = (location.state as LocationState | null)?.from || '/dashboard';
@@ -96,6 +114,27 @@ export function Login() {
                         {submitting ? 'Signing in…' : 'Sign in'}
                     </button>
                 </form>
+
+                {providers.length > 0 && (
+                    <>
+                        <div className="my-6 flex items-center gap-3 text-xs uppercase tracking-wider text-gray-400">
+                            <span className="h-px flex-1 bg-gray-200" />
+                            or
+                            <span className="h-px flex-1 bg-gray-200" />
+                        </div>
+                        <div className="space-y-2">
+                            {providers.map((provider) => (
+                                <a
+                                    key={provider.id}
+                                    href={`/v1/auth/oidc/login?provider_id=${encodeURIComponent(provider.id ?? '')}`}
+                                    className="flex w-full items-center justify-center gap-2 rounded-md border border-gray-200 px-3 py-2 text-sm font-medium text-gray-700 hover:border-oxblood hover:text-oxblood"
+                                >
+                                    Sign in with {provider.display_name || provider.name}
+                                </a>
+                            ))}
+                        </div>
+                    </>
+                )}
             </div>
         </div>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "mssql": "^11.0.1",
         "node-sql-parser": "^5.3.8",
         "nodemailer": "^8.0.1",
+        "openid-client": "^6.8.4",
         "parquetjs-lite": "^0.8.7",
         "pg": "^8.13.1",
         "xlsx": "^0.18.5"
@@ -873,6 +874,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-md4": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
@@ -1024,6 +1034,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/open": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -1040,6 +1059,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/parquetjs-lite": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mssql": "^11.0.1",
     "node-sql-parser": "^5.3.8",
     "nodemailer": "^8.0.1",
+    "openid-client": "^6.8.4",
     "parquetjs-lite": "^0.8.7",
     "pg": "^8.13.1",
     "xlsx": "^0.18.5"


### PR DESCRIPTION
Closes #30 — AUTH-010. Builds on AUTH-001..005. Unblocks AUTH-014 (the admin UI you originally pointed at).

## Summary
- Standards-based OIDC (authorization code + PKCE) login next to the existing email/password flow. Multiple providers per app; one shared callback path.
- New `auth_providers` table stores OIDC config (issuer / client_id / client_secret / scopes / redirect_uri / claims_mapping / enabled). The admin API redacts `client_secret`; the login API returns only id / name / display_name / type.
- ID-token validation, PKCE challenge/verifier, state + nonce all handled by `openid-client@^6`. Email is sourced from the configured claim (default `email`); if missing on the id_token, the service falls back to `/userinfo`.
- Identity mapping is "match by email only" — no JIT user creation. The callback returns a clear 403 if no active local user matches the IdP email. JIT lives with AUTH-012.
- Frontend Login page fetches the enabled-providers list and renders a "Sign in with X" link per provider that 302s through the backend, so the OIDC flow cookie stays first-party.

## New endpoints
- Public:
  - `GET /v1/auth/oidc/providers` — id / name / display_name / type for enabled providers.
  - `GET /v1/auth/oidc/login?provider_id=…` — generates state/nonce/PKCE, sets a signed `rp_oidc_flow` cookie, 302s to the IdP authorize URL.
  - `GET /v1/auth/oidc/callback` — validates the response, creates the `rp_session`, redirects to `/dashboard`.
- Admin (role: `admin`):
  - `GET /v1/admin/auth-providers` — list with `client_secret` redacted to `***`.
  - `POST /v1/admin/auth-providers` — create / upsert. Omitting `client_secret` on update keeps the existing value.
  - `DELETE /v1/admin/auth-providers/{providerId}`.

## Acceptance criteria
- [x] **Users can log in through at least one OIDC IdP.** — Verified end-to-end against an in-process IdP. Manually verifiable against Okta/Auth0/Azure AD/Keycloak by configuring a provider row with the IdP's issuer and registering `…/v1/auth/oidc/callback` as the redirect URI.
- [x] **ID token and userinfo claims are validated and mapped correctly.** — `openid-client.authorizationCodeGrant` enforces `expectedState`/`expectedNonce`/PKCE and JWKS-signature; the service prefers id_token claims and falls back to `/userinfo` for missing fields.
- [x] **OIDC login works alongside the existing auth method without regression.** — Email/password tests (`authApi.test.js`) still pass; the OIDC routes are additive.

## Design notes
- `openid-client@6` is ESM-only, so the service dynamic-`import()`s it on first use and otherwise keeps the rest of the codebase on CommonJS.
- For `http://` issuers (localhost, tests) the service passes `execute: [client.allowInsecureRequests]`. Production `https://` issuers go through standard verification.
- `client_secret` is stored plaintext today and redacted on read; encryption-at-rest is intentionally deferred. Deployments that care should encrypt via PG TDE / pgcrypto / a sidecar.
- The flow cookie carries PKCE verifier + state + nonce + provider_id, signed with HMAC-SHA256 from `AUTH_FLOW_SECRET` (≥32 bytes). Dev defaults to a per-process random with a production warning.

## Test plan
- [x] `DATABASE_URL=postgresql://test:test@localhost:5432/test npm test` → 91/91 passing (6 new for AUTH-010: migration shape, provider list is enabled-only + redacted, full login → IdP authorize → callback → `/v1/auth/me` happy path, callback 403 for unknown email, callback 400 without flow cookie, /login 404 for unknown/disabled providers).
- [x] `npm --prefix frontend run lint` clean.
- [x] `npm --prefix frontend run build` clean.
- [ ] Manual: run `npm run migrate` (applies 0017), create an admin via `scripts/create-user.js`, log in, then `curl` to `POST /v1/admin/auth-providers` with an Okta/Keycloak issuer + registered redirect URI. Visit `/login`, click the new button, confirm the round trip and `/v1/auth/me` after.

## Out of scope (next tickets)
- Admin UI screens for providers + mapping rules → AUTH-014.
- JIT user provisioning + account linking → AUTH-012.
- SAML / LDAP / Personal Directory → AUTH-011.
- SCIM provisioning → AUTH-013.
- Federation hardening (replay window, audience pinning, JWKS rotation policy) → AUTH-015.