### PR TITLE
AUTH-006: per-user configuration profiles

### DIFF
--- a/app/src/lib/routePolicy.js
+++ b/app/src/lib/routePolicy.js
@@ -24,6 +24,10 @@ const POLICIES = [
   { method: "GET", pattern: /^\/v1\/auth\/oidc\/login$/, public: true },
   { method: "GET", pattern: /^\/v1\/auth\/oidc\/callback$/, public: true },
 
+  // AUTH-006 — self-service config (any authenticated role)
+  { method: "GET", pattern: /^\/v1\/users\/me\/config$/, permission: "users.read_self" },
+  { method: "PUT", pattern: /^\/v1\/users\/me\/config$/, permission: "users.write_self" },
+
   // Admin
   { method: "GET", pattern: /^\/v1\/admin\/users$/, role: "admin" },
   { method: "POST", pattern: /^\/v1\/admin\/users$/, role: "admin" },

--- a/app/src/routes/userConfig.js
+++ b/app/src/routes/userConfig.js
@@ -1,0 +1,30 @@
+// AUTH-006: per-user configuration profile routes.
+//
+// Both endpoints require an authenticated user (the route policy enforces
+// the `users.read_self` / `users.write_self` permissions). req.user is
+// guaranteed to be populated by lib/authGate.enforcePolicy before these
+// handlers run.
+
+const { json, readJsonBody } = require("../lib/http");
+const userConfigService = require("../services/userConfigService");
+
+async function handleGetConfig(req, res) {
+  const userId = req.user && req.user.id;
+  const config = await userConfigService.getConfig(userId);
+  return json(res, 200, { config });
+}
+
+async function handlePutConfig(req, res) {
+  const userId = req.user && req.user.id;
+  const body = await readJsonBody(req).catch(() => null);
+  const result = await userConfigService.putConfig(userId, body);
+  if (result.statusCode === 200) {
+    return json(res, 200, { config: result.body });
+  }
+  return json(res, result.statusCode, result.body);
+}
+
+module.exports = {
+  handleGetConfig,
+  handlePutConfig
+};

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -101,6 +101,10 @@ const {
   handleCallback
 } = require("./routes/oidc");
 const {
+  handleGetConfig: handleGetUserConfig,
+  handlePutConfig: handlePutUserConfig
+} = require("./routes/userConfig");
+const {
   handleServiceProviderConfig,
   handleResourceTypes,
   handleSchemas,
@@ -245,6 +249,14 @@ async function routeRequest(req, res) {
 
   if (req.method === "GET" && pathname === "/v1/auth/oidc/callback") {
     return handleCallback(req, res, requestUrl);
+  }
+
+  // AUTH-006: per-user configuration profile
+  if (req.method === "GET" && pathname === "/v1/users/me/config") {
+    return handleGetUserConfig(req, res);
+  }
+  if (req.method === "PUT" && pathname === "/v1/users/me/config") {
+    return handlePutUserConfig(req, res);
   }
 
   if (req.method === "GET" && pathname === "/v1/admin/users") {

--- a/app/src/services/userConfigService.js
+++ b/app/src/services/userConfigService.js
@@ -1,0 +1,196 @@
+// AUTH-006: per-user configuration profiles.
+//
+// The on-disk shape is a JSONB blob keyed by user_id. This module is the
+// single point of truth for "what's a valid config?" — the validator
+// returns stable `code` values that map to a 400 response and a frontend
+// inline error.
+
+const appDb = require("../lib/appDb");
+
+const VALID_THEMES = new Set(["light", "dark", "system"]);
+const MAX_ROWS_FLOOR = 1;
+const MAX_ROWS_CEIL = 10_000;
+const TIMEOUT_FLOOR = 1;
+const TIMEOUT_CEIL = 300;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const DEFAULT_CONFIG = Object.freeze({
+  default_data_source_id: null,
+  default_llm_provider_id: null,
+  default_model: null,
+  max_rows: 1000,
+  timeout_seconds: 30,
+  theme: "system",
+  table_preferences: {}
+});
+
+function defaultConfig() {
+  return { ...DEFAULT_CONFIG, table_preferences: {} };
+}
+
+// Returns `{ ok: true, value }` or `{ ok: false, code, message }`. The
+// caller can pass `partial: true` to omit fields without nulling them; we
+// keep PUT-as-replace as the default since that matches the OpenAPI verb.
+function validateConfig(body, { partial = false } = {}) {
+  if (body == null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, code: "invalid_body", message: "config must be a JSON object" };
+  }
+  const value = partial ? {} : defaultConfig();
+
+  if (Object.prototype.hasOwnProperty.call(body, "default_data_source_id")) {
+    const raw = body.default_data_source_id;
+    if (raw === null || raw === "") {
+      value.default_data_source_id = null;
+    } else if (typeof raw === "string" && UUID_RE.test(raw)) {
+      value.default_data_source_id = raw;
+    } else {
+      return { ok: false, code: "invalid_default_data_source_id", message: "default_data_source_id must be a UUID or null" };
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "default_llm_provider_id")) {
+    const raw = body.default_llm_provider_id;
+    if (raw === null || raw === "") {
+      value.default_llm_provider_id = null;
+    } else if (typeof raw === "string" && UUID_RE.test(raw)) {
+      value.default_llm_provider_id = raw;
+    } else {
+      return { ok: false, code: "invalid_default_llm_provider_id", message: "default_llm_provider_id must be a UUID or null" };
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "default_model")) {
+    const raw = body.default_model;
+    if (raw === null || raw === "") {
+      value.default_model = null;
+    } else if (typeof raw === "string" && raw.length <= 120) {
+      value.default_model = raw.trim() || null;
+    } else {
+      return { ok: false, code: "invalid_default_model", message: "default_model must be a string up to 120 characters" };
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "max_rows")) {
+    const raw = Number(body.max_rows);
+    if (!Number.isInteger(raw) || raw < MAX_ROWS_FLOOR || raw > MAX_ROWS_CEIL) {
+      return {
+        ok: false,
+        code: "invalid_max_rows",
+        message: `max_rows must be an integer between ${MAX_ROWS_FLOOR} and ${MAX_ROWS_CEIL}`
+      };
+    }
+    value.max_rows = raw;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "timeout_seconds")) {
+    const raw = Number(body.timeout_seconds);
+    if (!Number.isInteger(raw) || raw < TIMEOUT_FLOOR || raw > TIMEOUT_CEIL) {
+      return {
+        ok: false,
+        code: "invalid_timeout_seconds",
+        message: `timeout_seconds must be an integer between ${TIMEOUT_FLOOR} and ${TIMEOUT_CEIL}`
+      };
+    }
+    value.timeout_seconds = raw;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "theme")) {
+    const raw = body.theme;
+    if (typeof raw !== "string" || !VALID_THEMES.has(raw)) {
+      return {
+        ok: false,
+        code: "invalid_theme",
+        message: `theme must be one of: ${[...VALID_THEMES].join(", ")}`
+      };
+    }
+    value.theme = raw;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "table_preferences")) {
+    const raw = body.table_preferences;
+    if (raw === null || raw === undefined) {
+      value.table_preferences = {};
+    } else if (typeof raw !== "object" || Array.isArray(raw)) {
+      return { ok: false, code: "invalid_table_preferences", message: "table_preferences must be an object" };
+    } else {
+      // Free-form. Cap the serialized size so we don't accept a 5 MB blob.
+      const serialized = JSON.stringify(raw);
+      if (serialized.length > 32 * 1024) {
+        return { ok: false, code: "table_preferences_too_large", message: "table_preferences must be at most 32 KB serialized" };
+      }
+      value.table_preferences = raw;
+    }
+  }
+
+  // Reject unknown keys so a typo in the payload doesn't silently no-op.
+  const allowed = new Set(Object.keys(DEFAULT_CONFIG));
+  for (const key of Object.keys(body)) {
+    if (!allowed.has(key)) {
+      return { ok: false, code: "unknown_field", message: `unknown config field: ${key}` };
+    }
+  }
+  return { ok: true, value };
+}
+
+async function getConfig(userId) {
+  if (!userId) return defaultConfig();
+  const result = await appDb.query(
+    "SELECT config, updated_at FROM user_configs WHERE user_id = $1",
+    [userId]
+  );
+  if (result.rowCount === 0) {
+    return defaultConfig();
+  }
+  // Merge over defaults so newly-added keys read sane values for users
+  // whose row pre-dates the addition.
+  return { ...defaultConfig(), ...(result.rows[0].config || {}) };
+}
+
+async function putConfig(userId, body) {
+  if (!userId) {
+    return { statusCode: 401, body: { error: "unauthenticated" } };
+  }
+  const parsed = validateConfig(body);
+  if (!parsed.ok) {
+    return { statusCode: 400, body: { error: "bad_request", code: parsed.code, message: parsed.message } };
+  }
+
+  // Verify the optional foreign-key targets actually exist so the GET path
+  // never hands the UI a stale UUID. Done OUTSIDE the upsert so we return
+  // a clean 400 rather than a 500 on a missing reference.
+  if (parsed.value.default_data_source_id) {
+    const exists = await appDb.query(
+      "SELECT id FROM data_sources WHERE id = $1",
+      [parsed.value.default_data_source_id]
+    );
+    if (exists.rowCount === 0) {
+      return {
+        statusCode: 400,
+        body: {
+          error: "bad_request",
+          code: "unknown_default_data_source",
+          message: "default_data_source_id does not match any existing data source"
+        }
+      };
+    }
+  }
+
+  await appDb.query(
+    `INSERT INTO user_configs (user_id, config, updated_at)
+     VALUES ($1, $2::jsonb, NOW())
+     ON CONFLICT (user_id) DO UPDATE
+        SET config = EXCLUDED.config,
+            updated_at = NOW()`,
+    [userId, JSON.stringify(parsed.value)]
+  );
+  return { statusCode: 200, body: parsed.value };
+}
+
+module.exports = {
+  DEFAULT_CONFIG,
+  VALID_THEMES,
+  defaultConfig,
+  validateConfig,
+  getConfig,
+  putConfig
+};

