### PR TITLE
AUTH-007: per-user prompt presets

### DIFF
--- a/app/src/lib/routePolicy.js
+++ b/app/src/lib/routePolicy.js
@@ -28,6 +28,12 @@ const POLICIES = [
   { method: "GET", pattern: /^\/v1\/users\/me\/config$/, permission: "users.read_self" },
   { method: "PUT", pattern: /^\/v1\/users\/me\/config$/, permission: "users.write_self" },
 
+  // AUTH-007 — per-user prompt presets (any authenticated role)
+  { method: "GET", pattern: /^\/v1\/users\/me\/prompt-presets$/, permission: "users.read_self" },
+  { method: "POST", pattern: /^\/v1\/users\/me\/prompt-presets$/, permission: "users.write_self" },
+  { method: "PUT", pattern: /^\/v1\/users\/me\/prompt-presets\/[^/]+$/, permission: "users.write_self" },
+  { method: "DELETE", pattern: /^\/v1\/users\/me\/prompt-presets\/[^/]+$/, permission: "users.write_self" },
+
   // Admin
   { method: "GET", pattern: /^\/v1\/admin\/users$/, role: "admin" },
   { method: "POST", pattern: /^\/v1\/admin\/users$/, role: "admin" },

--- a/app/src/routes/promptPresets.js
+++ b/app/src/routes/promptPresets.js
@@ -1,0 +1,49 @@
+// AUTH-007: user-scoped prompt preset routes.
+//
+// All four endpoints sit under `/v1/users/me/prompt-presets`. The route
+// policy enforces `users.read_self` (GET) or `users.write_self` (POST,
+// PUT, DELETE) — the same permissions AUTH-006 granted to every system
+// role. Ownership for mutate verbs is enforced inside the service.
+
+const { json, readJsonBody } = require("../lib/http");
+const { isUuid } = require("../lib/validation");
+const promptPresetService = require("../services/promptPresetService");
+
+async function handleList(req, res) {
+  const userId = req.user && req.user.id;
+  const items = await promptPresetService.listForUser({ userId, includeShared: true });
+  return json(res, 200, { items });
+}
+
+async function handleCreate(req, res) {
+  const userId = req.user && req.user.id;
+  const body = await readJsonBody(req).catch(() => null);
+  const result = await promptPresetService.createPreset({ ownerUserId: userId, body });
+  return json(res, result.statusCode, result.body);
+}
+
+async function handleUpdate(req, res, id) {
+  if (!isUuid(id)) {
+    return json(res, 400, { error: "bad_request", message: "preset id must be a uuid" });
+  }
+  const userId = req.user && req.user.id;
+  const body = await readJsonBody(req).catch(() => null);
+  const result = await promptPresetService.updatePreset({ ownerUserId: userId, id, body });
+  return json(res, result.statusCode, result.body);
+}
+
+async function handleDelete(req, res, id) {
+  if (!isUuid(id)) {
+    return json(res, 400, { error: "bad_request", message: "preset id must be a uuid" });
+  }
+  const userId = req.user && req.user.id;
+  const result = await promptPresetService.deletePreset({ ownerUserId: userId, id });
+  return json(res, result.statusCode, result.body);
+}
+
+module.exports = {
+  handleList,
+  handleCreate,
+  handleUpdate,
+  handleDelete
+};

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -105,6 +105,12 @@ const {
   handlePutConfig: handlePutUserConfig
 } = require("./routes/userConfig");
 const {
+  handleList: handleListPromptPresets,
+  handleCreate: handleCreatePromptPreset,
+  handleUpdate: handleUpdatePromptPreset,
+  handleDelete: handleDeletePromptPreset
+} = require("./routes/promptPresets");
+const {
   handleServiceProviderConfig,
   handleResourceTypes,
   handleSchemas,
@@ -257,6 +263,19 @@ async function routeRequest(req, res) {
   }
   if (req.method === "PUT" && pathname === "/v1/users/me/config") {
     return handlePutUserConfig(req, res);
+  }
+
+  // AUTH-007: per-user prompt presets
+  if (req.method === "GET" && pathname === "/v1/users/me/prompt-presets") {
+    return handleListPromptPresets(req, res);
+  }
+  if (req.method === "POST" && pathname === "/v1/users/me/prompt-presets") {
+    return handleCreatePromptPreset(req, res);
+  }
+  const promptPresetIdMatch = pathname.match(/^\/v1\/users\/me\/prompt-presets\/([^/]+)$/);
+  if (promptPresetIdMatch) {
+    if (req.method === "PUT") return handleUpdatePromptPreset(req, res, promptPresetIdMatch[1]);
+    if (req.method === "DELETE") return handleDeletePromptPreset(req, res, promptPresetIdMatch[1]);
   }
 
   if (req.method === "GET" && pathname === "/v1/admin/users") {

--- a/app/src/services/promptPresetService.js
+++ b/app/src/services/promptPresetService.js
@@ -1,0 +1,261 @@
+// AUTH-007: prompt preset CRUD + visibility-aware listing.
+//
+// Ownership is enforced by callers passing the authenticated user's id;
+// the service refuses any update / delete that doesn't match the owner.
+// Listing returns the union of:
+//   - the caller's own presets (regardless of visibility)
+//   - other users' presets with visibility = 'shared'
+//
+// `data_source_id` is optional; when set we keep it referentially intact
+// via the FK (ON DELETE SET NULL in the migration). The frontend can filter
+// the list to "presets that apply to my current data source" on its own.
+
+const appDb = require("../lib/appDb");
+
+const TITLE_MAX = 200;
+const PROMPT_MAX = 8 * 1024;
+const TAGS_MAX = 16;
+const TAG_MAX_LEN = 64;
+const ALLOWED_VISIBILITY = new Set(["private", "shared"]);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function rowToPreset(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    owner_user_id: row.owner_user_id,
+    title: row.title,
+    prompt_text: row.prompt_text,
+    data_source_id: row.data_source_id,
+    tags: row.tags || [],
+    visibility: row.visibility,
+    created_at: row.created_at,
+    updated_at: row.updated_at
+  };
+}
+
+function normalizeTags(value) {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) return null;
+  if (value.length > TAGS_MAX) return null;
+  const out = [];
+  const seen = new Set();
+  for (const entry of value) {
+    if (typeof entry !== "string") return null;
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    if (trimmed.length > TAG_MAX_LEN) return null;
+    const lower = trimmed.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+// Returns `{ ok: true, value }` or `{ ok: false, code, message }`.
+function validatePreset(body, { partial = false } = {}) {
+  if (body == null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, code: "invalid_body", message: "preset body must be a JSON object" };
+  }
+  const value = {};
+
+  const requireField = (key, validator, code, message) => {
+    const has = Object.prototype.hasOwnProperty.call(body, key);
+    if (!has) {
+      if (partial) return null;
+      return { ok: false, code, message };
+    }
+    const validated = validator(body[key]);
+    if (validated.ok) {
+      value[key] = validated.value;
+      return null;
+    }
+    return { ok: false, code, message: validated.message || message };
+  };
+
+  const titleErr = requireField(
+    "title",
+    (raw) => {
+      if (typeof raw !== "string") return { ok: false, message: "title must be a string" };
+      const trimmed = raw.trim();
+      if (!trimmed) return { ok: false, message: "title is required" };
+      if (trimmed.length > TITLE_MAX) return { ok: false, message: `title must be at most ${TITLE_MAX} characters` };
+      return { ok: true, value: trimmed };
+    },
+    "invalid_title",
+    "title is required"
+  );
+  if (titleErr) return titleErr;
+
+  const promptErr = requireField(
+    "prompt_text",
+    (raw) => {
+      if (typeof raw !== "string") return { ok: false, message: "prompt_text must be a string" };
+      const trimmed = raw.trim();
+      if (!trimmed) return { ok: false, message: "prompt_text is required" };
+      if (trimmed.length > PROMPT_MAX) return { ok: false, message: `prompt_text must be at most ${PROMPT_MAX} characters` };
+      return { ok: true, value: trimmed };
+    },
+    "invalid_prompt_text",
+    "prompt_text is required"
+  );
+  if (promptErr) return promptErr;
+
+  // Optional fields. When omitted on create we apply sensible defaults;
+  // when omitted on partial update we leave the existing column alone.
+  if (Object.prototype.hasOwnProperty.call(body, "data_source_id")) {
+    const raw = body.data_source_id;
+    if (raw === null || raw === "") {
+      value.data_source_id = null;
+    } else if (typeof raw === "string" && UUID_RE.test(raw)) {
+      value.data_source_id = raw;
+    } else {
+      return { ok: false, code: "invalid_data_source_id", message: "data_source_id must be a UUID or null" };
+    }
+  } else if (!partial) {
+    value.data_source_id = null;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "tags")) {
+    const tags = normalizeTags(body.tags);
+    if (tags === null) {
+      return { ok: false, code: "invalid_tags", message: `tags must be an array of up to ${TAGS_MAX} strings (each up to ${TAG_MAX_LEN} chars)` };
+    }
+    value.tags = tags;
+  } else if (!partial) {
+    value.tags = [];
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "visibility")) {
+    const raw = body.visibility;
+    if (typeof raw !== "string" || !ALLOWED_VISIBILITY.has(raw)) {
+      return { ok: false, code: "invalid_visibility", message: `visibility must be one of: ${[...ALLOWED_VISIBILITY].join(", ")}` };
+    }
+    value.visibility = raw;
+  } else if (!partial) {
+    value.visibility = "private";
+  }
+
+  return { ok: true, value };
+}
+
+async function listForUser({ userId, includeShared = true } = {}) {
+  if (!userId) return [];
+  const sql = includeShared
+    ? `SELECT id, owner_user_id, title, prompt_text, data_source_id, tags,
+              visibility, created_at, updated_at
+         FROM prompt_presets
+         WHERE owner_user_id = $1 OR visibility = 'shared'
+         ORDER BY created_at DESC`
+    : `SELECT id, owner_user_id, title, prompt_text, data_source_id, tags,
+              visibility, created_at, updated_at
+         FROM prompt_presets
+         WHERE owner_user_id = $1
+         ORDER BY created_at DESC`;
+  const result = await appDb.query(sql, [userId]);
+  return result.rows.map(rowToPreset);
+}
+
+async function findById(id) {
+  if (typeof id !== "string" || !id) return null;
+  const result = await appDb.query(
+    `SELECT id, owner_user_id, title, prompt_text, data_source_id, tags,
+            visibility, created_at, updated_at
+       FROM prompt_presets WHERE id = $1`,
+    [id]
+  );
+  return rowToPreset(result.rows[0] || null);
+}
+
+async function createPreset({ ownerUserId, body }) {
+  if (!ownerUserId) {
+    return { statusCode: 401, body: { error: "unauthenticated" } };
+  }
+  const parsed = validatePreset(body);
+  if (!parsed.ok) {
+    return { statusCode: 400, body: { error: "bad_request", code: parsed.code, message: parsed.message } };
+  }
+  const v = parsed.value;
+  // Guard against orphan FKs returning a 500 — surface a clean 400 instead.
+  if (v.data_source_id) {
+    const exists = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [v.data_source_id]);
+    if (exists.rowCount === 0) {
+      return {
+        statusCode: 400,
+        body: { error: "bad_request", code: "unknown_data_source", message: "data_source_id does not match any existing data source" }
+      };
+    }
+  }
+  const result = await appDb.query(
+    `INSERT INTO prompt_presets (owner_user_id, title, prompt_text, data_source_id, tags, visibility)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id, owner_user_id, title, prompt_text, data_source_id, tags,
+               visibility, created_at, updated_at`,
+    [ownerUserId, v.title, v.prompt_text, v.data_source_id, v.tags, v.visibility]
+  );
+  return { statusCode: 201, body: rowToPreset(result.rows[0]) };
+}
+
+async function updatePreset({ ownerUserId, id, body }) {
+  if (!ownerUserId) return { statusCode: 401, body: { error: "unauthenticated" } };
+  const existing = await findById(id);
+  if (!existing) return { statusCode: 404, body: { error: "not_found", message: "preset not found" } };
+  if (existing.owner_user_id !== ownerUserId) {
+    return { statusCode: 403, body: { error: "forbidden", message: "only the owner can edit this preset" } };
+  }
+  // Partial update: keep existing values for fields the caller doesn't send.
+  const parsed = validatePreset(body, { partial: true });
+  if (!parsed.ok) {
+    return { statusCode: 400, body: { error: "bad_request", code: parsed.code, message: parsed.message } };
+  }
+  const merged = { ...existing, ...parsed.value };
+  if (merged.data_source_id) {
+    const exists = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [merged.data_source_id]);
+    if (exists.rowCount === 0) {
+      return {
+        statusCode: 400,
+        body: { error: "bad_request", code: "unknown_data_source", message: "data_source_id does not match any existing data source" }
+      };
+    }
+  }
+  const result = await appDb.query(
+    `UPDATE prompt_presets
+        SET title = $2,
+            prompt_text = $3,
+            data_source_id = $4,
+            tags = $5,
+            visibility = $6,
+            updated_at = NOW()
+      WHERE id = $1
+      RETURNING id, owner_user_id, title, prompt_text, data_source_id, tags,
+                visibility, created_at, updated_at`,
+    [id, merged.title, merged.prompt_text, merged.data_source_id, merged.tags, merged.visibility]
+  );
+  return { statusCode: 200, body: rowToPreset(result.rows[0]) };
+}
+
+async function deletePreset({ ownerUserId, id }) {
+  if (!ownerUserId) return { statusCode: 401, body: { error: "unauthenticated" } };
+  const existing = await findById(id);
+  if (!existing) return { statusCode: 404, body: { error: "not_found", message: "preset not found" } };
+  if (existing.owner_user_id !== ownerUserId) {
+    return { statusCode: 403, body: { error: "forbidden", message: "only the owner can delete this preset" } };
+  }
+  await appDb.query("DELETE FROM prompt_presets WHERE id = $1", [id]);
+  return { statusCode: 200, body: { ok: true, id } };
+}
+
+module.exports = {
+  TITLE_MAX,
+  PROMPT_MAX,
+  TAGS_MAX,
+  TAG_MAX_LEN,
+  ALLOWED_VISIBILITY,
+  validatePreset,
+  listForUser,
+  findById,
+  createPreset,
+  updatePreset,
+  deletePreset
+};

