### PR TITLE
AUTH-009: security hardening and account controls

### DIFF
--- a/app/src/lib/sessionCookie.js
+++ b/app/src/lib/sessionCookie.js
@@ -49,6 +49,11 @@ function buildSessionCookie(token, expiresAt) {
   if (expiresAt) {
     const expires = expiresAt instanceof Date ? expiresAt : new Date(expiresAt);
     parts.push(`Expires=${expires.toUTCString()}`);
+    // AUTH-009: pair Expires with Max-Age so a clock-skewed client still
+    // receives a finite-lifetime cookie. Clamp to 0 to avoid negative values
+    // if the server passes an already-expired timestamp.
+    const maxAgeSeconds = Math.max(0, Math.floor((expires.getTime() - Date.now()) / 1000));
+    parts.push(`Max-Age=${maxAgeSeconds}`);
   }
   if (isSecureCookie()) {
     parts.push("Secure");

--- a/app/src/routes/auth.js
+++ b/app/src/routes/auth.js
@@ -6,6 +6,7 @@ const {
 } = require("../lib/sessionCookie");
 const authService = require("../services/authService");
 const auditService = require("../services/auditService");
+const loginLockoutService = require("../services/loginLockoutService");
 const roleService = require("../services/roleService");
 
 function clientAddress(req) {
@@ -54,6 +55,31 @@ async function handleLogin(req, res) {
 
   const userAgent = req.headers["user-agent"] || null;
   const ipAddress = clientAddress(req);
+
+  // AUTH-009: refuse the attempt entirely when the account or source IP is
+  // currently locked out. We record the blocked attempt so operators can see
+  // brute-force traffic continuing against a locked account.
+  const lockout = await loginLockoutService
+    .checkLockout({ email, ipAddress })
+    .catch(() => ({ locked: false }));
+  if (lockout.locked) {
+    await auditService
+      .writeEvent({
+        actorEmail: email,
+        action: "auth.login.locked_out",
+        outcome: "failure",
+        details: { reason: lockout.reason, retry_after_seconds: lockout.retryAfterSeconds },
+        ipAddress,
+        userAgent
+      })
+      .catch(() => {});
+    res.setHeader("Retry-After", String(lockout.retryAfterSeconds));
+    return json(res, 429, {
+      error: "too_many_requests",
+      reason: lockout.reason,
+      retry_after_seconds: lockout.retryAfterSeconds
+    });
+  }
 
   const result = await authService.loginWithPassword({
     email,

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -417,6 +417,22 @@ function startServer() {
     res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
     res.setHeader("Vary", "Origin");
 
+    // AUTH-009 baseline security headers — applied to every response so that
+    // both the JSON API and the served frontend HTML get them.
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("Referrer-Policy", "no-referrer");
+    res.setHeader(
+      "Permissions-Policy",
+      "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+    );
+    // HSTS only makes sense when the deployment terminates TLS. Gated on the
+    // same flag we use for `Secure` cookies so test/dev runs don't accidentally
+    // pin localhost browsers to HTTPS.
+    if (process.env.AUTH_COOKIE_SECURE === "true" || process.env.NODE_ENV === "production") {
+      res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+    }
+
     if (req.method === "OPTIONS") {
       res.writeHead(204);
       res.end();

--- a/app/src/services/adminUserService.js
+++ b/app/src/services/adminUserService.js
@@ -57,11 +57,9 @@ async function createUser({ email, password, displayName, roles, actorUserId }) 
   if (!normalizedEmail) {
     return failure(400, { error: "bad_request", message: "email is not a valid address" });
   }
-  if (!authService.validatePassword(password)) {
-    return failure(400, {
-      error: "bad_request",
-      message: `password must be ${authService.PASSWORD_MIN_LENGTH}-${authService.PASSWORD_MAX_LENGTH} characters`
-    });
+  const policy = authService.checkPasswordPolicy(password, { email: normalizedEmail });
+  if (!policy.ok) {
+    return failure(400, { error: "bad_request", code: policy.code, message: policy.message });
   }
 
   let requestedRoleNames = null;

--- a/app/src/services/authService.js
+++ b/app/src/services/authService.js
@@ -33,14 +33,86 @@ function normalizeEmail(value) {
   return trimmed.toLowerCase();
 }
 
-function validatePassword(value) {
+// AUTH-009: a tiny banned-passwords list. Reject the obvious top hits and the
+// ones most often shown up in password-spray attempts against this app's
+// length minimum. Kept short on purpose — we lean on length + char-class
+// coverage for entropy, not on a giant denylist.
+const BANNED_PASSWORDS = new Set([
+  "password",
+  "password1",
+  "password!",
+  "passw0rd",
+  "qwerty123",
+  "12345678",
+  "123456789",
+  "1234567890",
+  "letmein!",
+  "welcome1",
+  "admin123",
+  "iloveyou1"
+]);
+
+function passwordCharClasses(value) {
+  let classes = 0;
+  if (/[a-z]/.test(value)) classes += 1;
+  if (/[A-Z]/.test(value)) classes += 1;
+  if (/[0-9]/.test(value)) classes += 1;
+  // any non-alphanumeric, non-space character counts as a symbol
+  if (/[^A-Za-z0-9\s]/.test(value)) classes += 1;
+  return classes;
+}
+
+// Returns { ok: true } or { ok: false, code, message } with a stable error
+// code so the API can map it onto a `400` response and the frontend onto a
+// specific message.
+function checkPasswordPolicy(value, { email = null } = {}) {
   if (typeof value !== "string") {
-    return false;
+    return { ok: false, code: "invalid_password", message: "password must be a string" };
   }
-  if (value.length < PASSWORD_MIN_LENGTH || value.length > PASSWORD_MAX_LENGTH) {
-    return false;
+  if (value.length < PASSWORD_MIN_LENGTH) {
+    return {
+      ok: false,
+      code: "password_too_short",
+      message: `password must be at least ${PASSWORD_MIN_LENGTH} characters`
+    };
   }
-  return true;
+  if (value.length > PASSWORD_MAX_LENGTH) {
+    return {
+      ok: false,
+      code: "password_too_long",
+      message: `password must be at most ${PASSWORD_MAX_LENGTH} characters`
+    };
+  }
+  if (passwordCharClasses(value) < 2) {
+    return {
+      ok: false,
+      code: "password_too_weak",
+      message: "password must mix at least two of: lowercase, uppercase, digit, symbol"
+    };
+  }
+  const lowered = value.toLowerCase();
+  if (BANNED_PASSWORDS.has(lowered)) {
+    return {
+      ok: false,
+      code: "password_banned",
+      message: "password is on the common-passwords block list"
+    };
+  }
+  if (typeof email === "string" && email.includes("@")) {
+    const local = email.split("@")[0].toLowerCase();
+    if (local && local.length >= 3 && lowered === local) {
+      return {
+        ok: false,
+        code: "password_matches_email",
+        message: "password must not match your email address"
+      };
+    }
+  }
+  return { ok: true };
+}
+
+function validatePassword(value, options = {}) {
+  return checkPasswordPolicy(value, options).ok;
 }
 
 function hashPassword(password) {
@@ -146,9 +218,10 @@ async function createUser({ email, password, displayName = null }) {
     err.code = "invalid_email";
     throw err;
   }
-  if (!validatePassword(password)) {
-    const err = new Error(`password must be ${PASSWORD_MIN_LENGTH}-${PASSWORD_MAX_LENGTH} characters`);
-    err.code = "invalid_password";
+  const policy = checkPasswordPolicy(password, { email: normalized });
+  if (!policy.ok) {
+    const err = new Error(policy.message);
+    err.code = policy.code;
     throw err;
   }
   const passwordHash = hashPassword(password);
@@ -267,8 +340,10 @@ module.exports = {
   SESSION_COOKIE_NAME,
   PASSWORD_MIN_LENGTH,
   PASSWORD_MAX_LENGTH,
+  BANNED_PASSWORDS,
   normalizeEmail,
   validatePassword,
+  checkPasswordPolicy,
   hashPassword,
   verifyPassword,
   generateSessionToken,

--- a/app/src/services/loginLockoutService.js
+++ b/app/src/services/loginLockoutService.js
@@ -1,0 +1,146 @@
+// AUTH-009: account / IP lockout backed by the AUTH-008 audit log.
+//
+// Why query the audit log instead of a new table?
+//   * Failed logins are already recorded there with `outcome='failure'`,
+//     `actor_email`, and `ip_address`, and the table is indexed on
+//     (outcome, created_at DESC). One read per login attempt is acceptable
+//     for a human-scale login endpoint.
+//   * Anything we'd add to a separate "lockout" table (counters, last_seen)
+//     is derivable from the same audit rows, so a second source of truth
+//     would just risk drift.
+//
+// Policy:
+//   * Track the last WINDOW_MS of failures per (actor_email) and per
+//     (ip_address). If either count is >= THRESHOLD, the request is locked
+//     for WINDOW_MS measured from the most recent failure.
+//   * A successful login (`auth.login.success`) for the same actor_email
+//     inside the window resets the email-side count — we only block on
+//     consecutive failures, not on a stale failure that preceded a recovery.
+//     IP-side block is NOT reset by a single successful login from another
+//     account, since the IP could be sweeping addresses.
+//
+// All constants are overridable via env vars so deployments / tests can
+// dial the behavior without code edits.
+
+const appDb = require("../lib/appDb");
+
+const DEFAULTS = {
+  windowMs: 15 * 60 * 1000,
+  emailThreshold: 5,
+  ipThreshold: 20
+};
+
+function readPositiveInt(name, fallback) {
+  const raw = Number(process.env[name]);
+  if (Number.isFinite(raw) && raw > 0) return Math.floor(raw);
+  return fallback;
+}
+
+function getConfig() {
+  return {
+    windowMs: readPositiveInt("AUTH_LOCKOUT_WINDOW_MS", DEFAULTS.windowMs),
+    emailThreshold: readPositiveInt("AUTH_LOCKOUT_EMAIL_THRESHOLD", DEFAULTS.emailThreshold),
+    ipThreshold: readPositiveInt("AUTH_LOCKOUT_IP_THRESHOLD", DEFAULTS.ipThreshold)
+  };
+}
+
+function normalizeEmail(email) {
+  if (typeof email !== "string") return null;
+  const trimmed = email.trim().toLowerCase();
+  return trimmed || null;
+}
+
+function normalizeIp(ipAddress) {
+  if (typeof ipAddress !== "string") return null;
+  const trimmed = ipAddress.trim();
+  return trimmed || null;
+}
+
+// Returns `{ locked: false }` when the request may proceed, or
+// `{ locked: true, reason, retryAfterSeconds }` when it must be rejected.
+async function checkLockout({ email, ipAddress } = {}) {
+  const config = getConfig();
+  const normalizedEmail = normalizeEmail(email);
+  const normalizedIp = normalizeIp(ipAddress);
+  if (!normalizedEmail && !normalizedIp) {
+    return { locked: false };
+  }
+
+  const sinceIso = new Date(Date.now() - config.windowMs).toISOString();
+
+  if (normalizedEmail) {
+    // Count failures since the most recent success (so a successful login
+    // clears the email-side strike count).
+    const result = await appDb.query(
+      `
+        WITH recent AS (
+          SELECT outcome, created_at
+          FROM auth_audit_log
+          WHERE action IN ('auth.login.failure', 'auth.login.success')
+            AND lower(actor_email) = $1
+            AND created_at >= $2
+        ),
+        last_success AS (
+          SELECT MAX(created_at) AS at FROM recent WHERE outcome = 'success'
+        )
+        SELECT
+          COUNT(*) FILTER (
+            WHERE outcome = 'failure'
+              AND created_at > COALESCE((SELECT at FROM last_success), 'epoch')
+          )::int AS failures,
+          MAX(created_at) FILTER (
+            WHERE outcome = 'failure'
+              AND created_at > COALESCE((SELECT at FROM last_success), 'epoch')
+          ) AS last_failure_at
+        FROM recent
+      `,
+      [normalizedEmail, sinceIso]
+    );
+    const row = result.rows[0] || { failures: 0, last_failure_at: null };
+    if (row.failures >= config.emailThreshold) {
+      return buildLocked("too_many_failed_logins", row.last_failure_at, config.windowMs);
+    }
+  }
+
+  if (normalizedIp) {
+    const result = await appDb.query(
+      `
+        SELECT
+          COUNT(*)::int AS failures,
+          MAX(created_at) AS last_failure_at
+        FROM auth_audit_log
+        WHERE action = 'auth.login.failure'
+          AND outcome = 'failure'
+          AND ip_address = $1
+          AND created_at >= $2
+      `,
+      [normalizedIp, sinceIso]
+    );
+    const row = result.rows[0] || { failures: 0, last_failure_at: null };
+    if (row.failures >= config.ipThreshold) {
+      return buildLocked("ip_throttled", row.last_failure_at, config.windowMs);
+    }
+  }
+
+  return { locked: false };
+}
+
+function buildLocked(reason, lastFailureAt, windowMs) {
+  let retryAfterSeconds = Math.ceil(windowMs / 1000);
+  if (lastFailureAt) {
+    const last = lastFailureAt instanceof Date
+      ? lastFailureAt.getTime()
+      : new Date(lastFailureAt).getTime();
+    if (Number.isFinite(last)) {
+      const remainingMs = (last + windowMs) - Date.now();
+      retryAfterSeconds = Math.max(1, Math.ceil(remainingMs / 1000));
+    }
+  }
+  return { locked: true, reason, retryAfterSeconds };
+}
+
+module.exports = {
+  DEFAULTS,
+  getConfig,
+  checkLockout
+};

--- a/app/test/authService.test.js
+++ b/app/test/authService.test.js
@@ -14,12 +14,18 @@ test("normalizeEmail trims, lowercases, and rejects malformed addresses", () => 
   assert.equal(authService.normalizeEmail("a@b.c d"), null);
 });
 
-test("validatePassword enforces length bounds", () => {
+test("validatePassword enforces length and character-class policy (AUTH-009)", () => {
+  // Length floor
   assert.equal(authService.validatePassword("short"), false);
-  assert.equal(authService.validatePassword("12345678"), true);
-  assert.equal(authService.validatePassword(""), false);
+  // Length ceiling
   assert.equal(authService.validatePassword("x".repeat(257)), false);
+  // Empty / non-string
+  assert.equal(authService.validatePassword(""), false);
   assert.equal(authService.validatePassword(123456789), false);
+  // Single character class — rejected post-AUTH-009
+  assert.equal(authService.validatePassword("12345678"), false);
+  // Two character classes — accepted
+  assert.equal(authService.validatePassword("hunter22ok"), true);
 });
 
 test("hashPassword + verifyPassword round-trip and reject wrong values", () => {

--- a/app/test/passwordPolicy.test.js
+++ b/app/test/passwordPolicy.test.js
@@ -1,0 +1,64 @@
+// AUTH-009: server-side password policy. Pure unit tests against the
+// policy function — no DB / HTTP setup needed, but authService transitively
+// requires appDb which insists on a DATABASE_URL even when it's never used.
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const authService = require("../src/services/authService");
+
+test("rejects passwords below the minimum length", () => {
+  const result = authService.checkPasswordPolicy("Ab1!");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "password_too_short");
+});
+
+test("rejects passwords above the maximum length", () => {
+  const tooLong = "A1!".repeat(100);
+  const result = authService.checkPasswordPolicy(tooLong);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "password_too_long");
+});
+
+test("rejects passwords with only one character class", () => {
+  const result = authService.checkPasswordPolicy("aaaaaaaaaaaaaa");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "password_too_weak");
+});
+
+test("accepts passwords with two character classes", () => {
+  const result = authService.checkPasswordPolicy("hunter22ok");
+  assert.equal(result.ok, true);
+});
+
+test("rejects banned common passwords regardless of case", () => {
+  for (const variant of ["password1", "Password1", "PASSWORD1"]) {
+    const result = authService.checkPasswordPolicy(variant);
+    assert.equal(result.ok, false, `should reject ${variant}`);
+    assert.equal(result.code, "password_banned");
+  }
+});
+
+test("rejects passwords that equal the email local-part", () => {
+  const result = authService.checkPasswordPolicy("alice123", { email: "alice123@example.com" });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "password_matches_email");
+});
+
+test("passes a strong password unrelated to the email", () => {
+  const result = authService.checkPasswordPolicy("Tr0ub4dor!!", { email: "alice@example.com" });
+  assert.equal(result.ok, true);
+});
+
+test("rejects non-string input", () => {
+  assert.equal(authService.checkPasswordPolicy(undefined).ok, false);
+  assert.equal(authService.checkPasswordPolicy(null).ok, false);
+  assert.equal(authService.checkPasswordPolicy(12345678).ok, false);
+});
+
+test("validatePassword is a boolean shim over checkPasswordPolicy", () => {
+  assert.equal(authService.validatePassword("hunter22ok"), true);
+  assert.equal(authService.validatePassword("short"), false);
+});

--- a/app/test/securityHardeningApi.test.js
+++ b/app/test/securityHardeningApi.test.js
@@ -1,0 +1,291 @@
+// AUTH-009: end-to-end coverage for the hardening work — baseline security
+// headers on every response, complete session-cookie attributes, and the
+// brute-force lockout that returns 429 with a Retry-After header.
+//
+// We point the lockout service at a small window via env vars so the assertion
+// path doesn't have to wait minutes.
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+process.env.PORT = "0";
+process.env.AUTH_COOKIE_SECURE = "false";
+process.env.AUTH_LOCKOUT_WINDOW_MS = "60000";
+process.env.AUTH_LOCKOUT_EMAIL_THRESHOLD = "3";
+process.env.AUTH_LOCKOUT_IP_THRESHOLD = "10";
+
+const appDb = require("../src/lib/appDb");
+const authService = require("../src/services/authService");
+
+let server;
+let baseUrl;
+let users;
+let sessions;
+let auditRows;
+let originalQuery;
+let userCounter;
+let sessionCounter;
+let auditCounter;
+
+function uuid(prefix, counter) {
+  return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
+}
+
+function normalize(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+async function call(method, path, { cookie, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (cookie) headers.Cookie = cookie;
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  let payload = null;
+  if ((response.headers.get("content-type") || "").includes("application/json")) {
+    try { payload = await response.json(); } catch { payload = null; }
+  }
+  return {
+    status: response.status,
+    payload,
+    setCookie: response.headers.get("set-cookie"),
+    headers: response.headers
+  };
+}
+
+function emailFailureCount(email) {
+  return auditRows.filter(
+    (r) => r.action === "auth.login.failure" && r.actor_email === email.toLowerCase()
+  ).length;
+}
+
+before(async () => {
+  originalQuery = appDb.query;
+  users = new Map();
+  sessions = new Map();
+  auditRows = [];
+  userCounter = 0;
+  sessionCounter = 0;
+  auditCounter = 0;
+
+  // Seed an active user we can log in as.
+  userCounter += 1;
+  const userId = uuid("aaaa", userCounter);
+  users.set(userId, {
+    id: userId,
+    email: "alice@example.com",
+    password_hash: authService.hashPassword("Hunter22ok!"),
+    display_name: "Alice",
+    is_active: true,
+    last_login_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  });
+
+  appDb.query = async (sql, params = []) => {
+    const n = normalize(sql);
+
+    if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
+      const [emailLower] = params;
+      const row = [...users.values()].find((u) => u.email.toLowerCase() === emailLower);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    if (n.startsWith("insert into user_sessions")) {
+      const [uid, tokenHash, ua, ip, expiresAt] = params;
+      sessionCounter += 1;
+      const id = uuid("bbbb", sessionCounter);
+      sessions.set(id, { id, user_id: uid, token_hash: tokenHash, user_agent: ua, ip_address: ip, expires_at: expiresAt, created_at: new Date().toISOString(), revoked_at: null });
+      return { rowCount: 1, rows: [{ id, expires_at: expiresAt }] };
+    }
+
+    if (n.startsWith("update users set last_login_at = now() where id = $1")) {
+      return { rowCount: 1, rows: [] };
+    }
+
+    // auditService.writeEvent insert
+    if (n.startsWith("insert into auth_audit_log")) {
+      const [actorUserId, actorEmail, targetUserId, action, outcome, detailsJson, ipAddress, userAgent] = params;
+      auditCounter += 1;
+      auditRows.push({
+        id: uuid("dddd", auditCounter),
+        actor_user_id: actorUserId,
+        actor_email: actorEmail,
+        target_user_id: targetUserId,
+        action,
+        outcome,
+        details: JSON.parse(detailsJson),
+        ip_address: ipAddress,
+        user_agent: userAgent,
+        created_at: new Date(Date.now() + auditCounter).toISOString()
+      });
+      return { rowCount: 1, rows: [] };
+    }
+
+    // loginLockoutService — email-window query
+    if (n.startsWith("with recent as ( select outcome, created_at from auth_audit_log where action in")) {
+      const [emailLower, sinceIso] = params;
+      const relevant = auditRows.filter(
+        (r) => (r.action === "auth.login.failure" || r.action === "auth.login.success")
+          && (r.actor_email || "").toLowerCase() === emailLower
+          && r.created_at >= sinceIso
+      );
+      const lastSuccess = relevant
+        .filter((r) => r.outcome === "success")
+        .reduce((max, r) => (r.created_at > max ? r.created_at : max), "");
+      const failures = relevant
+        .filter((r) => r.outcome === "failure" && (lastSuccess === "" || r.created_at > lastSuccess));
+      const lastFailureAt = failures.reduce((max, r) => (r.created_at > max ? r.created_at : max), null);
+      return { rowCount: 1, rows: [{ failures: failures.length, last_failure_at: lastFailureAt }] };
+    }
+
+    // loginLockoutService — IP query
+    if (n.startsWith("select count(*)::int as failures, max(created_at) as last_failure_at from auth_audit_log where action = 'auth.login.failure'")) {
+      const [ipAddress, sinceIso] = params;
+      const matching = auditRows.filter(
+        (r) => r.action === "auth.login.failure"
+          && r.outcome === "failure"
+          && r.ip_address === ipAddress
+          && r.created_at >= sinceIso
+      );
+      const lastFailureAt = matching.reduce((max, r) => (r.created_at > max ? r.created_at : max), null);
+      return { rowCount: 1, rows: [{ failures: matching.length, last_failure_at: lastFailureAt }] };
+    }
+
+    // Session lookup (after successful login, used by /v1/auth/me) — not
+    // strictly needed by this suite but kept for completeness.
+    if (n.startsWith("select s.id as session_id, s.expires_at, s.revoked_at, u.id, u.email")) {
+      const [tokenHash] = params;
+      const session = [...sessions.values()].find((s) => s.token_hash === tokenHash);
+      if (!session) return { rowCount: 0, rows: [] };
+      const user = users.get(session.user_id);
+      if (!user) return { rowCount: 0, rows: [] };
+      return {
+        rowCount: 1,
+        rows: [{
+          session_id: session.id,
+          expires_at: session.expires_at,
+          revoked_at: session.revoked_at,
+          id: user.id,
+          email: user.email,
+          password_hash: user.password_hash,
+          display_name: user.display_name,
+          is_active: user.is_active,
+          last_login_at: user.last_login_at,
+          created_at: user.created_at,
+          updated_at: user.updated_at
+        }]
+      };
+    }
+
+    // role / permission lookups during successful login authz hydration —
+    // empty result is acceptable, the user just has no roles in the
+    // response.
+    if (n.startsWith("select r.id, r.name, r.description, r.is_system, ur.assigned_at from user_roles ur")) {
+      return { rowCount: 0, rows: [] };
+    }
+    if (n.startsWith("select distinct p.name from user_roles ur")) {
+      return { rowCount: 0, rows: [] };
+    }
+
+    throw new Error(`Unexpected SQL in security hardening test stub: ${n}`);
+  };
+
+  delete require.cache[require.resolve("../src/server")];
+  const { startServer } = require("../src/server");
+  server = await startServer();
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  appDb.query = originalQuery;
+});
+
+beforeEach(() => {
+  auditRows.length = 0;
+  auditCounter = 0;
+});
+
+test("all responses carry baseline security headers", async () => {
+  const result = await call("GET", "/health");
+  assert.equal(result.status, 200);
+  assert.equal(result.headers.get("x-content-type-options"), "nosniff");
+  assert.equal(result.headers.get("x-frame-options"), "DENY");
+  assert.equal(result.headers.get("referrer-policy"), "no-referrer");
+  const permissions = result.headers.get("permissions-policy");
+  assert.ok(permissions && permissions.includes("camera=()"));
+  // HSTS is gated on secure cookies / production. Tests run with
+  // AUTH_COOKIE_SECURE=false, so HSTS must NOT be set here.
+  assert.equal(result.headers.get("strict-transport-security"), null);
+});
+
+test("successful login sets a session cookie with HttpOnly, SameSite, and Max-Age", async () => {
+  const result = await call("POST", "/v1/auth/login", {
+    body: { email: "alice@example.com", password: "Hunter22ok!" }
+  });
+  assert.equal(result.status, 200);
+  assert.ok(result.setCookie, "expected Set-Cookie header");
+  assert.match(result.setCookie, /HttpOnly/);
+  assert.match(result.setCookie, /SameSite=Lax/);
+  assert.match(result.setCookie, /Path=\//);
+  const maxAge = result.setCookie.match(/Max-Age=(\d+)/);
+  assert.ok(maxAge, "expected Max-Age on the session cookie");
+  assert.ok(Number(maxAge[1]) > 0, "Max-Age should be positive");
+  // Secure must NOT be set in the test environment (AUTH_COOKIE_SECURE=false).
+  assert.doesNotMatch(result.setCookie, /Secure/);
+});
+
+test("repeated failed logins return 429 with Retry-After and emit an audit row", async () => {
+  const body = { email: "alice@example.com", password: "wrong-Pass-1!" };
+
+  for (let i = 0; i < 3; i += 1) {
+    const r = await call("POST", "/v1/auth/login", { body });
+    assert.equal(r.status, 401, `attempt ${i + 1} should be 401`);
+  }
+  // Wait for the audit writes (they are .catch'd and fire asynchronously).
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(emailFailureCount("alice@example.com"), 3);
+
+  const locked = await call("POST", "/v1/auth/login", { body });
+  assert.equal(locked.status, 429);
+  assert.equal(locked.payload.error, "too_many_requests");
+  assert.equal(locked.payload.reason, "too_many_failed_logins");
+  assert.ok(locked.payload.retry_after_seconds >= 1);
+  assert.equal(
+    locked.headers.get("retry-after"),
+    String(locked.payload.retry_after_seconds)
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  const lockoutRow = auditRows.find((r) => r.action === "auth.login.locked_out");
+  assert.ok(lockoutRow, "lockout attempts must be recorded");
+  assert.equal(lockoutRow.outcome, "failure");
+  assert.equal(lockoutRow.details.reason, "too_many_failed_logins");
+});
+
+test("a successful login mid-window resets the email-side strike counter", async () => {
+  // Three failures bring us to the threshold (which is `>=`, not `>`),
+  // so the next login attempt would normally be locked. A successful login
+  // between them must reset the count and let the user proceed.
+  const wrong = { email: "alice@example.com", password: "wrong-Pass-1!" };
+  const right = { email: "alice@example.com", password: "Hunter22ok!" };
+
+  for (let i = 0; i < 2; i += 1) {
+    const r = await call("POST", "/v1/auth/login", { body: wrong });
+    assert.equal(r.status, 401);
+  }
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const success = await call("POST", "/v1/auth/login", { body: right });
+  assert.equal(success.status, 200);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  // After the success, two more failures should be allowed (not locked).
+  for (let i = 0; i < 2; i += 1) {
+    const r = await call("POST", "/v1/auth/login", { body: wrong });
+    assert.equal(r.status, 401, `post-success attempt ${i + 1} should still be 401, not 429`);
+  }
+});

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -18,7 +18,11 @@ paths:
     post:
       tags: [Auth]
       summary: Authenticate with email and password
-      description: Returns the authenticated user and sets an HttpOnly session cookie.
+      description: |
+        Returns the authenticated user and sets an HttpOnly session cookie.
+        After repeated failures from the same email or source IP within a
+        sliding window, the endpoint refuses further attempts with `429` and
+        a `Retry-After` header (AUTH-009).
       requestBody:
         required: true
         content:
@@ -36,6 +40,19 @@ paths:
           description: Missing email or password
         "401":
           description: Invalid credentials
+        "429":
+          description: |
+            Too many failed login attempts for this email or source IP.
+            Retry once `Retry-After` (in seconds) has elapsed.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds the client should wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoginLockoutResponse"
   /v1/auth/logout:
     post:
       tags: [Auth]
@@ -1443,6 +1460,19 @@ components:
           format: email
         password:
           type: string
+    LoginLockoutResponse:
+      type: object
+      required: [error, retry_after_seconds]
+      properties:
+        error:
+          type: string
+          enum: [too_many_requests]
+        reason:
+          type: string
+          enum: [too_many_failed_logins, ip_throttled]
+        retry_after_seconds:
+          type: integer
+          minimum: 1
     AuthUser:
       type: object
       properties:

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -26,7 +26,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     const login = useCallback(
         async (email: string, password: string) => {
-            const { data, response } = await client.POST('/v1/auth/login', {
+            const { data, response, error } = await client.POST('/v1/auth/login', {
                 body: { email, password },
             });
             if (response.ok && data?.user) {
@@ -34,6 +34,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 setExpiresAt(data.expires_at ?? null);
                 setStatus('authenticated');
                 return { ok: true } as const;
+            }
+            if (response.status === 429) {
+                // AUTH-009 lockout: backend returns retry_after_seconds in the
+                // body and a Retry-After header. Prefer the body so the message
+                // matches whichever predicate (email vs ip) tripped.
+                const retryHeader = response.headers.get('Retry-After');
+                const bodyRetry =
+                    error && typeof error === 'object' && 'retry_after_seconds' in error
+                        ? Number((error as { retry_after_seconds?: unknown }).retry_after_seconds)
+                        : NaN;
+                const seconds = Number.isFinite(bodyRetry)
+                    ? bodyRetry
+                    : retryHeader
+                        ? Number(retryHeader)
+                        : 60;
+                const minutes = Math.max(1, Math.ceil(seconds / 60));
+                return {
+                    ok: false,
+                    message: `Too many failed sign-in attempts. Try again in about ${minutes} minute${minutes === 1 ? '' : 's'}.`,
+                } as const;
             }
             const message =
                 response.status === 401

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -16,6 +16,9 @@ export interface paths {
         /**
          * Authenticate with email and password
          * @description Returns the authenticated user and sets an HttpOnly session cookie.
+         *     After repeated failures from the same email or source IP within a
+         *     sliding window, the endpoint refuses further attempts with `429` and
+         *     a `Retry-After` header (AUTH-009).
          */
         post: {
             parameters: {
@@ -52,6 +55,20 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
+                };
+                /**
+                 * @description Too many failed login attempts for this email or source IP.
+                 *     Retry once `Retry-After` (in seconds) has elapsed.
+                 */
+                429: {
+                    headers: {
+                        /** @description Seconds the client should wait before retrying. */
+                        "Retry-After"?: number;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["LoginLockoutResponse"];
+                    };
                 };
             };
         };
@@ -2700,6 +2717,13 @@ export interface components {
             /** Format: email */
             email: string;
             password: string;
+        };
+        LoginLockoutResponse: {
+            /** @enum {string} */
+            error: "too_many_requests";
+            /** @enum {string} */
+            reason?: "too_many_failed_logins" | "ip_throttled";
+            retry_after_seconds: number;
         };
         AuthUser: {
             id?: string;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -91,10 +91,15 @@ export function Login() {
                             type="password"
                             autoComplete="current-password"
                             required
+                            minLength={8}
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
                             className="w-full px-3 py-2 text-sm border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-oxblood focus:border-transparent"
+                            aria-describedby="login-password-hint"
                         />
+                        <p id="login-password-hint" className="mt-1 text-xs text-gray-500">
+                            At least 8 characters with a mix of letters and digits.
+                        </p>
                     </div>
 
                     {error && (


### PR DESCRIPTION
## Summary

- Adds login lockout (429 + `Retry-After`) on top of the AUTH-008 audit log: locks an email after 5 failed attempts in a 15-minute sliding window, and an IP after 20. A successful login clears the email-side strike count. Lockout-blocked attempts are themselves recorded as `auth.login.locked_out` audit rows.
- Tightens the server-side password policy: min 8 / max 256 chars, must mix at least two of lowercase / uppercase / digit / symbol, banned-passwords list, must not equal the email local-part. Error codes are stable (`password_too_short`, `password_too_weak`, `password_banned`, `password_matches_email`).
- Sets baseline security headers on every response: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `Permissions-Policy`, and (production-gated) `Strict-Transport-Security`.
- Adds `Max-Age` to the session cookie alongside `Expires` so clock-skewed clients still get a finite-lifetime cookie.
- Frontend login flow surfaces a friendly "Try again in N minutes" message on 429 and adds an inline password hint matching the server policy.

## Implementation notes

- Lockout is implemented as a read against `auth_audit_log` (indexed on `outcome` + `created_at` by AUTH-008) rather than a new table. One short query per login attempt; no separate counter to keep in sync.
- Thresholds and window are overridable via `AUTH_LOCKOUT_WINDOW_MS`, `AUTH_LOCKOUT_EMAIL_THRESHOLD`, `AUTH_LOCKOUT_IP_THRESHOLD`.
- HSTS is gated on `AUTH_COOKIE_SECURE=true` or `NODE_ENV=production` so localhost / test runs don't accidentally pin browsers to HTTPS.
- The legacy single-classifier password test was updated to reflect the new policy; no production password storage changes (existing scrypt hashes are unaffected).

## Verification

- [x] `npm test` — 116 pass, 0 fail
- [x] `npm --prefix frontend run lint` — clean
- [x] `cd frontend && npx tsc -b` — clean
- [ ] Manual: confirm 429 + Retry-After in browser after 5 wrong passwords; confirm headers via DevTools

Closes #29