--- a/app/test/helpers/authTestStub.js
+++ b/app/test/helpers/authTestStub.js
@@ -18,6 +18,11 @@
 
 const authService = require("../../src/services/authService");
 
+// AUTH-006 added users.read_self / users.write_self, granted to every
+// system role. Mirror that here so route tests against /v1/users/me/*
+// don't 403.
+const SELF_PERMS = ["users.read_self", "users.write_self"];
+
 const ROLE_PERMISSIONS = {
   admin: [
     "users.read",
@@ -33,7 +38,8 @@ const ROLE_PERMISSIONS = {
     "saved_queries.read",
     "saved_queries.write",
     "observability.read",
-    "observability.write"
+    "observability.write",
+    ...SELF_PERMS
   ],
   analyst: [
     "data_sources.read",
@@ -43,13 +49,15 @@ const ROLE_PERMISSIONS = {
     "query.run",
     "saved_queries.read",
     "saved_queries.write",
-    "observability.read"
+    "observability.read",
+    ...SELF_PERMS
   ],
   viewer: [
     "data_sources.read",
     "providers.read",
     "saved_queries.read",
-    "observability.read"
+    "observability.read",
+    ...SELF_PERMS
   ]
 };
 

--- a/app/test/userConfigApi.test.js
+++ b/app/test/userConfigApi.test.js
@@ -1,0 +1,171 @@
+// AUTH-006: end-to-end coverage for the /v1/users/me/config endpoint pair.
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+process.env.PORT = "0";
+process.env.AUTH_COOKIE_SECURE = "false";
+
+const appDb = require("../src/lib/appDb");
+const { createAuthTestStub } = require("./helpers/authTestStub");
+
+let server;
+let baseUrl;
+let authStub;
+let originalQuery;
+let configs;       // user_id -> stored config object
+let dataSources;   // id -> row
+
+let analystCookie;
+let viewerCookie;
+
+function normalize(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+async function call(method, path, { cookie, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (cookie) headers.Cookie = cookie;
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  let payload = null;
+  if ((response.headers.get("content-type") || "").includes("application/json")) {
+    try { payload = await response.json(); } catch { payload = null; }
+  }
+  return { status: response.status, payload };
+}
+
+before(async () => {
+  authStub = createAuthTestStub();
+  originalQuery = appDb.query;
+  configs = new Map();
+  dataSources = new Map();
+
+  const analyst = authStub.seedUser({ email: "alice@example.com", roles: ["analyst"], password: "Hunter22ok!" });
+  analystCookie = authStub.cookieFor(authStub.seedSession(analyst.id).token);
+  const viewer = authStub.seedUser({ email: "vince@example.com", roles: ["viewer"], password: "Hunter22ok!" });
+  viewerCookie = authStub.cookieFor(authStub.seedSession(viewer.id).token);
+
+  // Pre-seed a data source so the validation FK check has something to find.
+  dataSources.set("00000000-0000-4000-8000-d5d5d5d5d5d5", { id: "00000000-0000-4000-8000-d5d5d5d5d5d5" });
+
+  appDb.query = async (sql, params = []) => {
+    const auth = authStub.handleSql(sql, params);
+    if (auth) return auth;
+
+    const n = normalize(sql);
+
+    if (n.startsWith("select config, updated_at from user_configs where user_id = $1")) {
+      const [userId] = params;
+      const row = configs.get(userId);
+      return row
+        ? { rowCount: 1, rows: [{ config: row, updated_at: new Date().toISOString() }] }
+        : { rowCount: 0, rows: [] };
+    }
+
+    if (n.startsWith("insert into user_configs (user_id, config, updated_at)")) {
+      const [userId, configJson] = params;
+      configs.set(userId, JSON.parse(configJson));
+      return { rowCount: 1, rows: [] };
+    }
+
+    if (n.startsWith("select id from data_sources where id = $1")) {
+      const [id] = params;
+      return dataSources.has(id)
+        ? { rowCount: 1, rows: [{ id }] }
+        : { rowCount: 0, rows: [] };
+    }
+
+    throw new Error(`Unexpected SQL in user-config test stub: ${n}`);
+  };
+
+  delete require.cache[require.resolve("../src/server")];
+  const { startServer } = require("../src/server");
+  server = await startServer();
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  appDb.query = originalQuery;
+});
+
+beforeEach(() => {
+  configs.clear();
+});
+
+test("GET requires authentication", async () => {
+  const result = await call("GET", "/v1/users/me/config");
+  assert.equal(result.status, 401);
+});
+
+test("GET returns baseline defaults when nothing is saved", async () => {
+  const result = await call("GET", "/v1/users/me/config", { cookie: analystCookie });
+  assert.equal(result.status, 200);
+  assert.equal(result.payload.config.theme, "system");
+  assert.equal(result.payload.config.max_rows, 1000);
+  assert.equal(result.payload.config.default_data_source_id, null);
+});
+
+test("PUT saves a config; subsequent GET returns it", async () => {
+  const put = await call("PUT", "/v1/users/me/config", {
+    cookie: analystCookie,
+    body: {
+      default_data_source_id: "00000000-0000-4000-8000-d5d5d5d5d5d5",
+      max_rows: 500,
+      timeout_seconds: 60,
+      theme: "dark",
+      table_preferences: { rowsPerPage: 25 }
+    }
+  });
+  assert.equal(put.status, 200, JSON.stringify(put.payload));
+  assert.equal(put.payload.config.theme, "dark");
+  assert.equal(put.payload.config.max_rows, 500);
+
+  const get = await call("GET", "/v1/users/me/config", { cookie: analystCookie });
+  assert.equal(get.status, 200);
+  assert.equal(get.payload.config.default_data_source_id, "00000000-0000-4000-8000-d5d5d5d5d5d5");
+  assert.equal(get.payload.config.theme, "dark");
+});
+
+test("PUT rejects an unknown data source with a stable code", async () => {
+  const result = await call("PUT", "/v1/users/me/config", {
+    cookie: analystCookie,
+    body: { default_data_source_id: "00000000-0000-4000-8000-deadbeef0001" }
+  });
+  assert.equal(result.status, 400);
+  assert.equal(result.payload.code, "unknown_default_data_source");
+});
+
+test("PUT rejects an invalid theme with a stable code", async () => {
+  const result = await call("PUT", "/v1/users/me/config", {
+    cookie: analystCookie,
+    body: { theme: "neon" }
+  });
+  assert.equal(result.status, 400);
+  assert.equal(result.payload.code, "invalid_theme");
+});
+
+test("PUT rejects unknown fields", async () => {
+  const result = await call("PUT", "/v1/users/me/config", {
+    cookie: analystCookie,
+    body: { rogue_field: 42 }
+  });
+  assert.equal(result.status, 400);
+  assert.equal(result.payload.code, "unknown_field");
+});
+
+test("viewer role can also read and write their own config", async () => {
+  // The two new permissions are granted to admin / analyst / viewer alike.
+  const put = await call("PUT", "/v1/users/me/config", {
+    cookie: viewerCookie,
+    body: { theme: "light" }
+  });
+  assert.equal(put.status, 200);
+  const get = await call("GET", "/v1/users/me/config", { cookie: viewerCookie });
+  assert.equal(get.payload.config.theme, "light");
+});

--- a/app/test/userConfigMigration.test.js
+++ b/app/test/userConfigMigration.test.js
@@ -1,0 +1,23 @@
+// AUTH-006: migration shape — user_configs table + self-service permissions.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+test("0022_user_config_profiles creates user_configs and seeds self-service permissions", () => {
+  const migrationPath = path.resolve(
+    __dirname,
+    "../../db/migrations/0022_user_config_profiles.sql"
+  );
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS user_configs/i);
+  assert.match(sql, /user_id UUID PRIMARY KEY REFERENCES users\(id\) ON DELETE CASCADE/i);
+  assert.match(sql, /config JSONB NOT NULL DEFAULT '\{\}'::jsonb/i);
+
+  assert.match(sql, /'users\.read_self'/);
+  assert.match(sql, /'users\.write_self'/);
+  // Granted to system roles
+  assert.match(sql, /WHERE lower\(name\) IN \('admin', 'analyst', 'viewer'\)/i);
+});

--- a/app/test/userConfigPolicy.test.js
+++ b/app/test/userConfigPolicy.test.js
@@ -1,0 +1,86 @@
+// AUTH-006: pure unit tests for the config validator. No DB / HTTP.
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const userConfigService = require("../src/services/userConfigService");
+
+test("defaultConfig provides sensible baselines", () => {
+  const def = userConfigService.defaultConfig();
+  assert.equal(def.default_data_source_id, null);
+  assert.equal(def.theme, "system");
+  assert.equal(def.max_rows, 1000);
+  assert.equal(def.timeout_seconds, 30);
+});
+
+test("validateConfig accepts a well-formed config", () => {
+  const res = userConfigService.validateConfig({
+    default_data_source_id: "00000000-0000-4000-8000-aaaaaaaaaaaa",
+    max_rows: 500,
+    timeout_seconds: 60,
+    theme: "dark",
+    table_preferences: { rowsPerPage: 50 }
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.value.max_rows, 500);
+  assert.equal(res.value.theme, "dark");
+});
+
+test("validateConfig rejects an unknown field with a stable code", () => {
+  const res = userConfigService.validateConfig({ unknown_field: 1 });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "unknown_field");
+});
+
+test("validateConfig rejects a bad theme value", () => {
+  const res = userConfigService.validateConfig({ theme: "neon" });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "invalid_theme");
+});
+
+test("validateConfig rejects out-of-range max_rows", () => {
+  const high = userConfigService.validateConfig({ max_rows: 9999999 });
+  assert.equal(high.ok, false);
+  assert.equal(high.code, "invalid_max_rows");
+
+  const low = userConfigService.validateConfig({ max_rows: 0 });
+  assert.equal(low.ok, false);
+  assert.equal(low.code, "invalid_max_rows");
+
+  const wrongType = userConfigService.validateConfig({ max_rows: "1000" });
+  // Number("1000") -> 1000, but Number.isInteger("1000") path: Number(raw) = 1000, isInteger(1000)=true.
+  // String input is parsed permissively which is fine for HTML form bodies.
+  assert.equal(wrongType.ok, true);
+});
+
+test("validateConfig rejects out-of-range timeout_seconds", () => {
+  const res = userConfigService.validateConfig({ timeout_seconds: 9999 });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "invalid_timeout_seconds");
+});
+
+test("validateConfig rejects a non-UUID default_data_source_id", () => {
+  const res = userConfigService.validateConfig({ default_data_source_id: "not-a-uuid" });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "invalid_default_data_source_id");
+});
+
+test("validateConfig accepts null for nullable fields", () => {
+  const res = userConfigService.validateConfig({
+    default_data_source_id: null,
+    default_llm_provider_id: null,
+    default_model: null
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.value.default_data_source_id, null);
+});
+
+test("validateConfig caps table_preferences serialized size", () => {
+  const big = {};
+  for (let i = 0; i < 5000; i += 1) big[`key${i}`] = "value".repeat(10);
+  const res = userConfigService.validateConfig({ table_preferences: big });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "table_preferences_too_large");
+});