--- a/app/test/promptPresetsApi.test.js
+++ b/app/test/promptPresetsApi.test.js
@@ -1,0 +1,255 @@
+// AUTH-007: end-to-end coverage for the /v1/users/me/prompt-presets surface.
+
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+process.env.PORT = "0";
+process.env.AUTH_COOKIE_SECURE = "false";
+
+const appDb = require("../src/lib/appDb");
+const { createAuthTestStub } = require("./helpers/authTestStub");
+
+let server;
+let baseUrl;
+let authStub;
+let originalQuery;
+let presets;       // id -> row
+let dataSources;   // id -> row
+let presetCounter;
+let aliceCookie;
+let bobCookie;
+let aliceId;
+let bobId;
+
+function uuid(prefix, counter) {
+  return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
+}
+function nextPresetId() { presetCounter += 1; return uuid("9988", presetCounter); }
+
+function normalize(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+async function call(method, path, { cookie, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (cookie) headers.Cookie = cookie;
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  let payload = null;
+  if ((response.headers.get("content-type") || "").includes("application/json")) {
+    try { payload = await response.json(); } catch { payload = null; }
+  }
+  return { status: response.status, payload };
+}
+
+before(async () => {
+  authStub = createAuthTestStub();
+  originalQuery = appDb.query;
+  presets = new Map();
+  dataSources = new Map();
+  presetCounter = 0;
+
+  const alice = authStub.seedUser({ email: "alice@example.com", roles: ["analyst"], password: "Hunter22ok!" });
+  const bob = authStub.seedUser({ email: "bob@example.com", roles: ["analyst"], password: "Hunter22ok!" });
+  aliceId = alice.id;
+  bobId = bob.id;
+  aliceCookie = authStub.cookieFor(authStub.seedSession(alice.id).token);
+  bobCookie = authStub.cookieFor(authStub.seedSession(bob.id).token);
+
+  // Pre-seed one data source so the FK check has something to find.
+  dataSources.set("00000000-0000-4000-8000-d5d5d5d5d5d5", { id: "00000000-0000-4000-8000-d5d5d5d5d5d5" });
+
+  appDb.query = async (sql, params = []) => {
+    const auth = authStub.handleSql(sql, params);
+    if (auth) return auth;
+
+    const n = normalize(sql);
+
+    if (n.startsWith("select id, owner_user_id, title, prompt_text, data_source_id, tags, visibility, created_at, updated_at from prompt_presets where owner_user_id = $1 or visibility = 'shared'")) {
+      const [userId] = params;
+      const rows = [...presets.values()]
+        .filter((p) => p.owner_user_id === userId || p.visibility === "shared")
+        .sort((a, b) => b.created_at.localeCompare(a.created_at));
+      return { rowCount: rows.length, rows };
+    }
+    if (n.startsWith("select id, owner_user_id, title, prompt_text, data_source_id, tags, visibility, created_at, updated_at from prompt_presets where id = $1")) {
+      const [id] = params;
+      const row = presets.get(id);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    if (n.startsWith("select id from data_sources where id = $1")) {
+      const [id] = params;
+      return dataSources.has(id) ? { rowCount: 1, rows: [{ id }] } : { rowCount: 0, rows: [] };
+    }
+
+    if (n.startsWith("insert into prompt_presets")) {
+      const [ownerUserId, title, promptText, dataSourceId, tags, visibility] = params;
+      const row = {
+        id: nextPresetId(),
+        owner_user_id: ownerUserId,
+        title,
+        prompt_text: promptText,
+        data_source_id: dataSourceId,
+        tags: tags || [],
+        visibility,
+        created_at: new Date(Date.now() + presetCounter).toISOString(),
+        updated_at: new Date().toISOString()
+      };
+      presets.set(row.id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (n.startsWith("update prompt_presets set title = $2, prompt_text = $3, data_source_id = $4, tags = $5, visibility = $6, updated_at = now() where id = $1")) {
+      const [id, title, promptText, dataSourceId, tags, visibility] = params;
+      const row = presets.get(id);
+      if (!row) return { rowCount: 0, rows: [] };
+      row.title = title;
+      row.prompt_text = promptText;
+      row.data_source_id = dataSourceId;
+      row.tags = tags || [];
+      row.visibility = visibility;
+      row.updated_at = new Date().toISOString();
+      presets.set(id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (n.startsWith("delete from prompt_presets where id = $1")) {
+      const [id] = params;
+      const had = presets.delete(id);
+      return { rowCount: had ? 1 : 0, rows: [] };
+    }
+
+    throw new Error(`Unexpected SQL in prompt-presets test stub: ${n}`);
+  };
+
+  delete require.cache[require.resolve("../src/server")];
+  const { startServer } = require("../src/server");
+  server = await startServer();
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  appDb.query = originalQuery;
+});
+
+beforeEach(() => {
+  presets.clear();
+  presetCounter = 0;
+});
+
+test("GET is unauthenticated → 401", async () => {
+  const result = await call("GET", "/v1/users/me/prompt-presets");
+  assert.equal(result.status, 401);
+});
+
+test("POST creates a private preset for the caller", async () => {
+  const result = await call("POST", "/v1/users/me/prompt-presets", {
+    cookie: aliceCookie,
+    body: { title: "Revenue YoY", prompt_text: "Show revenue YoY by region" }
+  });
+  assert.equal(result.status, 201, JSON.stringify(result.payload));
+  assert.equal(result.payload.title, "Revenue YoY");
+  assert.equal(result.payload.visibility, "private");
+  assert.equal(result.payload.owner_user_id, aliceId);
+});
+
+test("POST rejects invalid input with a stable code", async () => {
+  const result = await call("POST", "/v1/users/me/prompt-presets", {
+    cookie: aliceCookie,
+    body: { title: "" }
+  });
+  assert.equal(result.status, 400);
+  assert.equal(result.payload.code, "invalid_title");
+});
+
+test("POST with unknown data_source_id returns 400", async () => {
+  const result = await call("POST", "/v1/users/me/prompt-presets", {
+    cookie: aliceCookie,
+    body: { title: "Foo", prompt_text: "bar", data_source_id: "00000000-0000-4000-8000-deadbeef0001" }
+  });
+  assert.equal(result.status, 400);
+  assert.equal(result.payload.code, "unknown_data_source");
+});
+
+test("GET returns the caller's own presets + shared presets from others", async () => {
+  // Alice creates a private preset.
+  await call("POST", "/v1/users/me/prompt-presets", {
+    cookie: aliceCookie,
+    body: { title: "Alice private", prompt_text: "p1" }
+  });
+  // Bob creates a private preset (should NOT show in Alice's list).
+  await call("POST", "/v1/users/me/prompt-presets", {
+    cookie: bobCookie,
+    body: { title: "Bob private", prompt_text: "p2" }
+  });
+  // Bob creates a shared preset (SHOULD show in Alice's list).
+  await call("POST", "/v1/users/me/prompt-presets", {
+    cookie: bobCookie,
+    body: { title: "Bob shared", prompt_text: "p3", visibility: "shared" }
+  });
+
+  const aliceList = await call("GET", "/v1/users/me/prompt-presets", { cookie: aliceCookie });
+  assert.equal(aliceList.status, 200);
+  const titles = aliceList.payload.items.map((it) => it.title).sort();
+  assert.deepEqual(titles, ["Alice private", "Bob shared"]);
+});
+
+test("PUT enforces ownership: a non-owner gets 403", async () => {
+  const created = await call("POST", "/v1/users/me/prompt-presets", {
+    cookie: aliceCookie,
+    body: { title: "Alice's", prompt_text: "p", visibility: "shared" }
+  });
+  assert.equal(created.status, 201);
+  const update = await call("PUT", `/v1/users/me/prompt-presets/${created.payload.id}`, {
+    cookie: bobCookie,
+    body: { title: "Bob renamed" }
+  });
+  assert.equal(update.status, 403);
+});
+
+test("PUT by owner applies a partial update", async () => {
+  const created = await call("POST", "/v1/users/me/prompt-presets", {
+    cookie: aliceCookie,
+    body: { title: "Draft", prompt_text: "x" }
+  });
+  const update = await call("PUT", `/v1/users/me/prompt-presets/${created.payload.id}`, {
+    cookie: aliceCookie,
+    body: { visibility: "shared", tags: ["finance"] }
+  });
+  assert.equal(update.status, 200);
+  assert.equal(update.payload.title, "Draft", "title untouched when omitted");
+  assert.equal(update.payload.visibility, "shared");
+  assert.deepEqual(update.payload.tags, ["finance"]);
+});
+
+test("DELETE enforces ownership and returns 404 for unknown ids", async () => {
+  const created = await call("POST", "/v1/users/me/prompt-presets", {
+    cookie: aliceCookie,
+    body: { title: "x", prompt_text: "y" }
+  });
+  const bobDel = await call("DELETE", `/v1/users/me/prompt-presets/${created.payload.id}`, { cookie: bobCookie });
+  assert.equal(bobDel.status, 403);
+
+  const aliceDel = await call("DELETE", `/v1/users/me/prompt-presets/${created.payload.id}`, { cookie: aliceCookie });
+  assert.equal(aliceDel.status, 200);
+
+  const again = await call("DELETE", `/v1/users/me/prompt-presets/${created.payload.id}`, { cookie: aliceCookie });
+  assert.equal(again.status, 404);
+});
+
+test("malformed ids return 400 before touching the DB", async () => {
+  const bad = await call("PUT", "/v1/users/me/prompt-presets/not-a-uuid", {
+    cookie: aliceCookie,
+    body: { title: "x" }
+  });
+  assert.equal(bad.status, 400);
+});
+
+// Quiet noise — both ids are used implicitly via cookies / assertions.
+void bobId;

--- a/app/test/promptPresetsMigration.test.js
+++ b/app/test/promptPresetsMigration.test.js
@@ -1,0 +1,23 @@
+// AUTH-007: migration shape — prompt_presets table + indexes.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+test("0023_prompt_presets creates prompt_presets with owner FK and visibility check", () => {
+  const migrationPath = path.resolve(
+    __dirname,
+    "../../db/migrations/0023_prompt_presets.sql"
+  );
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS prompt_presets/i);
+  assert.match(sql, /owner_user_id UUID NOT NULL REFERENCES users\(id\) ON DELETE CASCADE/i);
+  assert.match(sql, /data_source_id UUID REFERENCES data_sources\(id\) ON DELETE SET NULL/i);
+  assert.match(sql, /visibility TEXT NOT NULL DEFAULT 'private'/i);
+  assert.match(sql, /CHECK \(visibility IN \('private', 'shared'\)\)/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_prompt_presets_owner/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_prompt_presets_shared/i);
+  assert.match(sql, /WHERE visibility = 'shared'/i);
+});

--- a/app/test/promptPresetsPolicy.test.js
+++ b/app/test/promptPresetsPolicy.test.js
@@ -1,0 +1,74 @@
+// AUTH-007: pure unit tests for the preset validator. No DB / HTTP.
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const service = require("../src/services/promptPresetService");
+
+test("validatePreset accepts a well-formed body and defaults optional fields", () => {
+  const res = service.validatePreset({ title: "Revenue YoY", prompt_text: "Show revenue YoY by region" });
+  assert.equal(res.ok, true);
+  assert.equal(res.value.visibility, "private");
+  assert.deepEqual(res.value.tags, []);
+  assert.equal(res.value.data_source_id, null);
+});
+
+test("validatePreset rejects missing title / prompt_text on create", () => {
+  const noTitle = service.validatePreset({ prompt_text: "Show revenue" });
+  assert.equal(noTitle.ok, false);
+  assert.equal(noTitle.code, "invalid_title");
+
+  const noPrompt = service.validatePreset({ title: "x" });
+  assert.equal(noPrompt.ok, false);
+  assert.equal(noPrompt.code, "invalid_prompt_text");
+});
+
+test("validatePreset allows missing title in partial mode", () => {
+  const res = service.validatePreset({ visibility: "shared" }, { partial: true });
+  assert.equal(res.ok, true);
+  assert.equal(res.value.visibility, "shared");
+  // No title in the partial value: caller is expected to merge with existing.
+  assert.equal(res.value.title, undefined);
+});
+
+test("validatePreset rejects an out-of-range tag length", () => {
+  const longTag = "x".repeat(80);
+  const res = service.validatePreset({
+    title: "x", prompt_text: "y", tags: [longTag]
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "invalid_tags");
+});
+
+test("validatePreset deduplicates tags case-insensitively while preserving original casing", () => {
+  const res = service.validatePreset({
+    title: "x", prompt_text: "y", tags: ["Finance", "finance", "  Risk  "]
+  });
+  assert.equal(res.ok, true);
+  assert.deepEqual(res.value.tags, ["Finance", "Risk"]);
+});
+
+test("validatePreset rejects an invalid visibility", () => {
+  const res = service.validatePreset({
+    title: "x", prompt_text: "y", visibility: "public"
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "invalid_visibility");
+});
+
+test("validatePreset rejects an oversized prompt", () => {
+  const huge = "x".repeat(9 * 1024);
+  const res = service.validatePreset({ title: "x", prompt_text: huge });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "invalid_prompt_text");
+});
+
+test("validatePreset rejects a malformed data_source_id", () => {
+  const res = service.validatePreset({
+    title: "x", prompt_text: "y", data_source_id: "not-a-uuid"
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "invalid_data_source_id");
+});

--- a/db/migrations/0023_prompt_presets.sql
+++ b/db/migrations/0023_prompt_presets.sql
@@ -1,0 +1,35 @@
+-- AUTH-007: per-user prompt preset library.
+--
+-- A prompt preset is a saved natural-language question the user can reload
+-- into the query workspace. Each preset is owned by exactly one user; the
+-- `visibility` column controls whether other users see it on their list:
+--   'private' (default) — only the owner sees it.
+--   'shared'            — visible read-only to every authenticated user;
+--                         only the owner can edit / delete it.
+--
+-- `data_source_id` is optional: presets may be scoped to a specific data
+-- source ("month-end revenue by region") or generic ("what tables relate
+-- to customers?"). When set we FK to data_sources with ON DELETE SET NULL
+-- so a deleted data source doesn't orphan the preset.
+
+CREATE TABLE IF NOT EXISTS prompt_presets (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  prompt_text TEXT NOT NULL,
+  data_source_id UUID REFERENCES data_sources(id) ON DELETE SET NULL,
+  tags TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+  visibility TEXT NOT NULL DEFAULT 'private'
+    CHECK (visibility IN ('private', 'shared')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_prompt_presets_owner
+  ON prompt_presets (owner_user_id, created_at DESC);
+
+-- Shared listing is hot path: the WHERE clause in the API filters by
+-- visibility = 'shared' first to surface other users' presets.
+CREATE INDEX IF NOT EXISTS idx_prompt_presets_shared
+  ON prompt_presets (visibility, created_at DESC)
+  WHERE visibility = 'shared';

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -140,6 +140,115 @@ paths:
           description: Unauthenticated
         "403":
           description: Forbidden
+  /v1/users/me/prompt-presets:
+    get:
+      tags: [Auth]
+      summary: List the current user's prompt presets, plus any presets shared by others
+      description: AUTH-007. Returns the union of the caller's own presets (any visibility) and other users' presets with `visibility = 'shared'`, newest first.
+      responses:
+        "200":
+          description: Presets visible to the caller
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PromptPreset"
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+    post:
+      tags: [Auth]
+      summary: Create a prompt preset owned by the current user
+      description: AUTH-007.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PromptPresetUpsertRequest"
+      responses:
+        "201":
+          description: Preset created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PromptPreset"
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserConfigErrorResponse"
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Forbidden
+  /v1/users/me/prompt-presets/{id}:
+    put:
+      tags: [Auth]
+      summary: Update an owned prompt preset
+      description: AUTH-007. Partial update — only the supplied fields are changed. Only the owner can edit.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PromptPresetUpsertRequest"
+      responses:
+        "200":
+          description: Updated preset
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PromptPreset"
+        "400":
+          description: Invalid input
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Caller is not the owner
+        "404":
+          description: Preset not found
+    delete:
+      tags: [Auth]
+      summary: Delete an owned prompt preset
+      description: AUTH-007. Only the owner can delete.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  id:
+                    type: string
+        "401":
+          description: Unauthenticated
+        "403":
+          description: Caller is not the owner
+        "404":
+          description: Preset not found
   /v1/admin/users:
     get:
       tags: [Admin]
@@ -2123,6 +2232,59 @@ components:
         table_preferences:
           type: object
           additionalProperties: true
+    PromptPreset:
+      type: object
+      description: AUTH-007. A saved prompt template owned by a single user.
+      required: [id, owner_user_id, title, prompt_text, tags, visibility, created_at, updated_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        owner_user_id:
+          type: string
+          format: uuid
+        title:
+          type: string
+          maxLength: 200
+        prompt_text:
+          type: string
+          maxLength: 8192
+        data_source_id:
+          type: string
+          format: uuid
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: string
+        visibility:
+          type: string
+          enum: [private, shared]
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    PromptPresetUpsertRequest:
+      type: object
+      description: AUTH-007. Body for create / update. On update, omitted fields keep their existing value.
+      properties:
+        title:
+          type: string
+        prompt_text:
+          type: string
+        data_source_id:
+          type: string
+          format: uuid
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: string
+        visibility:
+          type: string
+          enum: [private, shared]
     UserConfigErrorResponse:
       type: object
       required: [error, code, message]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { Settings } from './pages/Settings';
 import { LLMProviders } from './pages/LLMProviders';
 import { AuthProviders } from './pages/AuthProviders';
 import { AuditLog } from './pages/AuditLog';
+import { PromptPresets } from './pages/PromptPresets';
 
 function App() {
   return (
@@ -79,6 +80,7 @@ function App() {
               )}
             />
             <Route path="/settings" element={<Settings />} />
+            <Route path="/prompts" element={<PromptPresets />} />
             <Route
               path="/admin/auth-providers"
               element={(

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -3,6 +3,7 @@ import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import {
     Bell,
     BookOpen,
+    Bookmark,
     ChevronDown,
     ChevronRight,
     Database,
@@ -35,6 +36,7 @@ type NavEntry = {
 const PRIMARY_NAV: NavEntry[] = [
     { path: '/dashboard', label: 'Home', icon: Home },
     { path: '/queries', label: 'Queries', icon: Terminal, permission: 'saved_queries.read' },
+    { path: '/prompts', label: 'Prompts', icon: Bookmark, permission: 'users.read_self' },
     { path: '/data-sources', label: 'Datasets', icon: Database, permission: 'data_sources.read' },
     { path: '/folders', label: 'Folders', icon: FolderClosed, stub: true },
     { path: '/favorites', label: 'Favorites', icon: Star, stub: true },
@@ -66,6 +68,7 @@ const PATH_LABELS: Record<string, string> = {
     '/docs': 'Documentation',
     '/admin/auth-providers': 'Auth Providers',
     '/admin/audit-log': 'Audit Log',
+    '/prompts': 'Prompt Presets',
 };
 
 function NavItem({ to, label, Icon, stub }: { to: string; label: string; Icon: typeof Home; stub?: boolean }) {

--- a/frontend/src/components/Query/PromptSection.tsx
+++ b/frontend/src/components/Query/PromptSection.tsx
@@ -1,8 +1,12 @@
-import { useState, type RefObject } from 'react';
-import { History, Loader2, Settings2, Sparkles } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import { Bookmark, History, Loader2, Settings2, Sparkles } from 'lucide-react';
 import { PromptHistoryPanel } from './PromptHistoryPanel';
 import { RunSettingsPopover } from './RunSettingsPopover';
 import type { LlmProvider, PromptHistoryItem, PromptHistoryPosition } from './types';
+import { client } from '../../lib/api/client';
+import type { components } from '../../lib/api/types';
+
+type PromptPreset = components['schemas']['PromptPreset'];
 
 interface PromptSectionProps {
     isDryRun: boolean;
@@ -66,6 +70,35 @@ export function PromptSection({
     const [isSettingsOpen, setIsSettingsOpen] = useState(false);
     const canGenerate = !isGenerating && question.trim().length > 0 && Boolean(selectedDataSourceId);
 
+    // AUTH-007: per-user prompt presets. We lazy-load them the first time the
+    // picker opens so the page doesn't issue an extra request on mount.
+    const [isPresetsOpen, setIsPresetsOpen] = useState(false);
+    const [presets, setPresets] = useState<PromptPreset[] | null>(null);
+    const [presetsLoading, setPresetsLoading] = useState(false);
+    const presetsPanelRef = useRef<HTMLDivElement | null>(null);
+    const loadPresets = useCallback(async () => {
+        setPresetsLoading(true);
+        try {
+            const { data } = await client.GET('/v1/users/me/prompt-presets');
+            setPresets(data?.items ?? []);
+        } finally {
+            setPresetsLoading(false);
+        }
+    }, []);
+    useEffect(() => {
+        if (isPresetsOpen && presets === null) void loadPresets();
+    }, [isPresetsOpen, presets, loadPresets]);
+    useEffect(() => {
+        if (!isPresetsOpen) return;
+        const onDocClick = (event: MouseEvent) => {
+            if (presetsPanelRef.current && !presetsPanelRef.current.contains(event.target as Node)) {
+                setIsPresetsOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', onDocClick);
+        return () => document.removeEventListener('mousedown', onDocClick);
+    }, [isPresetsOpen]);
+
     return (
         <div className="flex-shrink-0 border-b border-outline-variant bg-surface-container-low p-4">
             {isDryRun && (
@@ -92,6 +125,61 @@ export function PromptSection({
                 />
 
                 <div className="absolute right-2 flex items-center gap-1">
+                    <div ref={presetsPanelRef} className="relative">
+                        <button
+                            type="button"
+                            onClick={() => setIsPresetsOpen((open) => !open)}
+                            className="rounded p-1.5 text-slate-500 hover:bg-slate-100"
+                            title="Prompt presets"
+                            aria-label="Prompt presets"
+                        >
+                            <Bookmark size={14} />
+                        </button>
+                        {isPresetsOpen && (
+                            <div className="absolute right-0 top-9 z-30 w-80 overflow-hidden rounded-lg border border-outline-variant bg-white shadow-lg">
+                                <div className="flex items-center justify-between border-b border-outline-variant px-3 py-2 text-xs font-medium text-slate-600">
+                                    <span>Saved prompts</span>
+                                    <span className="text-[10px] text-slate-400">{presets?.length ?? 0}</span>
+                                </div>
+                                <div className="max-h-80 overflow-y-auto">
+                                    {presetsLoading ? (
+                                        <div className="px-3 py-4 text-xs text-slate-500">Loading…</div>
+                                    ) : !presets || presets.length === 0 ? (
+                                        <div className="px-3 py-4 text-xs text-slate-500">
+                                            No saved prompts yet. Create one from the <strong>Prompts</strong> page.
+                                        </div>
+                                    ) : (
+                                        presets.map((preset) => {
+                                            const matchesDataSource = !preset.data_source_id || preset.data_source_id === selectedDataSourceId;
+                                            return (
+                                                <button
+                                                    key={preset.id}
+                                                    type="button"
+                                                    onClick={() => { onQuestionChange(preset.prompt_text); setIsPresetsOpen(false); }}
+                                                    className="block w-full border-b border-outline-variant px-3 py-2 text-left last:border-b-0 hover:bg-slate-50"
+                                                >
+                                                    <div className="flex items-center justify-between gap-2">
+                                                        <span className="truncate text-xs font-medium text-slate-800">{preset.title}</span>
+                                                        <span className={`shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-medium ${
+                                                            preset.visibility === 'shared' ? 'bg-blue-50 text-blue-700' : 'bg-slate-100 text-slate-600'
+                                                        }`}>
+                                                            {preset.visibility}
+                                                        </span>
+                                                    </div>
+                                                    <div className="mt-0.5 line-clamp-1 text-[11px] text-slate-500">{preset.prompt_text}</div>
+                                                    {!matchesDataSource && preset.data_source_id && (
+                                                        <div className="mt-0.5 text-[10px] text-amber-700">
+                                                            Saved for a different data source
+                                                        </div>
+                                                    )}
+                                                </button>
+                                            );
+                                        })
+                                    )}
+                                </div>
+                            </div>
+                        )}
+                    </div>
                     <div ref={promptHistoryRef} className="relative">
                         <button
                             ref={promptHistoryButtonRef}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -274,6 +274,233 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/users/me/prompt-presets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the current user's prompt presets, plus any presets shared by others
+         * @description AUTH-007. Returns the union of the caller's own presets (any visibility) and other users' presets with `visibility = 'shared'`, newest first.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Presets visible to the caller */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: components["schemas"]["PromptPreset"][];
+                        };
+                    };
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create a prompt preset owned by the current user
+         * @description AUTH-007.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["PromptPresetUpsertRequest"];
+                };
+            };
+            responses: {
+                /** @description Preset created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PromptPreset"];
+                    };
+                };
+                /** @description Invalid input */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserConfigErrorResponse"];
+                    };
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/users/me/prompt-presets/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update an owned prompt preset
+         * @description AUTH-007. Partial update — only the supplied fields are changed. Only the owner can edit.
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["PromptPresetUpsertRequest"];
+                };
+            };
+            responses: {
+                /** @description Updated preset */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PromptPreset"];
+                    };
+                };
+                /** @description Invalid input */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Caller is not the owner */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Preset not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        /**
+         * Delete an owned prompt preset
+         * @description AUTH-007. Only the owner can delete.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            ok?: boolean;
+                            id?: string;
+                        };
+                    };
+                };
+                /** @description Unauthenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Caller is not the owner */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Preset not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/users": {
         parameters: {
             query?: never;
@@ -3605,6 +3832,34 @@ export interface components {
             table_preferences?: {
                 [key: string]: unknown;
             };
+        };
+        /** @description AUTH-007. A saved prompt template owned by a single user. */
+        PromptPreset: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            owner_user_id: string;
+            title: string;
+            prompt_text: string;
+            /** Format: uuid */
+            data_source_id?: string | null;
+            tags: string[];
+            /** @enum {string} */
+            visibility: "private" | "shared";
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        /** @description AUTH-007. Body for create / update. On update, omitted fields keep their existing value. */
+        PromptPresetUpsertRequest: {
+            title?: string;
+            prompt_text?: string;
+            /** Format: uuid */
+            data_source_id?: string | null;
+            tags?: string[];
+            /** @enum {string} */
+            visibility?: "private" | "shared";
         };
         UserConfigErrorResponse: {
             /** @enum {string} */

--- a/frontend/src/pages/PromptPresets.tsx
+++ b/frontend/src/pages/PromptPresets.tsx
@@ -1,0 +1,367 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { BookmarkPlus, Eye, EyeOff, Pencil, Plus, RefreshCw, Trash2, Users } from 'lucide-react';
+import { format } from 'date-fns';
+import { toast } from 'sonner';
+import { client } from '../lib/api/client';
+import type { components } from '../lib/api/types';
+
+type PromptPreset = components['schemas']['PromptPreset'];
+
+type DataSource = { id: string; name: string };
+
+type EditingState = {
+    id?: string;
+    title: string;
+    prompt_text: string;
+    data_source_id: string;
+    tags: string;
+    visibility: 'private' | 'shared';
+};
+
+const EMPTY_FORM: EditingState = {
+    title: '',
+    prompt_text: '',
+    data_source_id: '',
+    tags: '',
+    visibility: 'private',
+};
+
+function presetToForm(preset: PromptPreset): EditingState {
+    return {
+        id: preset.id,
+        title: preset.title,
+        prompt_text: preset.prompt_text,
+        data_source_id: preset.data_source_id ?? '',
+        tags: (preset.tags ?? []).join(', '),
+        visibility: preset.visibility,
+    };
+}
+
+export function PromptPresets() {
+    const [items, setItems] = useState<PromptPreset[]>([]);
+    const [dataSources, setDataSources] = useState<DataSource[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [editing, setEditing] = useState<EditingState | null>(null);
+    const [meUserId, setMeUserId] = useState<string | null>(null);
+
+    const fetchAll = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            const [presets, dss, me] = await Promise.all([
+                client.GET('/v1/users/me/prompt-presets'),
+                client.GET('/v1/data-sources'),
+                client.GET('/v1/auth/me'),
+            ]);
+            setItems(presets.data?.items ?? []);
+            setDataSources((dss.data?.items ?? []).map((d) => ({ id: d.id, name: d.name })));
+            setMeUserId(me.data?.user?.id ?? null);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void fetchAll();
+    }, [fetchAll]);
+
+    const ownedItems = useMemo(
+        () => items.filter((p) => p.owner_user_id === meUserId),
+        [items, meUserId],
+    );
+    const sharedItems = useMemo(
+        () => items.filter((p) => p.owner_user_id !== meUserId),
+        [items, meUserId],
+    );
+
+    function startNew() { setEditing({ ...EMPTY_FORM }); }
+    function startEdit(preset: PromptPreset) { setEditing(presetToForm(preset)); }
+    function cancel() { setEditing(null); }
+
+    function setField<K extends keyof EditingState>(key: K, value: EditingState[K]) {
+        setEditing((prev) => (prev ? { ...prev, [key]: value } : prev));
+    }
+
+    async function handleSave() {
+        if (!editing) return;
+        const tags = editing.tags
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean);
+        const body = {
+            title: editing.title.trim(),
+            prompt_text: editing.prompt_text.trim(),
+            data_source_id: editing.data_source_id || null,
+            tags,
+            visibility: editing.visibility,
+        };
+        if (editing.id) {
+            const { response, error } = await client.PUT('/v1/users/me/prompt-presets/{id}', {
+                params: { path: { id: editing.id } },
+                body,
+            });
+            if (!response.ok) {
+                const msg = (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: string }).message === 'string')
+                    ? (error as { message: string }).message
+                    : `Failed (${response.status}).`;
+                toast.error(msg);
+                return;
+            }
+            toast.success('Preset updated.');
+        } else {
+            const { response, error } = await client.POST('/v1/users/me/prompt-presets', { body });
+            if (!response.ok) {
+                const msg = (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: string }).message === 'string')
+                    ? (error as { message: string }).message
+                    : `Failed (${response.status}).`;
+                toast.error(msg);
+                return;
+            }
+            toast.success('Preset created.');
+        }
+        setEditing(null);
+        await fetchAll();
+    }
+
+    async function handleDelete(id: string) {
+        const { response } = await client.DELETE('/v1/users/me/prompt-presets/{id}', {
+            params: { path: { id } },
+        });
+        if (response.ok) {
+            toast.success('Preset deleted.');
+            await fetchAll();
+        } else {
+            toast.error('Failed to delete preset.');
+        }
+    }
+
+    function dataSourceName(id?: string | null) {
+        if (!id) return null;
+        return dataSources.find((d) => d.id === id)?.name ?? id;
+    }
+
+    return (
+        <div className="flex h-full flex-col p-6">
+            <div className="mb-6 flex items-start justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold text-gray-900">Prompt Presets</h1>
+                    <p className="mt-1 text-sm text-gray-500">
+                        Save reusable prompts and share favorites with your team.
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={startNew}
+                    className="flex items-center gap-2 rounded-md bg-oxblood px-4 py-2 text-sm font-medium text-white hover:bg-oxblood-deep"
+                >
+                    <Plus size={16} />
+                    New preset
+                </button>
+            </div>
+
+            {editing && (
+                <div className="mb-6 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                    <div className="mb-4 flex items-center justify-between">
+                        <h2 className="text-sm font-semibold text-gray-900">
+                            {editing.id ? 'Edit preset' : 'New preset'}
+                        </h2>
+                        <button
+                            type="button"
+                            onClick={cancel}
+                            className="text-xs text-gray-500 hover:text-gray-700"
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                        <div className="md:col-span-2">
+                            <label className="mb-1 block text-xs font-medium text-gray-700">Title</label>
+                            <input
+                                type="text"
+                                value={editing.title}
+                                onChange={(e) => setField('title', e.target.value)}
+                                placeholder="Revenue by region — YoY"
+                                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                            />
+                        </div>
+                        <div className="md:col-span-2">
+                            <label className="mb-1 block text-xs font-medium text-gray-700">Prompt text</label>
+                            <textarea
+                                value={editing.prompt_text}
+                                onChange={(e) => setField('prompt_text', e.target.value)}
+                                rows={4}
+                                placeholder="Show me top 10 regions by revenue YoY for the last 12 months."
+                                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                            />
+                        </div>
+                        <div>
+                            <label className="mb-1 block text-xs font-medium text-gray-700">Data source (optional)</label>
+                            <select
+                                value={editing.data_source_id}
+                                onChange={(e) => setField('data_source_id', e.target.value)}
+                                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                            >
+                                <option value="">Any data source</option>
+                                {dataSources.map((ds) => (
+                                    <option key={ds.id} value={ds.id}>{ds.name}</option>
+                                ))}
+                            </select>
+                        </div>
+                        <div>
+                            <label className="mb-1 block text-xs font-medium text-gray-700">Visibility</label>
+                            <select
+                                value={editing.visibility}
+                                onChange={(e) => setField('visibility', e.target.value as 'private' | 'shared')}
+                                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                            >
+                                <option value="private">Private — only you</option>
+                                <option value="shared">Shared — visible to all signed-in users</option>
+                            </select>
+                        </div>
+                        <div className="md:col-span-2">
+                            <label className="mb-1 block text-xs font-medium text-gray-700">Tags (comma-separated)</label>
+                            <input
+                                type="text"
+                                value={editing.tags}
+                                onChange={(e) => setField('tags', e.target.value)}
+                                placeholder="finance, revenue"
+                                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-oxblood"
+                            />
+                        </div>
+                    </div>
+                    <div className="mt-4 flex justify-end gap-2">
+                        <button
+                            type="button"
+                            onClick={cancel}
+                            className="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => void handleSave()}
+                            className="rounded-md bg-oxblood px-3 py-2 text-sm font-medium text-white hover:bg-oxblood-deep"
+                        >
+                            {editing.id ? 'Save changes' : 'Create preset'}
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            <div className="flex-1 space-y-6 overflow-y-auto">
+                <PresetSection
+                    label="Your presets"
+                    icon={<BookmarkPlus size={16} />}
+                    items={ownedItems}
+                    isLoading={isLoading}
+                    canEdit
+                    dataSourceName={dataSourceName}
+                    onEdit={startEdit}
+                    onDelete={handleDelete}
+                    emptyHint="You haven't saved any prompts yet. Click 'New preset' to start."
+                />
+                <PresetSection
+                    label="Shared by your team"
+                    icon={<Users size={16} />}
+                    items={sharedItems}
+                    isLoading={isLoading}
+                    canEdit={false}
+                    dataSourceName={dataSourceName}
+                    onEdit={startEdit}
+                    onDelete={handleDelete}
+                    emptyHint="No shared presets yet. Set a preset's visibility to 'shared' to share it."
+                />
+            </div>
+        </div>
+    );
+}
+
+function PresetSection({
+    label,
+    icon,
+    items,
+    isLoading,
+    canEdit,
+    dataSourceName,
+    onEdit,
+    onDelete,
+    emptyHint,
+}: {
+    label: string;
+    icon: React.ReactNode;
+    items: PromptPreset[];
+    isLoading: boolean;
+    canEdit: boolean;
+    dataSourceName: (id?: string | null) => string | null;
+    onEdit: (p: PromptPreset) => void;
+    onDelete: (id: string) => void;
+    emptyHint: string;
+}) {
+    return (
+        <section>
+            <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-gray-800">
+                {icon}
+                {label}
+                <span className="text-xs font-normal text-gray-500">({items.length})</span>
+            </div>
+            <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+                {isLoading ? (
+                    <div className="flex items-center justify-center py-10 text-sm text-gray-500">
+                        <RefreshCw className="mr-2 animate-spin" size={16} /> Loading…
+                    </div>
+                ) : items.length === 0 ? (
+                    <div className="p-6 text-sm text-gray-500">{emptyHint}</div>
+                ) : (
+                    items.map((preset) => (
+                        <div key={preset.id} className="border-b border-gray-100 px-4 py-3 last:border-b-0">
+                            <div className="flex items-start justify-between gap-3">
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-center gap-2">
+                                        <span className="text-sm font-medium text-gray-900">{preset.title}</span>
+                                        <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                                            preset.visibility === 'shared' ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 text-gray-600'
+                                        }`}>
+                                            {preset.visibility === 'shared' ? <Eye size={10} /> : <EyeOff size={10} />}
+                                            {preset.visibility}
+                                        </span>
+                                        {dataSourceName(preset.data_source_id) && (
+                                            <span className="rounded-full bg-purple-50 px-2 py-0.5 text-[10px] font-medium text-purple-700">
+                                                {dataSourceName(preset.data_source_id)}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="mt-1 line-clamp-2 text-xs text-gray-600">{preset.prompt_text}</p>
+                                    <div className="mt-1 flex items-center gap-2 text-[10px] text-gray-400">
+                                        <span>Updated {format(new Date(preset.updated_at), 'yyyy-MM-dd HH:mm')}</span>
+                                        {preset.tags && preset.tags.length > 0 && (
+                                            <span>· {preset.tags.join(', ')}</span>
+                                        )}
+                                    </div>
+                                </div>
+                                {canEdit && (
+                                    <div className="flex shrink-0 items-center gap-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => onEdit(preset)}
+                                            className="rounded p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+                                            aria-label="Edit preset"
+                                        >
+                                            <Pencil size={14} />
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => onDelete(preset.id)}
+                                            className="rounded p-1.5 text-gray-500 hover:bg-gray-100 hover:text-red-600"
+                                            aria-label="Delete preset"
+                                        >
+                                            <Trash2 size={14} />
+                                        </button>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    ))
+                )}
+            </div>
+        </section>
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `prompt_presets` (one row per saved prompt, FK to owner + optional FK to data source) and the four endpoints required by the ticket: `GET / POST / PUT / DELETE /v1/users/me/prompt-presets[/{id}]`.
- Per-preset visibility: `private` (owner only) or `shared` (read-only to every authenticated user). Edit / delete are always owner-only — enforced in the service, not just the route.
- Frontend: new **Prompts** page at `/prompts` with create / edit / delete and separate "Your presets" / "Shared by your team" sections. Query Workspace prompt input gains a bookmark picker that lazy-loads the user's available presets and fills the input on click.
- Reuses AUTH-006's `users.read_self` / `users.write_self` permissions — no new role grants needed.

## Implementation notes

- Update is partial: any field the caller omits keeps its existing value. Create requires `title` + `prompt_text`.
- Tags are deduplicated case-insensitively but stored with the user's original casing for display.
- `data_source_id` FK is verified with a separate `SELECT id FROM data_sources` before insert/update so a missing reference returns 400 + `unknown_data_source` rather than a 500.
- Shared-listing path is backed by a partial index `WHERE visibility = 'shared'` so the JOIN with the user-owned set stays cheap.

## Verification

- [x] `npm test` — 179 pass, 0 fail (+18 new)
- [x] `npm --prefix frontend run lint` — clean
- [x] `cd frontend && npx tsc -b` — clean
- [ ] Manual: create a preset on `/prompts`, open Query Workspace, click the bookmark picker, confirm the prompt fills in

Closes #27