### PR TITLE
AUTH-015: federation security hardening

### DIFF
--- a/app/src/routes/oidc.js
+++ b/app/src/routes/oidc.js
@@ -6,6 +6,7 @@ const auditService = require("../services/auditService");
 const authProviderService = require("../services/authProviderService");
 const externalLoginService = require("../services/externalLoginService");
 const oidcService = require("../services/oidcService");
+const oidcStateService = require("../services/oidcStateService");
 
 function clientAddress(req) {
   const fwd = req.headers["x-forwarded-for"];
@@ -72,6 +73,32 @@ async function handleCallback(req, res, requestUrl) {
 
   const ipAddress = clientAddress(req);
   const userAgent = req.headers["user-agent"] || null;
+
+  // AUTH-015: replay protection. Mark the state as consumed BEFORE running
+  // the token exchange so a concurrent replay can't sneak in. If the state
+  // hash is already on file we abort with a 400 and record a security
+  // event.
+  const stateExpiresAt = new Date(Date.now() + 15 * 60 * 1000);
+  const recorded = await oidcStateService
+    .recordUsedState({ state: flowState.state, providerId: provider.id, expiresAt: stateExpiresAt })
+    .catch((err) => ({ replayed: false, ok: false, reason: err && err.message }));
+  if (recorded.replayed) {
+    res.setHeader("Set-Cookie", buildClearFlowCookie());
+    await auditService
+      .writeEvent({
+        action: "auth.security.state_replay_blocked",
+        outcome: "failure",
+        details: { method: "oidc", provider: provider.name, reason: recorded.reason || "state_replayed" },
+        ipAddress,
+        userAgent
+      })
+      .catch(() => {});
+    return json(res, 400, {
+      error: "bad_request",
+      code: "state_replayed",
+      message: "this authorization response has already been processed"
+    });
+  }
 
   let principal;
   try {

--- a/app/src/services/authProviderService.js
+++ b/app/src/services/authProviderService.js
@@ -51,6 +51,7 @@ const PROVIDER_COLUMNS = `
   id, type, name, display_name, issuer, client_id, client_secret,
   scopes, redirect_uri, claims_mapping, enabled,
   auto_link_by_email, jit_enabled, jit_default_role, jit_allowed_domains,
+  require_email_verified,
   created_at, updated_at
 `;
 
@@ -72,6 +73,7 @@ function publicProvider(row, { includeSecret = false } = {}) {
     jit_enabled: row.jit_enabled === true,
     jit_default_role: row.jit_default_role || "viewer",
     jit_allowed_domains: row.jit_allowed_domains || [],
+    require_email_verified: row.require_email_verified !== false,
     created_at: row.created_at,
     updated_at: row.updated_at
   };
@@ -309,6 +311,13 @@ function validateMappingRules(body) {
     value.auto_link_by_email = body.auto_link_by_email;
   }
 
+  if (Object.prototype.hasOwnProperty.call(body, "require_email_verified")) {
+    if (typeof body.require_email_verified !== "boolean") {
+      return { ok: false, message: "require_email_verified must be a boolean" };
+    }
+    value.require_email_verified = body.require_email_verified;
+  }
+
   if (Object.prototype.hasOwnProperty.call(body, "jit_enabled")) {
     if (typeof body.jit_enabled !== "boolean") {
       return { ok: false, message: "jit_enabled must be a boolean" };
@@ -400,7 +409,8 @@ async function updateMappingRules(providerId, body, { actorUserId = null } = {})
       auto_link_by_email: row.auto_link_by_email,
       jit_enabled: row.jit_enabled,
       jit_default_role: row.jit_default_role,
-      jit_allowed_domains: row.jit_allowed_domains || []
+      jit_allowed_domains: row.jit_allowed_domains || [],
+      require_email_verified: row.require_email_verified !== false
     }
   };
 }

--- a/app/src/services/externalLoginService.js
+++ b/app/src/services/externalLoginService.js
@@ -100,6 +100,15 @@ async function resolveExternalLogin(provider, principal, context = {}) {
     return { ok: true, user: rowToUser(userRow), mode: "linked_by_sub" };
   }
 
+  // AUTH-015: when the IdP exposes an `email_verified` claim and it's
+  // explicitly false, refuse any path that trusts the email (auto-link
+  // by email + JIT). Linking by subject already happened above and is
+  // unaffected — the IdP's prior attestation of subject ownership is what
+  // protects that path.
+  const emailUnverified = provider.require_email_verified !== false
+    && principal.claims
+    && principal.claims.email_verified === false;
+
   // 2) No existing link — look for a local user by email.
   const userByEmail = await authService.findUserByEmail(principal.email);
   if (userByEmail) {
@@ -109,6 +118,29 @@ async function resolveExternalLogin(provider, principal, context = {}) {
         code: "inactive_user",
         status: 403,
         message: "local account is inactive"
+      };
+    }
+    if (emailUnverified) {
+      await auditService
+        .writeEvent({
+          actorEmail: principal.email,
+          action: "auth.security.email_unverified",
+          outcome: "failure",
+          details: {
+            provider: provider.name,
+            provider_id: provider.id,
+            subject: principal.sub,
+            phase: "auto_link"
+          },
+          ipAddress: context.ipAddress,
+          userAgent: context.userAgent
+        })
+        .catch(() => {});
+      return {
+        ok: false,
+        code: "email_unverified",
+        status: 403,
+        message: `cannot link ${principal.email}: the IdP did not assert that the email is verified.`
       };
     }
     if (!provider.auto_link_by_email) {
@@ -173,6 +205,29 @@ async function resolveExternalLogin(provider, principal, context = {}) {
       code: "jit_disabled",
       status: 403,
       message: `no active local account for ${principal.email}. Ask an administrator to create one.`
+    };
+  }
+  if (emailUnverified) {
+    await auditService
+      .writeEvent({
+        actorEmail: principal.email,
+        action: "auth.security.email_unverified",
+        outcome: "failure",
+        details: {
+          provider: provider.name,
+          provider_id: provider.id,
+          subject: principal.sub,
+          phase: "jit"
+        },
+        ipAddress: context.ipAddress,
+        userAgent: context.userAgent
+      })
+      .catch(() => {});
+    return {
+      ok: false,
+      code: "email_unverified",
+      status: 403,
+      message: `cannot provision ${principal.email}: the IdP did not assert that the email is verified.`
     };
   }
   if (!domainAllowed(principal.email, provider.jit_allowed_domains)) {

--- a/app/src/services/oidcService.js
+++ b/app/src/services/oidcService.js
@@ -29,6 +29,19 @@ function displayNameClaimFor(provider) {
   return (provider.claims_mapping && provider.claims_mapping.display_name) || DEFAULT_CLAIM_DISPLAY_NAME;
 }
 
+// AUTH-015: clock-skew tolerance for ID-token validation. Most production
+// IdPs sit behind load balancers whose clock can drift a handful of seconds;
+// 60s is the openid-client recommended default for production deployments
+// and matches what every major IdP documents. Configurable so deployments
+// with stricter requirements can dial it down.
+function getClockToleranceSeconds() {
+  const raw = Number(process.env.AUTH_OIDC_CLOCK_TOLERANCE_SECONDS);
+  if (Number.isFinite(raw) && raw >= 0 && raw <= 600) {
+    return Math.floor(raw);
+  }
+  return 60;
+}
+
 async function buildConfiguration(provider) {
   const client = await getOidcClient();
   const issuerUrl = new URL(provider.issuer);
@@ -36,10 +49,14 @@ async function buildConfiguration(provider) {
   // localhost / dev / tests; production should be https anyway.
   const allowHttp = issuerUrl.protocol === "http:";
   const options = allowHttp ? { execute: [client.allowInsecureRequests] } : undefined;
+  // Metadata object carries the clientSecret (when present) and the
+  // clock-skew tolerance. openid-client treats clockTolerance as a Symbol
+  // key on the metadata object.
+  const metadata = { [client.clockTolerance]: getClockToleranceSeconds() };
   if (provider.client_secret) {
-    return client.discovery(issuerUrl, provider.client_id, provider.client_secret, undefined, options);
+    metadata.client_secret = provider.client_secret;
   }
-  return client.discovery(issuerUrl, provider.client_id, undefined, undefined, options);
+  return client.discovery(issuerUrl, provider.client_id, metadata, undefined, options);
 }
 
 async function startLogin(provider) {

--- a/app/src/services/oidcStateService.js
+++ b/app/src/services/oidcStateService.js
@@ -1,0 +1,69 @@
+// AUTH-015: replay protection for the OIDC authorization code flow.
+//
+// The signed flow cookie alone isn't enough — once captured (e.g. a stolen
+// laptop / browser dump within the TTL window) it can be replayed against
+// the callback endpoint. We persist a hash of every state value we've seen
+// at callback time, and refuse any callback whose state we've already
+// recorded.
+//
+// Two helpers, both keyed on a SHA-256 hash so the raw state is never
+// persisted:
+//
+//   recordUsedState({ state, providerId, expiresAt })
+//     Inserts the row. If the state is already present we return
+//     `{ replayed: true }` and the caller refuses the callback. We sweep
+//     expired rows opportunistically here so the table stays bounded.
+//
+//   pruneExpired()
+//     Exposed for tests / a future scheduled sweep. Safe to call any time.
+
+const crypto = require("crypto");
+const appDb = require("../lib/appDb");
+
+const DEFAULT_GRACE_MS = 60 * 1000;
+
+function hashState(state) {
+  if (typeof state !== "string" || !state) return null;
+  return crypto.createHash("sha256").update(state, "utf8").digest("hex");
+}
+
+async function recordUsedState({ state, providerId, expiresAt }) {
+  const hash = hashState(state);
+  if (!hash) {
+    return { replayed: false, ok: false, reason: "invalid_state" };
+  }
+  const expiry = expiresAt instanceof Date
+    ? expiresAt
+    : new Date(Number(expiresAt) || (Date.now() + DEFAULT_GRACE_MS));
+  if (Number.isNaN(expiry.getTime())) {
+    return { replayed: false, ok: false, reason: "invalid_expiry" };
+  }
+
+  try {
+    await appDb.query(
+      `INSERT INTO oidc_used_states (state_hash, provider_id, expires_at)
+       VALUES ($1, $2, $3)`,
+      [hash, providerId || null, expiry.toISOString()]
+    );
+  } catch (err) {
+    if (err && err.code === "23505") {
+      return { replayed: true, ok: false, reason: "state_replayed" };
+    }
+    throw err;
+  }
+
+  // Opportunistic prune — keeps the table bounded without needing a cron.
+  // Best-effort; failure here must not block the login.
+  pruneExpired().catch(() => {});
+  return { replayed: false, ok: true };
+}
+
+async function pruneExpired() {
+  await appDb.query("DELETE FROM oidc_used_states WHERE expires_at < NOW()");
+}
+
+module.exports = {
+  hashState,
+  recordUsedState,
+  pruneExpired
+};

--- a/app/test/federationHardeningApi.test.js
+++ b/app/test/federationHardeningApi.test.js
@@ -1,0 +1,294 @@
+// AUTH-015: covers the federation-hardening additions on top of AUTH-012.
+//
+// What this exercises:
+//   - externalLoginService refuses to auto-link by email when the IdP
+//     asserts `email_verified=false` (and the provider has the default
+//     `require_email_verified=true`).
+//   - externalLoginService refuses to JIT-provision when the IdP asserts
+//     `email_verified=false`.
+//   - When `require_email_verified=false`, the same `email_verified=false`
+//     principal is allowed through (auto-linked) for ops-controlled IdPs.
+//   - oidcStateService.recordUsedState returns `replayed: true` on the
+//     second insertion of the same state — the in-DB unique constraint is
+//     what backs replay protection.
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+
+const appDb = require("../src/lib/appDb");
+const externalLoginService = require("../src/services/externalLoginService");
+const oidcStateService = require("../src/services/oidcStateService");
+
+let originalQuery;
+let originalWithTransaction;
+
+let providers;
+let users;
+let linkedIdentities;
+let auditRows;
+let usedStates;
+let providerCounter;
+let userCounter;
+let identityCounter;
+let auditCounter;
+
+function uuid(prefix, counter) {
+  return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
+}
+
+function normalize(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function nextProviderId() { providerCounter += 1; return uuid("eeee", providerCounter); }
+function nextUserId() { userCounter += 1; return uuid("aaab", userCounter); }
+function nextIdentityId() { identityCounter += 1; return uuid("ffff", identityCounter); }
+
+function seedProvider(overrides = {}) {
+  const row = {
+    id: overrides.id || nextProviderId(),
+    type: "oidc",
+    name: overrides.name || "okta",
+    display_name: overrides.display_name || "Okta",
+    issuer: overrides.issuer || "https://okta.example.com",
+    client_id: "test-client",
+    client_secret: null,
+    scopes: ["openid", "email", "profile"],
+    redirect_uri: "http://localhost/cb",
+    claims_mapping: {},
+    enabled: true,
+    auto_link_by_email: overrides.auto_link_by_email !== undefined ? overrides.auto_link_by_email : true,
+    jit_enabled: overrides.jit_enabled === true,
+    jit_default_role: overrides.jit_default_role || "viewer",
+    jit_allowed_domains: overrides.jit_allowed_domains || [],
+    require_email_verified: overrides.require_email_verified !== undefined ? overrides.require_email_verified : true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  };
+  providers.set(row.id, row);
+  return row;
+}
+
+before(() => {
+  originalQuery = appDb.query;
+  originalWithTransaction = appDb.withTransaction;
+  providers = new Map();
+  users = new Map();
+  linkedIdentities = new Map();
+  auditRows = [];
+  usedStates = new Map();
+  providerCounter = 0;
+  userCounter = 0;
+  identityCounter = 0;
+  auditCounter = 0;
+
+  appDb.withTransaction = async (handler) => {
+    const txClient = { query: async (sql, params) => appDb.query(sql, params) };
+    return handler(txClient);
+  };
+
+  appDb.query = async (sql, params = []) => {
+    const n = normalize(sql);
+
+    if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
+      const [emailLower] = params;
+      const row = [...users.values()].find((u) => u.email.toLowerCase() === emailLower);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+    if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where id = $1")) {
+      const [id] = params;
+      const row = users.get(id);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+    if (n.startsWith("select id, user_id, provider_id, subject, email_at_link, created_at, last_seen_at from linked_identities where provider_id = $1 and subject = $2")) {
+      const [providerId, subject] = params;
+      const row = [...linkedIdentities.values()].find(
+        (li) => li.provider_id === providerId && li.subject === subject
+      );
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+    if (n.startsWith("insert into linked_identities")) {
+      const [userId, providerId, subject, emailAtLink] = params;
+      const row = {
+        id: nextIdentityId(),
+        user_id: userId, provider_id: providerId, subject, email_at_link: emailAtLink || null,
+        created_at: new Date().toISOString(), last_seen_at: new Date().toISOString()
+      };
+      linkedIdentities.set(row.id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+    if (n.startsWith("insert into users")) {
+      const [email] = params;
+      const row = {
+        id: nextUserId(), email, password_hash: null, display_name: params[2] || null,
+        is_active: true, last_login_at: null,
+        created_at: new Date().toISOString(), updated_at: new Date().toISOString()
+      };
+      users.set(row.id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+    if (n.startsWith("select id, name from roles where lower(name) = any($1::text[])")) {
+      const [names] = params;
+      return { rowCount: (names || []).length, rows: (names || []).map((name, idx) => ({ id: uuid("ccc1", idx + 1), name })) };
+    }
+    if (n.startsWith("insert into user_roles")) {
+      return { rowCount: 1, rows: [{ role_id: params[1], user_id: params[0] }] };
+    }
+    if (n.startsWith("insert into auth_audit_log")) {
+      auditCounter += 1;
+      const [actorUserId, actorEmail, targetUserId, action, outcome, detailsJson, ipAddress, userAgent] = params;
+      auditRows.push({
+        id: uuid("dddd", auditCounter),
+        actor_user_id: actorUserId, actor_email: actorEmail,
+        target_user_id: targetUserId, action, outcome,
+        details: JSON.parse(detailsJson),
+        ip_address: ipAddress, user_agent: userAgent,
+        created_at: new Date().toISOString()
+      });
+      return { rowCount: 1, rows: [] };
+    }
+    // oidcStateService.recordUsedState
+    if (n.startsWith("insert into oidc_used_states")) {
+      const [hash, providerId, expiresAt] = params;
+      if (usedStates.has(hash)) {
+        const err = new Error("dup state"); err.code = "23505"; throw err;
+      }
+      usedStates.set(hash, { state_hash: hash, provider_id: providerId, expires_at: expiresAt });
+      return { rowCount: 1, rows: [] };
+    }
+    // oidcStateService.pruneExpired
+    if (n.startsWith("delete from oidc_used_states where expires_at < now()")) {
+      return { rowCount: 0, rows: [] };
+    }
+    throw new Error(`Unexpected SQL in federation-hardening test stub: ${n}`);
+  };
+});
+
+after(() => {
+  appDb.query = originalQuery;
+  appDb.withTransaction = originalWithTransaction;
+});
+
+beforeEach(() => {
+  providers.clear();
+  users.clear();
+  linkedIdentities.clear();
+  auditRows.length = 0;
+  usedStates.clear();
+  providerCounter = 0;
+  userCounter = 0;
+  identityCounter = 0;
+  auditCounter = 0;
+});
+
+test("auto-link by email is refused when email_verified is explicitly false", async () => {
+  const provider = seedProvider();
+  const userId = nextUserId();
+  users.set(userId, {
+    id: userId, email: "alice@example.com", password_hash: null, display_name: null,
+    is_active: true, last_login_at: null,
+    created_at: new Date().toISOString(), updated_at: new Date().toISOString()
+  });
+
+  const result = await externalLoginService.resolveExternalLogin(
+    provider,
+    {
+      email: "alice@example.com",
+      sub: "sub-1",
+      display_name: "Alice",
+      claims: { email_verified: false }
+    },
+    {}
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "email_unverified");
+  assert.equal(result.status, 403);
+  assert.ok(auditRows.some((r) => r.action === "auth.security.email_unverified"));
+});
+
+test("auto-link by email proceeds when email_verified is true", async () => {
+  const provider = seedProvider();
+  const userId = nextUserId();
+  users.set(userId, {
+    id: userId, email: "alice@example.com", password_hash: null, display_name: null,
+    is_active: true, last_login_at: null,
+    created_at: new Date().toISOString(), updated_at: new Date().toISOString()
+  });
+
+  const result = await externalLoginService.resolveExternalLogin(
+    provider,
+    {
+      email: "alice@example.com",
+      sub: "sub-2",
+      claims: { email_verified: true }
+    },
+    {}
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.mode, "linked_by_email");
+});
+
+test("JIT is refused when email_verified is explicitly false", async () => {
+  const provider = seedProvider({ jit_enabled: true });
+  const result = await externalLoginService.resolveExternalLogin(
+    provider,
+    {
+      email: "new@example.com",
+      sub: "sub-3",
+      claims: { email_verified: false }
+    },
+    {}
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "email_unverified");
+  assert.ok(auditRows.some((r) => r.action === "auth.security.email_unverified"));
+});
+
+test("turning require_email_verified off lets unverified emails through (ops opt-out)", async () => {
+  const provider = seedProvider({ require_email_verified: false });
+  const userId = nextUserId();
+  users.set(userId, {
+    id: userId, email: "alice@example.com", password_hash: null, display_name: null,
+    is_active: true, last_login_at: null,
+    created_at: new Date().toISOString(), updated_at: new Date().toISOString()
+  });
+  const result = await externalLoginService.resolveExternalLogin(
+    provider,
+    { email: "alice@example.com", sub: "sub-x", claims: { email_verified: false } },
+    {}
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.mode, "linked_by_email");
+});
+
+test("oidcStateService rejects a replayed state", async () => {
+  const first = await oidcStateService.recordUsedState({
+    state: "state-abc-123",
+    providerId: uuid("eeee", 1),
+    expiresAt: new Date(Date.now() + 60_000)
+  });
+  assert.equal(first.replayed, false);
+  assert.equal(first.ok, true);
+
+  const second = await oidcStateService.recordUsedState({
+    state: "state-abc-123",
+    providerId: uuid("eeee", 1),
+    expiresAt: new Date(Date.now() + 60_000)
+  });
+  assert.equal(second.replayed, true);
+  assert.equal(second.ok, false);
+});
+
+test("oidcStateService never persists the plaintext state value", async () => {
+  await oidcStateService.recordUsedState({
+    state: "raw-state-1234",
+    providerId: uuid("eeee", 1),
+    expiresAt: new Date(Date.now() + 60_000)
+  });
+  for (const row of usedStates.values()) {
+    assert.notEqual(row.state_hash, "raw-state-1234", "raw state must not be stored");
+    assert.match(row.state_hash, /^[a-f0-9]{64}$/);
+  }
+});

--- a/app/test/federationHardeningMigration.test.js
+++ b/app/test/federationHardeningMigration.test.js
@@ -1,0 +1,24 @@
+// AUTH-015: migration adds the OIDC used-state table and the
+// require_email_verified column. Pure shape assertion.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+test("0020_oidc_state_replay_and_email_verified creates oidc_used_states and adds require_email_verified", () => {
+  const migrationPath = path.resolve(
+    __dirname,
+    "../../db/migrations/0020_oidc_state_replay_and_email_verified.sql"
+  );
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS oidc_used_states/i);
+  assert.match(sql, /state_hash TEXT PRIMARY KEY/i);
+  assert.match(sql, /provider_id UUID REFERENCES auth_providers\(id\) ON DELETE CASCADE/i);
+  assert.match(sql, /expires_at TIMESTAMPTZ NOT NULL/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_oidc_used_states_expires_at/i);
+
+  assert.match(sql, /ALTER TABLE auth_providers/i);
+  assert.match(sql, /require_email_verified BOOLEAN NOT NULL DEFAULT TRUE/i);
+});

--- a/app/test/oidcLoginApi.test.js
+++ b/app/test/oidcLoginApi.test.js
@@ -215,6 +215,15 @@ before(async () => {
     if (n.startsWith("update linked_identities set last_seen_at = now() where id = $1")) {
       return { rowCount: 1, rows: [] };
     }
+    // AUTH-015: state replay protection. Tests in this file always present
+    // a fresh state, so the insert succeeds; the dedicated replay coverage
+    // lives in federationHardeningApi.test.js.
+    if (n.startsWith("insert into oidc_used_states")) {
+      return { rowCount: 1, rows: [] };
+    }
+    if (n.startsWith("delete from oidc_used_states")) {
+      return { rowCount: 0, rows: [] };
+    }
     // Audit writes from the resolver are .catch'd by callers, so failure is
     // tolerable — but returning an empty result keeps the logs clean.
     if (n.startsWith("insert into auth_audit_log")) {

--- a/db/migrations/0020_oidc_state_replay_and_email_verified.sql
+++ b/db/migrations/0020_oidc_state_replay_and_email_verified.sql
@@ -1,0 +1,34 @@
+-- AUTH-015: harden the external-IdP login path.
+--
+-- 1. oidc_used_states — replay protection for the OIDC authorization code
+--    flow. The state value from a callback is hashed and stored here once
+--    it's been consumed (whether the callback succeeded or failed). A second
+--    callback that arrives with the same state is rejected before it ever
+--    reaches the token-exchange step, even if the signed flow cookie is
+--    intact and within its 10-minute TTL.
+--
+--    The hash is SHA-256 of the raw state value so the table never stores
+--    the plaintext that the IdP and the user's browser saw. expires_at is
+--    derived from the flow cookie's TTL plus a small grace window; a small
+--    sweep query at write time prunes rows past their expiry so the table
+--    stays bounded.
+--
+-- 2. require_email_verified on auth_providers — when true (the default),
+--    a successful OIDC token whose `email_verified` claim is explicitly
+--    `false` will NOT be allowed to auto-link to an existing local user by
+--    email. Linking by subject is still permitted (the IdP has already
+--    attested that this principal owns the account). This closes the
+--    primary vector against the auto-link path that AUTH-012 introduced.
+
+CREATE TABLE IF NOT EXISTS oidc_used_states (
+  state_hash TEXT PRIMARY KEY,
+  provider_id UUID REFERENCES auth_providers(id) ON DELETE CASCADE,
+  used_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_oidc_used_states_expires_at
+  ON oidc_used_states (expires_at);
+
+ALTER TABLE auth_providers
+  ADD COLUMN IF NOT EXISTS require_email_verified BOOLEAN NOT NULL DEFAULT TRUE;

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -165,7 +165,10 @@ paths:
       description: |
         Public endpoint. Reads the signed flow cookie, verifies `state`/`nonce`,
         exchanges the authorization code with PKCE, validates the ID token,
-        looks up a local user by `email`, and creates a session.
+        looks up a local user by `email`, and creates a session. AUTH-015
+        adds replay protection: each `state` value can only be redeemed
+        once — a second callback with the same state returns `400` with
+        `code: "state_replayed"`.
       parameters:
         - in: query
           name: code
@@ -181,9 +184,14 @@ paths:
         "302":
           description: "Successful login — `Set-Cookie: rp_session=...` and redirect to `/dashboard`"
         "400":
-          description: Missing or expired flow cookie / failed token exchange
+          description: |
+            Missing or expired flow cookie, failed token exchange, or replayed
+            `state` (response body `code: "state_replayed"`).
         "403":
-          description: No active local account for the IdP email claim
+          description: |
+            No active local account for the IdP email claim, JIT disabled, JIT
+            domain not allowed, or `email_verified=false` from the IdP
+            (`code: "email_unverified"`).
         "404":
           description: Provider no longer available
   /v1/admin/auth-providers:
@@ -1719,6 +1727,9 @@ components:
           description: When non-empty, JIT only applies to emails whose domain is in this list (case-insensitive).
           items:
             type: string
+        require_email_verified:
+          type: boolean
+          description: AUTH-015. When true, the IdP must assert `email_verified=true` before this app will auto-link an existing local user by email or provision a new one via JIT. Default true.
         created_at:
           type: string
           format: date-time
@@ -1728,7 +1739,8 @@ components:
     AuthProviderMappingRulesRequest:
       type: object
       description: |
-        AUTH-012 mapping rules. Only the fields supplied are updated.
+        AUTH-012 mapping rules + AUTH-015 email-verified gate. Only the
+        fields supplied are updated.
       properties:
         auto_link_by_email:
           type: boolean
@@ -1740,9 +1752,11 @@ components:
           type: array
           items:
             type: string
+        require_email_verified:
+          type: boolean
     AuthProviderMappingRulesResponse:
       type: object
-      required: [provider_id, auto_link_by_email, jit_enabled, jit_default_role, jit_allowed_domains]
+      required: [provider_id, auto_link_by_email, jit_enabled, jit_default_role, jit_allowed_domains, require_email_verified]
       properties:
         provider_id:
           type: string
@@ -1757,6 +1771,8 @@ components:
           type: array
           items:
             type: string
+        require_email_verified:
+          type: boolean
     LinkedIdentity:
       type: object
       required: [id, user_id, provider_id, subject]

--- a/frontend/src/components/Admin/AuthProviderDialog.tsx
+++ b/frontend/src/components/Admin/AuthProviderDialog.tsx
@@ -16,13 +16,15 @@ export interface AuthProviderFormValues {
     redirect_uri: string;
     claims_mapping: { email?: string; display_name?: string };
     enabled: boolean;
-    // AUTH-012 mapping rules. Persisted by a separate POST to
-    // /v1/admin/auth-providers/{id}/mapping-rules after the main upsert.
+    // AUTH-012 mapping rules + AUTH-015 email-verified gate. Persisted by a
+    // separate POST to /v1/admin/auth-providers/{id}/mapping-rules after the
+    // main upsert.
     mapping_rules: {
         auto_link_by_email: boolean;
         jit_enabled: boolean;
         jit_default_role: string;
         jit_allowed_domains: string[];
+        require_email_verified: boolean;
     };
 }
 
@@ -45,6 +47,7 @@ const DEFAULT_MAPPING_RULES = {
     jit_enabled: false,
     jit_default_role: 'viewer',
     jit_allowed_domains: [] as string[],
+    require_email_verified: true,
 };
 
 function defaultValues(initial: AuthProvider | null, defaultRedirectUri: string): AuthProviderFormValues {
@@ -80,6 +83,7 @@ function defaultValues(initial: AuthProvider | null, defaultRedirectUri: string)
             jit_enabled: initial.jit_enabled ?? false,
             jit_default_role: initial.jit_default_role ?? 'viewer',
             jit_allowed_domains: initial.jit_allowed_domains ?? [],
+            require_email_verified: initial.require_email_verified ?? true,
         },
     };
 }
@@ -168,6 +172,7 @@ function AuthProviderDialogInner({ initial, defaultRedirectUri, onClose, onSubmi
                 jit_enabled: values.mapping_rules.jit_enabled,
                 jit_default_role: values.mapping_rules.jit_default_role.trim().toLowerCase() || 'viewer',
                 jit_allowed_domains: Array.from(new Set(domains)),
+                require_email_verified: values.mapping_rules.require_email_verified,
             },
         };
         const found = validate(normalized, isEdit);
@@ -340,6 +345,20 @@ function AuthProviderDialogInner({ initial, defaultRedirectUri, onClose, onSubmi
                                 Auto-link by email
                                 <span className="block text-xs text-gray-500">
                                     When an SSO login email matches an existing local user, attach the external identity automatically. Disable for IdPs that don&apos;t verify email ownership.
+                                </span>
+                            </span>
+                        </label>
+                        <label className="mt-3 flex items-start gap-2 text-sm text-gray-700">
+                            <input
+                                type="checkbox"
+                                checked={values.mapping_rules.require_email_verified}
+                                onChange={(e) => setRule('require_email_verified', e.target.checked)}
+                                className="mt-0.5 h-4 w-4 rounded border-gray-300 text-oxblood focus:ring-oxblood"
+                            />
+                            <span>
+                                Require <code className="rounded bg-gray-100 px-1 py-0.5 text-xs">email_verified</code> claim
+                                <span className="block text-xs text-gray-500">
+                                    Refuse auto-link and JIT when the IdP says the email isn&apos;t verified. Keep on unless you trust this IdP to never assert unverified emails.
                                 </span>
                             </span>
                         </label>

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -377,7 +377,10 @@ export interface paths {
          * OIDC callback — exchange code, validate ID token, create session
          * @description Public endpoint. Reads the signed flow cookie, verifies `state`/`nonce`,
          *     exchanges the authorization code with PKCE, validates the ID token,
-         *     looks up a local user by `email`, and creates a session.
+         *     looks up a local user by `email`, and creates a session. AUTH-015
+         *     adds replay protection: each `state` value can only be redeemed
+         *     once — a second callback with the same state returns `400` with
+         *     `code: "state_replayed"`.
          */
         get: {
             parameters: {
@@ -398,14 +401,21 @@ export interface paths {
                     };
                     content?: never;
                 };
-                /** @description Missing or expired flow cookie / failed token exchange */
+                /**
+                 * @description Missing or expired flow cookie, failed token exchange, or replayed
+                 *     `state` (response body `code: "state_replayed"`).
+                 */
                 400: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content?: never;
                 };
-                /** @description No active local account for the IdP email claim */
+                /**
+                 * @description No active local account for the IdP email claim, JIT disabled, JIT
+                 *     domain not allowed, or `email_verified=false` from the IdP
+                 *     (`code: "email_unverified"`).
+                 */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -3003,17 +3013,23 @@ export interface components {
             jit_default_role?: string;
             /** @description When non-empty, JIT only applies to emails whose domain is in this list (case-insensitive). */
             jit_allowed_domains?: string[];
+            /** @description AUTH-015. When true, the IdP must assert `email_verified=true` before this app will auto-link an existing local user by email or provision a new one via JIT. Default true. */
+            require_email_verified?: boolean;
             /** Format: date-time */
             created_at?: string;
             /** Format: date-time */
             updated_at?: string;
         };
-        /** @description AUTH-012 mapping rules. Only the fields supplied are updated. */
+        /**
+         * @description AUTH-012 mapping rules + AUTH-015 email-verified gate. Only the
+         *     fields supplied are updated.
+         */
         AuthProviderMappingRulesRequest: {
             auto_link_by_email?: boolean;
             jit_enabled?: boolean;
             jit_default_role?: string;
             jit_allowed_domains?: string[];
+            require_email_verified?: boolean;
         };
         AuthProviderMappingRulesResponse: {
             /** Format: uuid */
@@ -3022,6 +3038,7 @@ export interface components {
             jit_enabled: boolean;
             jit_default_role: string;
             jit_allowed_domains: string[];
+            require_email_verified: boolean;
         };
         LinkedIdentity: {
             /** Format: uuid */


### PR DESCRIPTION
## Summary

- Replay protection on the OIDC callback: every `state` value is hashed (SHA-256) and recorded in a new `oidc_used_states` table the first time it's seen. A second callback with the same state is rejected with `400 { code: "state_replayed" }` before token exchange and emits `auth.security.state_replay_blocked` to the audit log.
- New per-provider `require_email_verified` toggle (default on). When the IdP exposes `email_verified=false`, both the auto-link-by-email path and the JIT-provisioning path refuse with `403 { code: "email_unverified" }` and emit `auth.security.email_unverified`. Linking by subject is unaffected — the IdP's prior subject attestation is what protects that path.
- Configurable ID-token clock-skew tolerance via `AUTH_OIDC_CLOCK_TOLERANCE_SECONDS` (default 60s, clamped to [0, 600]). Passed to `openid-client` via the `clockTolerance` metadata Symbol.
- Mapping-rules endpoint + admin dialog get the new `require_email_verified` toggle.

## Implementation notes

- State table is keyed on the SHA-256 hash so plaintext state is never persisted. Replay rejection rides on the `PRIMARY KEY` unique constraint — the second insert trips `23505` which the service translates into `{ replayed: true }`.
- Opportunistic `DELETE … WHERE expires_at < NOW()` at write time keeps the table bounded without needing a cron. The 15-minute expiry leaves ample grace beyond the 10-minute flow cookie TTL.
- Email-verified gate trusts whatever the IdP asserts: `email_verified` is taken from the validated ID-token claims that `openid-client` already verified against the JWKS. Absent claim (e.g. older providers) is treated as "no statement", not as "false" — so legacy IdPs keep working.
- `auth.security.*` is a new action prefix distinct from `auth.login.failure` so AUTH-008 dashboards can break out hardening-related rejections from ordinary credential failures.

## Out of scope (deferred)

- SAML signature/certificate rotation — no SAML provider exists yet; will be picked up with AUTH-011.
- JWKS / discovery caching — delegated to `openid-client` defaults for now; revisit in a perf ticket if the per-request discovery becomes an issue.

## Verification

- [x] `npm test` — 135 pass, 0 fail
- [x] `npm --prefix frontend run lint` — clean
- [x] `cd frontend && npx tsc -b` — clean
- [ ] Manual: replay a callback URL twice → second attempt returns 400; flip an IdP to assert `email_verified=false` and confirm auto-link is refused

Closes #35