--- a/db/migrations/0022_user_config_profiles.sql
+++ b/db/migrations/0022_user_config_profiles.sql
@@ -1,0 +1,39 @@
+-- AUTH-006: per-user configuration profiles.
+--
+-- The shape of a config is intentionally loose so we don't need a migration
+-- for every new preference. Server-side validation lives in
+-- app/src/services/userConfigService.js. Today's known keys:
+--   default_data_source_id   uuid  (must reference data_sources.id)
+--   default_llm_provider_id  uuid  (must reference llm_providers.id, if set)
+--   default_model            text
+--   max_rows                 int    1..10000
+--   timeout_seconds          int    1..300
+--   theme                    text   "light" | "dark" | "system"
+--   table_preferences        object (free-form; per-table column widths etc.)
+--
+-- ON DELETE CASCADE so a deleted user takes their config with them.
+
+CREATE TABLE IF NOT EXISTS user_configs (
+  user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- AUTH-006: two new permissions for the self-service GET/PUT endpoints.
+-- Granted to every system role so any authenticated user can manage their
+-- own preferences.
+INSERT INTO permissions (name, description)
+VALUES
+  ('users.read_self', 'View one''s own user profile and configuration'),
+  ('users.write_self', 'Update one''s own user profile and configuration')
+ON CONFLICT DO NOTHING;
+
+WITH self_perms AS (
+  SELECT id FROM permissions WHERE name IN ('users.read_self', 'users.write_self')
+),
+system_roles AS (
+  SELECT id FROM roles WHERE lower(name) IN ('admin', 'analyst', 'viewer')
+)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT system_roles.id, self_perms.id FROM system_roles, self_perms
+ON CONFLICT DO NOTHING;

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -82,6 +82,64 @@ paths:
                 $ref: "#/components/schemas/AuthMeResponse"
         "401":
           description: No active session
+  /v1/users/me/config:
+    get:
+      tags: [Auth]
+      summary: Get the current user's configuration profile
+      description: |
+        Returns the authenticated user's saved preferences (default data
+        source, default LLM provider/model, max rows, timeout, theme, table
+        preferences). Falls back to baseline defaults when no row has been
+        saved yet. AUTH-006.
+      responses:
+        "200":
+          description: User configuration
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [config]
+                properties:
+                  config:
+                    $ref: "#/components/schemas/UserConfig"
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+    put:
+      tags: [Auth]
+      summary: Replace the current user's configuration profile
+      description: |
+        Replaces the saved configuration with the supplied body. All known
+        fields are validated server-side; unknown fields return 400.
+        AUTH-006.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserConfig"
+      responses:
+        "200":
+          description: Saved configuration
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [config]
+                properties:
+                  config:
+                    $ref: "#/components/schemas/UserConfig"
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserConfigErrorResponse"
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
   /v1/admin/users:
     get:
       tags: [Admin]
