### PR TITLE
feat(auth): AUTH-014 auth provider admin UI

### DIFF
--- a/app/src/lib/routePolicy.js
+++ b/app/src/lib/routePolicy.js
@@ -34,6 +34,7 @@ const POLICIES = [
   { method: "GET", pattern: /^\/v1\/admin\/auth-providers$/, role: "admin" },
   { method: "POST", pattern: /^\/v1\/admin\/auth-providers$/, role: "admin" },
   { method: "DELETE", pattern: /^\/v1\/admin\/auth-providers\/[^/]+$/, role: "admin" },
+  { method: "POST", pattern: /^\/v1\/admin\/auth-providers\/[^/]+\/test$/, role: "admin" },
 
   // Data sources
   { method: "GET", pattern: /^\/v1\/data-sources$/, permission: "data_sources.read" },

--- a/app/src/routes/admin.js
+++ b/app/src/routes/admin.js
@@ -4,6 +4,7 @@ const appDb = require("../lib/appDb");
 const adminUserService = require("../services/adminUserService");
 const dataSourceAccessService = require("../services/dataSourceAccessService");
 const authProviderService = require("../services/authProviderService");
+const oidcService = require("../services/oidcService");
 
 function writeResult(res, result) {
   return json(res, result.statusCode, result.body);
@@ -133,6 +134,18 @@ async function handleDeleteAuthProvider(_req, res, providerId) {
   return json(res, result.statusCode, result.body);
 }
 
+async function handleTestAuthProvider(_req, res, providerId) {
+  if (!isUuid(providerId)) {
+    return badRequest(res, "provider id must be a uuid");
+  }
+  const provider = await authProviderService.findProviderById(providerId, { withSecret: true });
+  if (!provider) {
+    return json(res, 404, { error: "not_found", message: "auth provider not found" });
+  }
+  const result = await oidcService.testConnection(provider);
+  return json(res, 200, result);
+}
+
 module.exports = {
   handleListUsers,
   handleCreateUser,
@@ -142,5 +155,6 @@ module.exports = {
   handleRevokeDataSourceAccess,
   handleListAuthProviders,
   handleUpsertAuthProvider,
-  handleDeleteAuthProvider
+  handleDeleteAuthProvider,
+  handleTestAuthProvider
 };

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -84,7 +84,8 @@ const {
   handleRevokeDataSourceAccess,
   handleListAuthProviders,
   handleUpsertAuthProvider,
-  handleDeleteAuthProvider
+  handleDeleteAuthProvider,
+  handleTestAuthProvider
 } = require("./routes/admin");
 const {
   handleListEnabledProviders,
@@ -211,6 +212,11 @@ async function routeRequest(req, res) {
   }
   if (req.method === "POST" && pathname === "/v1/admin/auth-providers") {
     return handleUpsertAuthProvider(req, res);
+  }
+
+  const adminAuthProviderTestMatch = pathname.match(/^\/v1\/admin\/auth-providers\/([^/]+)\/test$/);
+  if (req.method === "POST" && adminAuthProviderTestMatch) {
+    return handleTestAuthProvider(req, res, adminAuthProviderTestMatch[1]);
   }
 
   const adminAuthProviderDeleteMatch = pathname.match(/^\/v1\/admin\/auth-providers\/([^/]+)$/);

--- a/app/src/services/oidcService.js
+++ b/app/src/services/oidcService.js
@@ -131,7 +131,43 @@ async function completeLogin(provider, currentUrl, flowState) {
   };
 }
 
+// Lightweight reachability check: runs discovery against the issuer (which
+// fetches `.well-known/openid-configuration` and the JWKS) and returns a
+// success/error summary the admin UI can show. We do not actually try to
+// authenticate.
+async function testConnection(provider) {
+  if (!provider) {
+    return { ok: false, error: "provider not found" };
+  }
+  try {
+    const client = await getOidcClient();
+    const config = await buildConfiguration(provider);
+    const metadata = config.serverMetadata();
+    return {
+      ok: true,
+      issuer: metadata.issuer || provider.issuer,
+      authorization_endpoint: metadata.authorization_endpoint || null,
+      token_endpoint: metadata.token_endpoint || null,
+      userinfo_endpoint: metadata.userinfo_endpoint || null,
+      jwks_uri: metadata.jwks_uri || null,
+      id_token_signing_alg_values_supported: metadata.id_token_signing_alg_values_supported || [],
+      code_challenge_methods_supported: metadata.code_challenge_methods_supported || [],
+      // Surface a name-only summary of what the IdP advertises so the UI can
+      // sanity-check scope/response_type configuration without sending the
+      // entire blob through.
+      response_types_supported: metadata.response_types_supported || []
+    };
+    // eslint-disable-next-line no-unreachable
+  } catch (err) {
+    return {
+      ok: false,
+      error: err && err.message ? err.message : String(err)
+    };
+  }
+}
+
 module.exports = {
   startLogin,
-  completeLogin
+  completeLogin,
+  testConnection
 };

--- a/app/test/authProvidersAdminApi.test.js
+++ b/app/test/authProvidersAdminApi.test.js
@@ -1,0 +1,329 @@
+// AUTH-014: backend coverage for the admin-side auth-provider lifecycle:
+// list/create/update/delete + the new test-connection action. Hits the real
+// mock OIDC IdP for the success case and a bogus issuer for the failure case.
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+process.env.PORT = "0";
+process.env.AUTH_COOKIE_SECURE = "false";
+process.env.AUTH_FLOW_SECRET = "x".repeat(48);
+
+const appDb = require("../src/lib/appDb");
+const { createAuthTestStub } = require("./helpers/authTestStub");
+const { createMockOidcIdp } = require("./helpers/mockOidcIdp");
+
+let server;
+let baseUrl;
+let authStub;
+let idp;
+let originalQuery;
+let providers;
+let providerCounter;
+let adminCookie;
+let analystCookie;
+
+function normalize(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function uuid(prefix, counter) {
+  return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
+}
+
+function nextProviderId() {
+  providerCounter += 1;
+  return uuid("eeee", providerCounter);
+}
+
+function seedProvider(row) {
+  const created = {
+    id: row.id || nextProviderId(),
+    type: row.type || "oidc",
+    name: row.name,
+    display_name: row.display_name || null,
+    issuer: row.issuer,
+    client_id: row.client_id,
+    client_secret: row.client_secret || null,
+    scopes: row.scopes || ["openid", "email", "profile"],
+    redirect_uri: row.redirect_uri,
+    claims_mapping: row.claims_mapping || {},
+    enabled: row.enabled !== false,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  };
+  providers.set(created.id, created);
+  return created;
+}
+
+async function call(method, path, { cookie, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (cookie) headers.Cookie = cookie;
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  let payload = null;
+  if ((response.headers.get("content-type") || "").includes("application/json")) {
+    try { payload = await response.json(); } catch { payload = null; }
+  }
+  return { status: response.status, payload };
+}
+
+before(async () => {
+  authStub = createAuthTestStub();
+  idp = await createMockOidcIdp({
+    user: { sub: "user-admin", email: "admin@example.com", name: "Admin" },
+    clientId: "test-client",
+    clientSecret: "test-secret"
+  });
+  await idp.start();
+
+  originalQuery = appDb.query;
+  providers = new Map();
+  providerCounter = 0;
+
+  const admin = authStub.seedUser({ email: "admin@example.com", roles: ["admin"] });
+  const analyst = authStub.seedUser({ email: "analyst@example.com", roles: ["analyst"] });
+  adminCookie = authStub.cookieFor(authStub.seedSession(admin.id).token);
+  analystCookie = authStub.cookieFor(authStub.seedSession(analyst.id).token);
+
+  appDb.query = async (sql, params = []) => {
+    const auth = authStub.handleSql(sql, params);
+    if (auth) return auth;
+
+    const n = normalize(sql);
+
+    if (n.startsWith("select id, type, name, display_name, issuer, client_id, client_secret, scopes, redirect_uri, claims_mapping, enabled, created_at, updated_at from auth_providers where id = $1")) {
+      const [id] = params;
+      const row = providers.get(id);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    if (n.startsWith("select id, type, name, display_name, issuer, client_id, client_secret, scopes, redirect_uri, claims_mapping, enabled, created_at, updated_at from auth_providers order by lower(name)")) {
+      const rows = [...providers.values()].sort((a, b) => a.name.localeCompare(b.name));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (n.startsWith("insert into auth_providers")) {
+      const [type, name, displayName, issuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params;
+      const existing = [...providers.values()].find((p) => p.name.toLowerCase() === String(name).toLowerCase());
+      if (existing) {
+        const err = new Error("duplicate name"); err.code = "23505"; throw err;
+      }
+      const row = seedProvider({
+        type, name, display_name: displayName, issuer, client_id: clientId,
+        client_secret: clientSecret, scopes, redirect_uri: redirectUri,
+        claims_mapping: JSON.parse(claimsMappingJson), enabled
+      });
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (n.startsWith("update auth_providers")) {
+      const [id, type, name, displayName, issuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params;
+      const existing = providers.get(id);
+      if (!existing) return { rowCount: 0, rows: [] };
+      const next = {
+        ...existing,
+        type, name, display_name: displayName, issuer, client_id: clientId,
+        client_secret: clientSecret === null ? existing.client_secret : clientSecret,
+        scopes, redirect_uri: redirectUri,
+        claims_mapping: JSON.parse(claimsMappingJson),
+        enabled,
+        updated_at: new Date().toISOString()
+      };
+      providers.set(id, next);
+      return { rowCount: 1, rows: [next] };
+    }
+
+    if (n.startsWith("delete from auth_providers where id = $1 returning id")) {
+      const [id] = params;
+      if (!providers.has(id)) return { rowCount: 0, rows: [] };
+      providers.delete(id);
+      return { rowCount: 1, rows: [{ id }] };
+    }
+
+    throw new Error(`Unexpected SQL in admin-providers test stub: ${n}`);
+  };
+
+  delete require.cache[require.resolve("../src/server")];
+  const { startServer } = require("../src/server");
+  server = await startServer();
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+beforeEach(() => {
+  providers.clear();
+  providerCounter = 0;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  await idp.stop();
+  appDb.query = originalQuery;
+});
+
+test("admin can create, list, update, and delete auth providers; client_secret is redacted", async () => {
+  const create = await call("POST", "/v1/admin/auth-providers", {
+    cookie: adminCookie,
+    body: {
+      type: "oidc",
+      name: "okta",
+      display_name: "Okta SSO",
+      issuer: idp.issuer,
+      client_id: idp.clientId,
+      client_secret: idp.clientSecret,
+      redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
+    }
+  });
+  assert.equal(create.status, 201);
+  assert.equal(create.payload.name, "okta");
+  assert.equal(create.payload.display_name, "Okta SSO");
+  assert.equal(create.payload.client_secret, "***", "client_secret should be redacted in API responses");
+
+  const list = await call("GET", "/v1/admin/auth-providers", { cookie: adminCookie });
+  assert.equal(list.status, 200);
+  assert.equal(list.payload.items.length, 1);
+  assert.equal(list.payload.items[0].client_secret, "***");
+
+  // Updating without client_secret keeps the old one (still redacted in response).
+  const update = await call("POST", "/v1/admin/auth-providers", {
+    cookie: adminCookie,
+    body: {
+      id: create.payload.id,
+      type: "oidc",
+      name: "okta",
+      display_name: "Okta (prod)",
+      issuer: idp.issuer,
+      client_id: idp.clientId,
+      redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
+    }
+  });
+  assert.equal(update.status, 200);
+  assert.equal(update.payload.display_name, "Okta (prod)");
+  assert.equal(update.payload.client_secret, "***");
+
+  const del = await call("DELETE", `/v1/admin/auth-providers/${create.payload.id}`, { cookie: adminCookie });
+  assert.equal(del.status, 200);
+});
+
+test("auth provider validation surfaces field-level errors", async () => {
+  const badIssuer = await call("POST", "/v1/admin/auth-providers", {
+    cookie: adminCookie,
+    body: {
+      type: "oidc",
+      name: "bad",
+      issuer: "not-a-url",
+      client_id: "x",
+      redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
+    }
+  });
+  assert.equal(badIssuer.status, 400);
+  assert.match(badIssuer.payload.message, /issuer/i);
+
+  const badRedirect = await call("POST", "/v1/admin/auth-providers", {
+    cookie: adminCookie,
+    body: {
+      type: "oidc",
+      name: "bad2",
+      issuer: idp.issuer,
+      client_id: "x",
+      redirect_uri: "not-a-url"
+    }
+  });
+  assert.equal(badRedirect.status, 400);
+  assert.match(badRedirect.payload.message, /redirect_uri/i);
+
+  const badName = await call("POST", "/v1/admin/auth-providers", {
+    cookie: adminCookie,
+    body: {
+      type: "oidc",
+      name: "spaces in name",
+      issuer: idp.issuer,
+      client_id: "x",
+      redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
+    }
+  });
+  assert.equal(badName.status, 400);
+  assert.match(badName.payload.message, /name/i);
+
+  // Duplicate name → 409
+  await call("POST", "/v1/admin/auth-providers", {
+    cookie: adminCookie,
+    body: {
+      type: "oidc",
+      name: "dup",
+      issuer: idp.issuer,
+      client_id: "x",
+      redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
+    }
+  });
+  const dup = await call("POST", "/v1/admin/auth-providers", {
+    cookie: adminCookie,
+    body: {
+      type: "oidc",
+      name: "DUP",
+      issuer: idp.issuer,
+      client_id: "x",
+      redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
+    }
+  });
+  assert.equal(dup.status, 409);
+});
+
+test("POST .../test returns discovery metadata for a reachable provider", async () => {
+  const provider = seedProvider({
+    name: "okta",
+    issuer: idp.issuer,
+    client_id: idp.clientId,
+    client_secret: idp.clientSecret,
+    redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
+  });
+
+  const result = await call("POST", `/v1/admin/auth-providers/${provider.id}/test`, { cookie: adminCookie });
+  assert.equal(result.status, 200);
+  assert.equal(result.payload.ok, true);
+  assert.equal(result.payload.issuer, idp.issuer);
+  assert.ok(result.payload.authorization_endpoint && result.payload.authorization_endpoint.startsWith(idp.issuer));
+  assert.ok(result.payload.token_endpoint);
+  assert.ok(result.payload.jwks_uri);
+  assert.ok(Array.isArray(result.payload.code_challenge_methods_supported));
+  assert.ok(result.payload.code_challenge_methods_supported.includes("S256"));
+});
+
+test("POST .../test reports failure with the error message when discovery fails", async () => {
+  const provider = seedProvider({
+    name: "broken",
+    issuer: "http://127.0.0.1:1/no-such-idp",
+    client_id: "x",
+    redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
+  });
+
+  const result = await call("POST", `/v1/admin/auth-providers/${provider.id}/test`, { cookie: adminCookie });
+  assert.equal(result.status, 200);
+  assert.equal(result.payload.ok, false);
+  assert.ok(typeof result.payload.error === "string" && result.payload.error.length > 0);
+});
+
+test("test endpoint is admin-only and 404s for unknown providers", async () => {
+  const provider = seedProvider({
+    name: "okta",
+    issuer: idp.issuer,
+    client_id: idp.clientId,
+    redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
+  });
+
+  const analyst = await call("POST", `/v1/admin/auth-providers/${provider.id}/test`, { cookie: analystCookie });
+  assert.equal(analyst.status, 403);
+
+  const unauthenticated = await call("POST", `/v1/admin/auth-providers/${provider.id}/test`);
+  assert.equal(unauthenticated.status, 401);
+
+  const missing = await call("POST", "/v1/admin/auth-providers/00000000-0000-4000-8000-eeee99999999/test", { cookie: adminCookie });
+  assert.equal(missing.status, 404);
+
+  const badId = await call("POST", "/v1/admin/auth-providers/not-a-uuid/test", { cookie: adminCookie });
+  assert.equal(badId.status, 400);
+});

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -240,6 +240,33 @@ paths:
           description: Forbidden
         "404":
           description: Provider not found
+  /v1/admin/auth-providers/{providerId}/test:
+    post:
+      tags: [Admin]
+      summary: Test an OIDC provider's reachability and metadata
+      description: |
+        Requires the `admin` role. Runs OIDC discovery against the configured
+        issuer and returns the parsed metadata or a structured error. Does NOT
+        attempt authentication.
+      parameters:
+        - in: path
+          name: providerId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Test result (success or failure). Always 200 — inspect `ok`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthProviderTestResult"
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+        "404":
+          description: Provider not found
   /v1/admin/data-sources/{dataSourceId}/access:
     get:
       tags: [Admin]
@@ -1527,8 +1554,47 @@ components:
           type: string
         claims_mapping:
           type: object
+          properties:
+            email:
+              type: string
+            display_name:
+              type: string
         enabled:
           type: boolean
+    AuthProviderTestResult:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        error:
+          type: string
+          nullable: true
+        issuer:
+          type: string
+        authorization_endpoint:
+          type: string
+          nullable: true
+        token_endpoint:
+          type: string
+          nullable: true
+        userinfo_endpoint:
+          type: string
+          nullable: true
+        jwks_uri:
+          type: string
+          nullable: true
+        response_types_supported:
+          type: array
+          items:
+            type: string
+        id_token_signing_alg_values_supported:
+          type: array
+          items:
+            type: string
+        code_challenge_methods_supported:
+          type: array
+          items:
+            type: string
     OidcProviderLoginEntry:
       type: object
       properties:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { Login } from './pages/Login';
 import { NotFound } from './pages/NotFound';
 import { Settings } from './pages/Settings';
 import { LLMProviders } from './pages/LLMProviders';
+import { AuthProviders } from './pages/AuthProviders';
 
 function App() {
   return (
@@ -77,6 +78,14 @@ function App() {
               )}
             />
             <Route path="/settings" element={<Settings />} />
+            <Route
+              path="/admin/auth-providers"
+              element={(
+                <RequireAuth role="admin">
+                  <AuthProviders />
+                </RequireAuth>
+              )}
+            />
             <Route path="/folders" element={<ComingSoon />} />
             <Route path="/favorites" element={<ComingSoon />} />
             <Route path="/recent" element={<ComingSoon />} />

--- a/frontend/src/components/Admin/AuthProviderDialog.tsx
+++ b/frontend/src/components/Admin/AuthProviderDialog.tsx
@@ -1,0 +1,317 @@
+import { useState, type FormEvent } from 'react';
+import { X } from 'lucide-react';
+import type { components } from '../../lib/api/types';
+
+export type AuthProvider = components['schemas']['AuthProvider'];
+
+export interface AuthProviderFormValues {
+    id?: string;
+    type: 'oidc';
+    name: string;
+    display_name?: string | null;
+    issuer: string;
+    client_id: string;
+    client_secret?: string | null;
+    scopes: string[];
+    redirect_uri: string;
+    claims_mapping: { email?: string; display_name?: string };
+    enabled: boolean;
+}
+
+interface Props {
+    isOpen: boolean;
+    initial: AuthProvider | null;
+    defaultRedirectUri: string;
+    onClose: () => void;
+    onSubmit: (values: AuthProviderFormValues) => Promise<{ ok: boolean; message?: string }>;
+}
+
+type FieldErrors = Partial<Record<keyof AuthProviderFormValues | 'scopes_input', string>>;
+
+const NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const URL_PATTERN = /^https?:\/\//i;
+
+function defaultValues(initial: AuthProvider | null, defaultRedirectUri: string): AuthProviderFormValues {
+    if (!initial) {
+        return {
+            type: 'oidc',
+            name: '',
+            display_name: '',
+            issuer: '',
+            client_id: '',
+            client_secret: '',
+            scopes: ['openid', 'email', 'profile'],
+            redirect_uri: defaultRedirectUri,
+            claims_mapping: {},
+            enabled: true,
+        };
+    }
+    return {
+        id: initial.id,
+        type: 'oidc',
+        name: initial.name ?? '',
+        display_name: initial.display_name ?? '',
+        issuer: initial.issuer ?? '',
+        client_id: initial.client_id ?? '',
+        client_secret: '',
+        scopes: initial.scopes ?? ['openid', 'email', 'profile'],
+        redirect_uri: initial.redirect_uri ?? defaultRedirectUri,
+        claims_mapping: initial.claims_mapping ?? {},
+        enabled: initial.enabled ?? true,
+    };
+}
+
+function validate(values: AuthProviderFormValues, isEdit: boolean): FieldErrors {
+    const errors: FieldErrors = {};
+    if (!values.name.trim()) {
+        errors.name = 'Name is required.';
+    } else if (!NAME_PATTERN.test(values.name.trim())) {
+        errors.name = 'Use only letters, digits, underscore, or dash.';
+    } else if (values.name.length > 64) {
+        errors.name = 'Name cannot exceed 64 characters.';
+    }
+    if (!values.issuer.trim()) {
+        errors.issuer = 'Issuer URL is required.';
+    } else if (!URL_PATTERN.test(values.issuer.trim())) {
+        errors.issuer = 'Issuer must be an http(s) URL.';
+    }
+    if (!values.client_id.trim()) {
+        errors.client_id = 'Client ID is required.';
+    }
+    if (!values.redirect_uri.trim()) {
+        errors.redirect_uri = 'Redirect URI is required.';
+    } else if (!URL_PATTERN.test(values.redirect_uri.trim())) {
+        errors.redirect_uri = 'Redirect URI must be an http(s) URL.';
+    }
+    if (!isEdit && (!values.client_secret || !values.client_secret.trim())) {
+        // Public PKCE clients can omit. We surface a hint but don't block.
+        // No error set.
+    }
+    if (values.scopes.length === 0) {
+        errors.scopes_input = 'At least one scope is required.';
+    }
+    return errors;
+}
+
+export function AuthProviderDialog(props: Props) {
+    if (!props.isOpen) return null;
+    return <AuthProviderDialogInner {...props} key={props.initial?.id ?? 'new'} />;
+}
+
+function AuthProviderDialogInner({ initial, defaultRedirectUri, onClose, onSubmit }: Props) {
+    const isEdit = Boolean(initial);
+    const [values, setValues] = useState<AuthProviderFormValues>(() => defaultValues(initial, defaultRedirectUri));
+    const [errors, setErrors] = useState<FieldErrors>({});
+    const [serverError, setServerError] = useState<string | null>(null);
+    const [scopesInput, setScopesInput] = useState<string>(values.scopes.join(' '));
+    const [submitting, setSubmitting] = useState(false);
+
+    const setField = <K extends keyof AuthProviderFormValues>(key: K, value: AuthProviderFormValues[K]) => {
+        setValues((prev) => ({ ...prev, [key]: value }));
+    };
+    const setClaim = (key: 'email' | 'display_name', value: string) => {
+        setValues((prev) => ({
+            ...prev,
+            claims_mapping: { ...prev.claims_mapping, [key]: value.trim() || undefined },
+        }));
+    };
+
+    async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (submitting) return;
+        const scopes = scopesInput.split(/\s+/).map((s) => s.trim()).filter(Boolean);
+        const normalized: AuthProviderFormValues = {
+            ...values,
+            name: values.name.trim(),
+            issuer: values.issuer.trim(),
+            client_id: values.client_id.trim(),
+            redirect_uri: values.redirect_uri.trim(),
+            display_name: values.display_name?.trim() || null,
+            client_secret: values.client_secret && values.client_secret.length > 0 ? values.client_secret : null,
+            scopes,
+        };
+        const found = validate(normalized, isEdit);
+        if (Object.keys(found).length > 0) {
+            setErrors(found);
+            return;
+        }
+        setSubmitting(true);
+        setErrors({});
+        setServerError(null);
+        const result = await onSubmit(normalized);
+        setSubmitting(false);
+        if (!result.ok) {
+            setServerError(result.message || 'Failed to save provider.');
+        }
+    }
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4">
+            <div className="w-full max-w-2xl rounded-lg bg-white shadow-xl">
+                <div className="flex items-center justify-between border-b p-4">
+                    <h2 className="text-lg font-semibold">{isEdit ? 'Edit auth provider' : 'Add auth provider'}</h2>
+                    <button onClick={onClose} className="text-gray-500 hover:text-gray-700" aria-label="Close">
+                        <X size={20} />
+                    </button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-4 p-4">
+                    <div className="grid grid-cols-2 gap-4">
+                        <div>
+                            <label className="mb-1 block text-sm font-medium text-gray-700">Name</label>
+                            <input
+                                type="text"
+                                value={values.name}
+                                onChange={(e) => setField('name', e.target.value)}
+                                disabled={isEdit}
+                                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood disabled:bg-gray-50"
+                                placeholder="okta"
+                            />
+                            {errors.name && <p className="mt-1 text-xs text-red-600">{errors.name}</p>}
+                            {!errors.name && (
+                                <p className="mt-1 text-xs text-gray-500">URL-safe identifier. Cannot be changed after create.</p>
+                            )}
+                        </div>
+                        <div>
+                            <label className="mb-1 block text-sm font-medium text-gray-700">Display name</label>
+                            <input
+                                type="text"
+                                value={values.display_name ?? ''}
+                                onChange={(e) => setField('display_name', e.target.value)}
+                                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                                placeholder="Okta SSO"
+                            />
+                        </div>
+                    </div>
+
+                    <div>
+                        <label className="mb-1 block text-sm font-medium text-gray-700">Issuer URL</label>
+                        <input
+                            type="url"
+                            value={values.issuer}
+                            onChange={(e) => setField('issuer', e.target.value)}
+                            className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                            placeholder="https://example.okta.com"
+                        />
+                        {errors.issuer && <p className="mt-1 text-xs text-red-600">{errors.issuer}</p>}
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                        <div>
+                            <label className="mb-1 block text-sm font-medium text-gray-700">Client ID</label>
+                            <input
+                                type="text"
+                                value={values.client_id}
+                                onChange={(e) => setField('client_id', e.target.value)}
+                                className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                            />
+                            {errors.client_id && <p className="mt-1 text-xs text-red-600">{errors.client_id}</p>}
+                        </div>
+                        <div>
+                            <label className="mb-1 block text-sm font-medium text-gray-700">
+                                Client secret {isEdit && <span className="text-gray-400">(blank = keep existing)</span>}
+                            </label>
+                            <input
+                                type="password"
+                                value={values.client_secret ?? ''}
+                                onChange={(e) => setField('client_secret', e.target.value)}
+                                autoComplete="new-password"
+                                className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                            />
+                            <p className="mt-1 text-xs text-gray-500">Leave blank for public (PKCE-only) clients.</p>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label className="mb-1 block text-sm font-medium text-gray-700">Redirect URI</label>
+                        <input
+                            type="url"
+                            value={values.redirect_uri}
+                            onChange={(e) => setField('redirect_uri', e.target.value)}
+                            className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                        />
+                        {errors.redirect_uri && <p className="mt-1 text-xs text-red-600">{errors.redirect_uri}</p>}
+                        {!errors.redirect_uri && (
+                            <p className="mt-1 text-xs text-gray-500">Register this exact URL with the IdP.</p>
+                        )}
+                    </div>
+
+                    <div>
+                        <label className="mb-1 block text-sm font-medium text-gray-700">Scopes</label>
+                        <input
+                            type="text"
+                            value={scopesInput}
+                            onChange={(e) => setScopesInput(e.target.value)}
+                            className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                            placeholder="openid email profile"
+                        />
+                        {errors.scopes_input && <p className="mt-1 text-xs text-red-600">{errors.scopes_input}</p>}
+                        {!errors.scopes_input && (
+                            <p className="mt-1 text-xs text-gray-500">Space-separated. `openid` is added automatically.</p>
+                        )}
+                    </div>
+
+                    <fieldset className="rounded-md border border-gray-200 p-3">
+                        <legend className="px-2 text-xs font-medium uppercase tracking-wider text-gray-500">Claim mapping</legend>
+                        <div className="grid grid-cols-2 gap-4">
+                            <div>
+                                <label className="mb-1 block text-xs text-gray-600">Email claim</label>
+                                <input
+                                    type="text"
+                                    value={values.claims_mapping.email ?? ''}
+                                    onChange={(e) => setClaim('email', e.target.value)}
+                                    placeholder="email"
+                                    className="w-full rounded-md border border-gray-300 px-3 py-1.5 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                                />
+                            </div>
+                            <div>
+                                <label className="mb-1 block text-xs text-gray-600">Display name claim</label>
+                                <input
+                                    type="text"
+                                    value={values.claims_mapping.display_name ?? ''}
+                                    onChange={(e) => setClaim('display_name', e.target.value)}
+                                    placeholder="name"
+                                    className="w-full rounded-md border border-gray-300 px-3 py-1.5 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                                />
+                            </div>
+                        </div>
+                        <p className="mt-2 text-xs text-gray-500">Empty fields fall back to the OIDC standard claim names.</p>
+                    </fieldset>
+
+                    <label className="flex items-center gap-2 text-sm text-gray-700">
+                        <input
+                            type="checkbox"
+                            checked={values.enabled}
+                            onChange={(e) => setField('enabled', e.target.checked)}
+                            className="h-4 w-4 rounded border-gray-300 text-oxblood focus:ring-oxblood"
+                        />
+                        Enabled (visible on the login page)
+                    </label>
+
+                    {serverError && (
+                        <div role="alert" className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                            {serverError}
+                        </div>
+                    )}
+
+                    <div className="flex items-center justify-end gap-2 border-t pt-3">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={submitting}
+                            className="rounded-md bg-oxblood px-3 py-2 text-sm font-medium text-white hover:bg-oxblood-deep disabled:opacity-60"
+                        >
+                            {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create provider'}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -9,6 +9,7 @@ import {
     HelpCircle,
     History,
     Home,
+    KeyRound,
     Plus,
     Settings as SettingsIcon,
     Star,
@@ -27,6 +28,7 @@ type NavEntry = {
     icon: typeof Home;
     stub?: boolean;
     permission?: string;
+    role?: string;
 };
 
 const PRIMARY_NAV: NavEntry[] = [
@@ -36,6 +38,10 @@ const PRIMARY_NAV: NavEntry[] = [
     { path: '/folders', label: 'Folders', icon: FolderClosed, stub: true },
     { path: '/favorites', label: 'Favorites', icon: Star, stub: true },
     { path: '/recent', label: 'Recent', icon: History, stub: true },
+];
+
+const ADMIN_NAV: NavEntry[] = [
+    { path: '/admin/auth-providers', label: 'Auth Providers', icon: KeyRound, role: 'admin' },
 ];
 
 const FOOTER_NAV: NavEntry[] = [
@@ -168,7 +174,7 @@ function HeaderInner() {
 
 function AppShellInner() {
     const navigate = useNavigate();
-    const { hasPermission } = useAuth();
+    const { hasPermission, hasRole } = useAuth();
     const canRunQueries = hasPermission('query.run');
 
     const NewQueryButton = useMemo(() => (
@@ -184,8 +190,14 @@ function AppShellInner() {
         </button>
     ), [canRunQueries, navigate]);
 
-    const primaryNav = PRIMARY_NAV.filter((item) => !item.permission || hasPermission(item.permission));
-    const footerNav = FOOTER_NAV.filter((item) => !item.permission || hasPermission(item.permission));
+    function isVisible(item: NavEntry) {
+        if (item.role && !hasRole(item.role)) return false;
+        if (item.permission && !hasPermission(item.permission)) return false;
+        return true;
+    }
+    const primaryNav = PRIMARY_NAV.filter(isVisible);
+    const adminNav = ADMIN_NAV.filter(isVisible);
+    const footerNav = FOOTER_NAV.filter(isVisible);
 
     return (
         <div className="flex h-screen w-screen overflow-hidden">
@@ -206,6 +218,14 @@ function AppShellInner() {
                     {primaryNav.map((item) => (
                         <NavItem key={item.path} to={item.path} label={item.label} Icon={item.icon} stub={item.stub} />
                     ))}
+                    {adminNav.length > 0 && (
+                        <div className="mt-4 space-y-1 border-t border-white/5 pt-3">
+                            <div className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-slate-500">Admin</div>
+                            {adminNav.map((item) => (
+                                <NavItem key={item.path} to={item.path} label={item.label} Icon={item.icon} stub={item.stub} />
+                            ))}
+                        </div>
+                    )}
                 </nav>
 
                 <div className="mt-auto space-y-1 border-t border-white/5 px-2 pt-3">

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -597,6 +597,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/auth-providers/{providerId}/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Test an OIDC provider's reachability and metadata
+         * @description Requires the `admin` role. Runs OIDC discovery against the configured
+         *     issuer and returns the parsed metadata or a structured error. Does NOT
+         *     attempt authentication.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    providerId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Test result (success or failure). Always 200 — inspect `ok`. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AuthProviderTestResult"];
+                    };
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Provider not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/data-sources/{dataSourceId}/access": {
         parameters: {
             query?: never;
@@ -2647,8 +2711,23 @@ export interface components {
             client_secret?: string | null;
             scopes?: string[];
             redirect_uri: string;
-            claims_mapping?: Record<string, never>;
+            claims_mapping?: {
+                email?: string;
+                display_name?: string;
+            };
             enabled?: boolean;
+        };
+        AuthProviderTestResult: {
+            ok?: boolean;
+            error?: string | null;
+            issuer?: string;
+            authorization_endpoint?: string | null;
+            token_endpoint?: string | null;
+            userinfo_endpoint?: string | null;
+            jwks_uri?: string | null;
+            response_types_supported?: string[];
+            id_token_signing_alg_values_supported?: string[];
+            code_challenge_methods_supported?: string[];
         };
         OidcProviderLoginEntry: {
             id?: string;

--- a/frontend/src/pages/AuthProviders.tsx
+++ b/frontend/src/pages/AuthProviders.tsx
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CheckCircle2, KeyRound, Plus, RefreshCw, ShieldAlert, Trash2, XCircle } from 'lucide-react';
+import { format } from 'date-fns';
+import { toast } from 'sonner';
+import { client } from '../lib/api/client';
+import { AuthProviderDialog, type AuthProvider, type AuthProviderFormValues } from '../components/Admin/AuthProviderDialog';
+
+type TestState = {
+    ok: boolean | null;
+    error?: string;
+    issuer?: string;
+    at?: string;
+    running?: boolean;
+};
+
+function defaultRedirectUri(): string {
+    if (typeof window === 'undefined') return '';
+    return `${window.location.origin}/v1/auth/oidc/callback`;
+}
+
+export function AuthProviders() {
+    const [items, setItems] = useState<AuthProvider[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [editing, setEditing] = useState<AuthProvider | null>(null);
+    const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+    const [tests, setTests] = useState<Record<string, TestState>>({});
+
+    const fetchProviders = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            const { data } = await client.GET('/v1/admin/auth-providers');
+            setItems(data?.items ?? []);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void fetchProviders();
+    }, [fetchProviders]);
+
+    const redirectUri = useMemo(() => defaultRedirectUri(), []);
+
+    async function handleSubmit(values: AuthProviderFormValues): Promise<{ ok: boolean; message?: string }> {
+        const { id, ...rest } = values;
+        const body = id ? { id, ...rest } : rest;
+        const { response, data, error } = await client.POST('/v1/admin/auth-providers', { body });
+        if (response.ok) {
+            toast.success(id ? 'Provider updated.' : 'Provider created.');
+            setDialogOpen(false);
+            setEditing(null);
+            await fetchProviders();
+            if (data && 'id' in data && typeof data.id === 'string') {
+                setTests((prev) => ({ ...prev, [data.id as string]: { ok: null } }));
+            }
+            return { ok: true };
+        }
+        let message = `Failed (${response.status}).`;
+        if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: string }).message === 'string') {
+            message = (error as { message: string }).message;
+        }
+        return { ok: false, message };
+    }
+
+    async function handleDelete(id: string) {
+        const { response } = await client.DELETE('/v1/admin/auth-providers/{providerId}', {
+            params: { path: { providerId: id } },
+        });
+        if (response.ok) {
+            toast.success('Provider deleted.');
+            await fetchProviders();
+        } else {
+            toast.error('Failed to delete provider.');
+        }
+        setConfirmDeleteId(null);
+    }
+
+    async function handleTest(provider: AuthProvider) {
+        if (!provider.id) return;
+        setTests((prev) => ({ ...prev, [provider.id as string]: { ...(prev[provider.id as string] || { ok: null }), running: true } }));
+        const { data, response } = await client.POST(
+            '/v1/admin/auth-providers/{providerId}/test',
+            { params: { path: { providerId: provider.id } } },
+        );
+        if (!response.ok || !data) {
+            setTests((prev) => ({
+                ...prev,
+                [provider.id as string]: { ok: false, error: `HTTP ${response.status}`, at: new Date().toISOString() },
+            }));
+            return;
+        }
+        setTests((prev) => ({
+            ...prev,
+            [provider.id as string]: {
+                ok: Boolean(data.ok),
+                error: data.ok ? undefined : data.error ?? 'Test failed.',
+                issuer: data.issuer,
+                at: new Date().toISOString(),
+            },
+        }));
+    }
+
+    return (
+        <div className="flex h-full flex-col p-6">
+            <div className="mb-6 flex items-start justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold text-gray-900">Auth Providers</h1>
+                    <p className="mt-1 text-sm text-gray-500">
+                        Configure OIDC identity providers that appear on the login page.
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={() => { setEditing(null); setDialogOpen(true); }}
+                    className="flex items-center gap-2 rounded-md bg-oxblood px-4 py-2 text-sm font-medium text-white hover:bg-oxblood-deep"
+                >
+                    <Plus size={16} />
+                    Add provider
+                </button>
+            </div>
+
+            <div className="flex-1 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+                <div className="grid grid-cols-12 gap-4 border-b border-gray-200 bg-gray-50 px-4 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">
+                    <div className="col-span-3">Provider</div>
+                    <div className="col-span-3">Issuer</div>
+                    <div className="col-span-2">Status</div>
+                    <div className="col-span-2">Health</div>
+                    <div className="col-span-2 text-right">Actions</div>
+                </div>
+
+                <div className="h-full overflow-y-auto">
+                    {isLoading ? (
+                        <div className="flex h-64 flex-col items-center justify-center text-gray-500">
+                            <RefreshCw className="mb-2 animate-spin" size={20} />
+                            <p>Loading…</p>
+                        </div>
+                    ) : items.length === 0 ? (
+                        <div className="flex h-64 flex-col items-center justify-center text-gray-500">
+                            <KeyRound size={40} className="mb-3 opacity-30" />
+                            <p className="text-sm font-medium">No auth providers configured</p>
+                            <p className="mt-1 text-xs">Add your first OIDC provider to enable SSO on the login page.</p>
+                        </div>
+                    ) : (
+                        items.map((provider) => {
+                            const t = provider.id ? tests[provider.id] : undefined;
+                            return (
+                                <div key={provider.id} className="grid grid-cols-12 items-center gap-4 border-b border-gray-100 px-4 py-3 text-sm">
+                                    <div className="col-span-3">
+                                        <div className="font-medium text-gray-900">{provider.display_name || provider.name}</div>
+                                        <div className="text-xs text-gray-500">{provider.name} · {(provider.type || 'oidc').toUpperCase()}</div>
+                                    </div>
+                                    <div className="col-span-3 truncate text-xs text-gray-600" title={provider.issuer}>
+                                        {provider.issuer}
+                                    </div>
+                                    <div className="col-span-2">
+                                        <span
+                                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                                                provider.enabled ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-700'
+                                            }`}
+                                        >
+                                            {provider.enabled ? 'Enabled' : 'Disabled'}
+                                        </span>
+                                    </div>
+                                    <div className="col-span-2 text-xs">
+                                        {t?.running ? (
+                                            <span className="inline-flex items-center gap-1 text-gray-500">
+                                                <RefreshCw size={12} className="animate-spin" />
+                                                Testing…
+                                            </span>
+                                        ) : t?.ok === true ? (
+                                            <span className="inline-flex items-center gap-1 text-green-700">
+                                                <CheckCircle2 size={12} />
+                                                Reachable
+                                            </span>
+                                        ) : t?.ok === false ? (
+                                            <span className="inline-flex items-center gap-1 text-red-700" title={t.error}>
+                                                <XCircle size={12} />
+                                                Failed
+                                            </span>
+                                        ) : (
+                                            <span className="text-gray-400">Not tested</span>
+                                        )}
+                                        {t?.at && (
+                                            <div className="text-[10px] text-gray-400">{format(new Date(t.at), 'HH:mm:ss')}</div>
+                                        )}
+                                    </div>
+                                    <div className="col-span-2 flex items-center justify-end gap-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => handleTest(provider)}
+                                            className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-100"
+                                            title="Run OIDC discovery against the issuer"
+                                        >
+                                            Test
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => { setEditing(provider); setDialogOpen(true); }}
+                                            className="rounded px-2 py-1 text-xs text-oxblood hover:bg-oxblood/10"
+                                        >
+                                            Edit
+                                        </button>
+                                        {confirmDeleteId === provider.id ? (
+                                            <span className="flex items-center gap-1">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => provider.id && handleDelete(provider.id)}
+                                                    className="rounded bg-red-600 px-2 py-1 text-xs text-white hover:bg-red-700"
+                                                >
+                                                    Confirm
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setConfirmDeleteId(null)}
+                                                    className="px-1 text-xs text-gray-500 hover:text-gray-700"
+                                                >
+                                                    Cancel
+                                                </button>
+                                            </span>
+                                        ) : (
+                                            <button
+                                                type="button"
+                                                onClick={() => provider.id && setConfirmDeleteId(provider.id)}
+                                                className="text-gray-500 hover:text-red-600"
+                                                aria-label="Delete provider"
+                                            >
+                                                <Trash2 size={14} />
+                                            </button>
+                                        )}
+                                    </div>
+                                    {t?.ok === false && t.error && (
+                                        <div className="col-span-12 -mt-2 flex items-start gap-2 rounded border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-700">
+                                            <ShieldAlert size={14} className="mt-0.5 shrink-0" />
+                                            <div>
+                                                <div className="font-medium">Discovery failed</div>
+                                                <div className="font-mono text-[11px]">{t.error}</div>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        })
+                    )}
+                </div>
+            </div>
+
+            <AuthProviderDialog
+                isOpen={dialogOpen}
+                initial={editing}
+                defaultRedirectUri={redirectUri}
+                onClose={() => { setDialogOpen(false); setEditing(null); }}
+                onSubmit={handleSubmit}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
Closes #34 — AUTH-014. Builds on AUTH-010 (#117).

## Summary
- Admins now have a UI at `/admin/auth-providers` to add, edit, delete, and **test** OIDC providers without resorting to curl.
- New backend endpoint `POST /v1/admin/auth-providers/{id}/test` runs OIDC discovery against the configured issuer and returns the parsed metadata (or a structured error). Always responds 200 — the UI reads `ok`.
- Sidebar gains a role-gated "Admin" section. `NavEntry` now supports a `role` prop alongside `permission`; non-admins never see the section, and `RequireAuth role="admin"` blocks direct URL access too.

## Acceptance criteria
- [x] **Admin can add and activate multiple providers.** — Create / edit / delete in the new UI, with `enabled` toggle wired through. Multiple rows render side-by-side in the list.
- [x] **Provider health/test result is visible in UI.** — Each row has a "Test" button. Result shows as `Reachable` / `Failed` with a timestamp; on failure the error message is shown inline in monospace.
- [x] **Misconfiguration errors are surfaced clearly with field-level hints.** — The dialog runs client-side validation (name format, http(s) URLs, scopes required) and additionally renders backend 400/409 messages above the action row. Each field has its own helper line under the input.

## What landed
**Backend**
- `oidcService.testConnection(provider)` — runs `openid-client.discovery` and unwraps `serverMetadata()` into an admin-friendly shape (issuer / authorize / token / userinfo / JWKS endpoints + supported signing algs + PKCE methods).
- `POST /v1/admin/auth-providers/:id/test` in `routes/admin.js`, wired through the existing admin policy.
- `openapi.yaml` gains the endpoint + `AuthProviderTestResult` schema. `AuthProvider` / `AuthProviderUpsertRequest` now declare `claims_mapping` with explicit `email` / `display_name` properties so the regenerated TS types match the dialog payload.

**Frontend**
- `pages/AuthProviders.tsx` — list with status badge, per-row health column, test / edit / delete actions, inline error surface on failed tests.
- `components/Admin/AuthProviderDialog.tsx` — add/edit modal. Field-level validation, dedicated claim-mapping fieldset, scope free-text input, secure-by-default client secret (blank on edit preserves the existing value). Wrapper splits inner state with a `key` so React resets cleanly when the dialog opens — sidesteps the new `react-hooks/set-state-in-effect` lint rule.
- `App.tsx` — `/admin/auth-providers` wrapped in `RequireAuth role="admin"`.
- `AppShell.tsx` — `ADMIN_NAV` collection with the new "Auth Providers" entry, rendered as a separate sidebar section that only appears for admins.

## Test plan
- [x] `DATABASE_URL=postgresql://test:test@localhost:5432/test npm test` → 96/96 passing (5 new in `authProvidersAdminApi.test.js`: CRUD round-trip + secret redaction, field-level validation + 409 conflict, /test success, /test failure when issuer is unreachable, /test admin-only + 404/400).
- [x] `npm --prefix frontend run lint` clean.
- [x] `npm --prefix frontend run build` clean.
- [ ] Manual: log in as an admin, open the new sidebar entry, add an Okta/Keycloak provider, click **Test**, confirm the parsed metadata in the row. Toggle `enabled` off and confirm the provider disappears from the public `/login` page. Confirm a non-admin user does not see the sidebar entry and that `/admin/auth-providers` shows the Forbidden state for them.

## Out of scope (follow-ups)
- Claims/groups → roles mapping rules → AUTH-012 (JIT/linking) — needs richer mapping than email-only and is already its own ticket.
- Provider-specific connectivity diagnostics (e.g. fetching a sample userinfo response) — not in AUTH-014's scope.
- Encrypting `client_secret` at rest — out of scope for the UI ticket; tracked from AUTH-010.