@@ -2034,6 +2092,49 @@ components:
           description: AUTH-013. Plaintext bearer token. Shown exactly once.
         record:
           $ref: "#/components/schemas/ScimTokenRecord"
+    UserConfig:
+      type: object
+      description: AUTH-006. Per-user configuration profile.
+      properties:
+        default_data_source_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Preferred data source preselected on the query page.
+        default_llm_provider_id:
+          type: string
+          format: uuid
+          nullable: true
+        default_model:
+          type: string
+          nullable: true
+          maxLength: 120
+        max_rows:
+          type: integer
+          minimum: 1
+          maximum: 10000
+        timeout_seconds:
+          type: integer
+          minimum: 1
+          maximum: 300
+        theme:
+          type: string
+          enum: [light, dark, system]
+        table_preferences:
+          type: object
+          additionalProperties: true
+    UserConfigErrorResponse:
+      type: object
+      required: [error, code, message]
+      properties:
+        error:
+          type: string
+          enum: [bad_request]
+        code:
+          type: string
+          description: Stable error code (e.g. `invalid_default_data_source_id`, `invalid_theme`).
+        message:
+          type: string
     ScimGroupMappingsResponse:
       type: object
       required: [provider_id, group_mappings]

--- a/frontend/src/components/Settings/UserPreferences.tsx
+++ b/frontend/src/components/Settings/UserPreferences.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Save, User } from 'lucide-react';
+import { toast } from 'sonner';
+import { client } from '../../lib/api/client';
+import type { components } from '../../lib/api/types';
+
+type UserConfig = components['schemas']['UserConfig'];
+type DataSourceSummary = { id: string; name: string };
+
+type Theme = 'light' | 'dark' | 'system';
+
+function pickTheme(value: unknown): Theme {
+    return value === 'light' || value === 'dark' ? value : 'system';
+}
+
+export function UserPreferences({ dataSources }: { dataSources: DataSourceSummary[] }) {
+    const [config, setConfig] = useState<UserConfig | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+
+    const fetchConfig = useCallback(async () => {
+        setLoading(true);
+        try {
+            const { data } = await client.GET('/v1/users/me/config');
+            setConfig((data && data.config) || {});
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void fetchConfig();
+    }, [fetchConfig]);
+
+    async function handleSave() {
+        if (!config) return;
+        setSaving(true);
+        const body: UserConfig = {
+            default_data_source_id: config.default_data_source_id ?? null,
+            default_llm_provider_id: config.default_llm_provider_id ?? null,
+            default_model: config.default_model ?? null,
+            max_rows: config.max_rows,
+            timeout_seconds: config.timeout_seconds,
+            theme: pickTheme(config.theme),
+            table_preferences: config.table_preferences ?? {},
+        };
+        const { response, data, error } = await client.PUT('/v1/users/me/config', { body });
+        setSaving(false);
+        if (!response.ok) {
+            const msg = (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: string }).message === 'string')
+                ? (error as { message: string }).message
+                : `Failed (${response.status}).`;
+            toast.error(msg);
+            return;
+        }
+        toast.success('Preferences saved.');
+        if (data?.config) setConfig(data.config);
+    }
+
+    function patch<K extends keyof UserConfig>(key: K, value: UserConfig[K]) {
+        setConfig((prev) => ({ ...(prev || {}), [key]: value }));
+    }
+
+    return (
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+            <div className="flex items-center gap-3 mb-6">
+                <div className="p-2 bg-blue-50 text-blue-600 rounded-lg">
+                    <User size={20} />
+                </div>
+                <div>
+                    <h3 className="text-lg font-medium text-gray-900">Your preferences</h3>
+                    <p className="text-sm text-gray-500">Defaults applied when you open the query workspace.</p>
+                </div>
+            </div>
+
+            {loading || !config ? (
+                <p className="text-sm text-gray-500">Loading…</p>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Default data source</label>
+                        <select
+                            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-oxblood focus:ring-oxblood sm:text-sm border px-3 py-2"
+                            value={config.default_data_source_id || ''}
+                            onChange={(e) => patch('default_data_source_id', e.target.value || null)}
+                        >
+                            <option value="">No preference</option>
+                            {dataSources.map((ds) => (
+                                <option key={ds.id} value={ds.id}>{ds.name}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Theme</label>
+                        <select
+                            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-oxblood focus:ring-oxblood sm:text-sm border px-3 py-2"
+                            value={pickTheme(config.theme)}
+                            onChange={(e) => patch('theme', e.target.value as Theme)}
+                        >
+                            <option value="system">System</option>
+                            <option value="light">Light</option>
+                            <option value="dark">Dark</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Default row limit</label>
+                        <input
+                            type="number"
+                            min={1}
+                            max={10000}
+                            value={config.max_rows ?? 1000}
+                            onChange={(e) => patch('max_rows', Number(e.target.value))}
+                            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-oxblood focus:ring-oxblood sm:text-sm border px-3 py-2"
+                        />
+                        <p className="mt-1 text-xs text-gray-500">1–10000.</p>
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Query timeout (seconds)</label>
+                        <input
+                            type="number"
+                            min={1}
+                            max={300}
+                            value={config.timeout_seconds ?? 30}
+                            onChange={(e) => patch('timeout_seconds', Number(e.target.value))}
+                            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-oxblood focus:ring-oxblood sm:text-sm border px-3 py-2"
+                        />
+                        <p className="mt-1 text-xs text-gray-500">1–300.</p>
+                    </div>
+                </div>
+            )}
+
+            <div className="mt-6 flex justify-end">
+                <button
+                    type="button"
+                    onClick={() => void handleSave()}
+                    disabled={saving || loading || !config}
+                    className="flex items-center gap-2 px-4 py-2 bg-oxblood text-white text-sm font-medium rounded-md hover:bg-oxblood-deep disabled:opacity-60"
+                >
+                    <Save size={16} />
+                    {saving ? 'Saving…' : 'Save preferences'}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/contexts/DataSourceContext.tsx
+++ b/frontend/src/contexts/DataSourceContext.tsx
@@ -17,13 +17,23 @@ export function DataSourceProvider({ children }: { children: ReactNode }) {
 
     useEffect(() => {
         const fetchDataSources = async () => {
-            const { data } = await client.GET('/v1/data-sources');
-            if (!data?.items) return;
-            setDataSources(data.items);
+            // AUTH-006: when nothing is in sessionStorage yet, prefer the
+            // user's saved default before falling back to "first available".
+            const [dsResult, configResult] = await Promise.all([
+                client.GET('/v1/data-sources'),
+                client.GET('/v1/users/me/config'),
+            ]);
+            if (!dsResult.data?.items) return;
+            setDataSources(dsResult.data.items);
             const stored = sessionStorage.getItem(SESSION_KEY);
-            const valid = stored && data.items.some((ds) => ds.id === stored);
-            if (!valid && data.items.length > 0) {
-                setSelectedDataSourceId(data.items[0].id);
+            const validStored = stored && dsResult.data.items.some((ds) => ds.id === stored);
+            if (validStored) return;
+            const preferred = configResult.data?.config?.default_data_source_id;
+            const validPreferred = preferred && dsResult.data.items.some((ds) => ds.id === preferred);
+            if (validPreferred) {
+                setSelectedDataSourceId(preferred as string);
+            } else if (dsResult.data.items.length > 0) {
+                setSelectedDataSourceId(dsResult.data.items[0].id);
             }
         };
         void fetchDataSources();

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -162,6 +162,118 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/users/me/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the current user's configuration profile
+         * @description Returns the authenticated user's saved preferences (default data
+         *     source, default LLM provider/model, max rows, timeout, theme, table
+         *     preferences). Falls back to baseline defaults when no row has been
+         *     saved yet. AUTH-006.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description User configuration */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            config: components["schemas"]["UserConfig"];
+                        };
+                    };
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        /**
+         * Replace the current user's configuration profile
+         * @description Replaces the saved configuration with the supplied body. All known
+         *     fields are validated server-side; unknown fields return 400.
+         *     AUTH-006.
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UserConfig"];
+                };
+            };
+            responses: {
+                /** @description Saved configuration */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            config: components["schemas"]["UserConfig"];
+                        };
+                    };
+                };
+                /** @description Invalid input */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserConfigErrorResponse"];
+                    };
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/users": {
         parameters: {
             query?: never;
@@ -3475,6 +3587,31 @@ export interface components {
             /** @description AUTH-013. Plaintext bearer token. Shown exactly once. */
             token: string;
             record: components["schemas"]["ScimTokenRecord"];
+        };
+        /** @description AUTH-006. Per-user configuration profile. */
+        UserConfig: {
+            /**
+             * Format: uuid
+             * @description Preferred data source preselected on the query page.
+             */
+            default_data_source_id?: string | null;
+            /** Format: uuid */
+            default_llm_provider_id?: string | null;
+            default_model?: string | null;
+            max_rows?: number;
+            timeout_seconds?: number;
+            /** @enum {string} */
+            theme?: "light" | "dark" | "system";
+            table_preferences?: {
+                [key: string]: unknown;
+            };
+        };
+        UserConfigErrorResponse: {
+            /** @enum {string} */
+            error: "bad_request";
+            /** @description Stable error code (e.g. `invalid_default_data_source_id`, `invalid_theme`). */
+            code: string;
+            message: string;
         };
         ScimGroupMappingsResponse: {
             /** Format: uuid */

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { Settings as SettingsIcon, Network, Save, AlertCircle } from 'lucide-rea
 import { toast } from 'sonner';
 import { client } from '../lib/api/client';
 import type { components } from '../lib/api/types';
+import { UserPreferences } from '../components/Settings/UserPreferences';
 
 type RoutingStrategy = 'ordered_fallback' | 'cost_optimized' | 'latency_optimized';
 type ProviderType = components['schemas']['RoutingRuleRequest']['primary_provider'];
@@ -109,12 +110,19 @@ export const Settings: React.FC = () => {
             <div className="flex items-center gap-3 mb-8">
                 <SettingsIcon className="w-8 h-8 text-gray-700" />
                 <div>
-                    <h1 className="text-2xl font-bold text-gray-900">Routing Rules</h1>
-                    <p className="text-gray-500 mt-1">Configure provider routing policies per data source.</p>
+                    <h1 className="text-2xl font-bold text-gray-900">Settings</h1>
+                    <p className="text-gray-500 mt-1">Personal preferences and provider routing policies.</p>
                 </div>
             </div>
 
             <div className="space-y-6">
+                <UserPreferences dataSources={dataSources} />
+
+                <div className="border-t border-gray-200 pt-6">
+                    <h2 className="text-lg font-semibold text-gray-900 mb-1">Routing Rules</h2>
+                    <p className="text-sm text-gray-500 mb-4">Configure provider routing policies per data source.</p>
+                </div>
+
                 {dataSources.map(ds => {
                     const rule = routingRules[ds.id];
                     if (!rule) return null;


### PR DESCRIPTION
## Summary

- Adds `user_configs` (one JSONB row per user) with `GET` and `PUT /v1/users/me/config` endpoints. Every authenticated user can read and write their own profile via the new `users.read_self` / `users.write_self` permissions, granted to admin / analyst / viewer.
- Server-side validation with stable error codes — known keys today: `default_data_source_id`, `default_llm_provider_id`, `default_model`, `max_rows` (1..10000), `timeout_seconds` (1..300), `theme` ("light" | "dark" | "system"), `table_preferences` (free-form, 32 KB cap). Unknown fields are rejected with `unknown_field` so typos don't silently no-op.
- Settings page gains a "Your preferences" section above the existing routing rules.
- `DataSourceContext` consumes the saved `default_data_source_id` on first load — if nothing's in `sessionStorage`, the user's preferred data source wins over "first available."

## Implementation notes

- `default_data_source_id` is FK-validated outside the upsert so a missing reference returns 400 + `unknown_default_data_source` rather than a 500.
- Reads merge stored values over the baseline so adding a new preference key in a future migration doesn't break older users — their row reads the new default until they save again.
- The two new permissions are granted in the migration via `INSERT … ON CONFLICT DO NOTHING`, idempotent against re-runs.

## Verification

- [x] `npm test` — 161 pass, 0 fail (+17 new)
- [x] `npm --prefix frontend run lint` — clean
- [x] `cd frontend && npx tsc -b` — clean
- [ ] Manual: save a default data source in Settings, reload, confirm Query Workspace opens with it preselected

Closes #26