### PR TITLE
QUERY-004 load saved query with parameter form and run integration

### DIFF
--- a/frontend/src/components/Query/InspectorPanel.tsx
+++ b/frontend/src/components/Query/InspectorPanel.tsx
@@ -1,4 +1,4 @@
-import { Database, Info, Table } from 'lucide-react';
+import { Bookmark, Clock, Database, Info, Table } from 'lucide-react';
 import type { CitationCollection, RunResponse, SavedQuery } from './types';
 import type { components } from '../../lib/api/types';
 
@@ -9,6 +9,14 @@ interface InspectorPanelProps {
     selectedDataSource: DataSource | null;
     queryResult: RunResponse | null;
     isDryRun: boolean;
+}
+
+function formatTimestamp(value: string) {
+    try {
+        return new Date(value).toLocaleString();
+    } catch {
+        return value;
+    }
 }
 
 function MetricRow({ label, value }: { label: string; value: string }) {
@@ -66,6 +74,24 @@ export function InspectorPanel({
                         </span>
                     </div>
                     <div className="space-y-3">
+                        {loadedSavedQuery && (
+                            <div>
+                                <p className="mb-1 text-[10px] font-bold uppercase text-slate-500">Source</p>
+                                <p className="flex items-start gap-1.5 text-[12px] font-semibold text-on-surface">
+                                    <Bookmark size={14} className="mt-0.5 shrink-0 text-oxblood" />
+                                    <span className="break-words">{loadedSavedQuery.name}</span>
+                                </p>
+                                {loadedSavedQuery.description && (
+                                    <p className="mt-1 line-clamp-3 pl-5 text-[11px] text-slate-500">
+                                        {loadedSavedQuery.description}
+                                    </p>
+                                )}
+                                <p className="mt-1.5 flex items-center gap-1 pl-5 text-[10px] text-slate-400">
+                                    <Clock size={10} />
+                                    Updated {formatTimestamp(loadedSavedQuery.updated_at)}
+                                </p>
+                            </div>
+                        )}
                         <div>
                             <p className="mb-1 text-[10px] font-bold uppercase text-slate-500">Data Source</p>
                             <p className="flex items-center gap-1.5 text-[12px] font-semibold text-on-surface">

--- a/frontend/src/components/Query/SavedQueryParamsPanel.tsx
+++ b/frontend/src/components/Query/SavedQueryParamsPanel.tsx
@@ -1,0 +1,144 @@
+import { Variable } from 'lucide-react';
+import type { components } from '../../lib/api/types';
+
+type QueryParameter = components['schemas']['QueryParameter'];
+
+export type ParamValues = Record<string, unknown>;
+
+interface SavedQueryParamsPanelProps {
+    parameters: QueryParameter[];
+    values: ParamValues;
+    errors: Record<string, string> | null;
+    onChange: (values: ParamValues) => void;
+}
+
+function inputTypeForParam(type: QueryParameter['type']) {
+    if (type === 'integer' || type === 'decimal') return 'number';
+    if (type === 'date') return 'date';
+    if (type === 'timestamp') return 'datetime-local';
+    return 'text';
+}
+
+function placeholderForParam(param: QueryParameter) {
+    if (param.default !== null && param.default !== undefined) {
+        return `default: ${String(param.default)}`;
+    }
+    return param.required ? 'required' : 'optional';
+}
+
+function toInputValue(value: unknown) {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'boolean') return value ? 'true' : 'false';
+    return String(value);
+}
+
+export function SavedQueryParamsPanel({
+    parameters,
+    values,
+    errors,
+    onChange,
+}: SavedQueryParamsPanelProps) {
+    if (parameters.length === 0) {
+        return null;
+    }
+
+    const updateValue = (name: string, next: unknown) => {
+        onChange({ ...values, [name]: next });
+    };
+
+    return (
+        <div className="flex-shrink-0 border-b border-outline-variant bg-white px-4 py-3">
+            <div className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                <Variable size={12} className="text-oxblood" />
+                Parameters
+                <span className="font-normal normal-case tracking-normal text-slate-400">
+                    ({parameters.length})
+                </span>
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+                {parameters.map((param) => {
+                    const errorMessage = errors?.[param.name];
+                    const fieldId = `saved-query-param-${param.name}`;
+                    const allowed = Array.isArray(param.allowed_values) ? param.allowed_values : null;
+
+                    return (
+                        <div key={param.name} className="flex flex-col">
+                            <label
+                                htmlFor={fieldId}
+                                className="mb-1 flex items-center justify-between text-[11px] font-medium text-slate-600"
+                            >
+                                <span>
+                                    {param.name}
+                                    {param.required && <span className="ml-0.5 text-oxblood">*</span>}
+                                </span>
+                                <span className="text-[10px] font-normal text-slate-400">{param.type}</span>
+                            </label>
+                            {param.type === 'boolean' ? (
+                                <select
+                                    id={fieldId}
+                                    value={toInputValue(values[param.name])}
+                                    onChange={(event) => {
+                                        const next = event.target.value;
+                                        updateValue(param.name, next === '' ? null : next === 'true');
+                                    }}
+                                    className={[
+                                        'rounded-md border bg-white px-2 py-1.5 text-sm focus:outline-none focus:ring-1',
+                                        errorMessage
+                                            ? 'border-rose-300 focus:border-rose-400 focus:ring-rose-200'
+                                            : 'border-outline-variant focus:border-oxblood focus:ring-oxblood',
+                                    ].join(' ')}
+                                >
+                                    {!param.required && <option value="">—</option>}
+                                    <option value="true">true</option>
+                                    <option value="false">false</option>
+                                </select>
+                            ) : allowed && allowed.length > 0 ? (
+                                <select
+                                    id={fieldId}
+                                    value={toInputValue(values[param.name])}
+                                    onChange={(event) => {
+                                        const next = event.target.value;
+                                        updateValue(param.name, next === '' ? null : next);
+                                    }}
+                                    className={[
+                                        'rounded-md border bg-white px-2 py-1.5 text-sm focus:outline-none focus:ring-1',
+                                        errorMessage
+                                            ? 'border-rose-300 focus:border-rose-400 focus:ring-rose-200'
+                                            : 'border-outline-variant focus:border-oxblood focus:ring-oxblood',
+                                    ].join(' ')}
+                                >
+                                    {!param.required && <option value="">—</option>}
+                                    {allowed.map((value) => (
+                                        <option key={String(value)} value={String(value)}>
+                                            {String(value)}
+                                        </option>
+                                    ))}
+                                </select>
+                            ) : (
+                                <input
+                                    id={fieldId}
+                                    type={inputTypeForParam(param.type)}
+                                    value={toInputValue(values[param.name])}
+                                    placeholder={placeholderForParam(param)}
+                                    onChange={(event) => {
+                                        const raw = event.target.value;
+                                        updateValue(param.name, raw === '' ? null : raw);
+                                    }}
+                                    className={[
+                                        'rounded-md border px-2 py-1.5 text-sm placeholder-slate-400 focus:outline-none focus:ring-1',
+                                        errorMessage
+                                            ? 'border-rose-300 focus:border-rose-400 focus:ring-rose-200'
+                                            : 'border-outline-variant focus:border-oxblood focus:ring-oxblood',
+                                    ].join(' ')}
+                                />
+                            )}
+                            {errorMessage && (
+                                <span className="mt-1 text-[10px] text-rose-600">{errorMessage}</span>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/QueryWorkspace.tsx
+++ b/frontend/src/pages/QueryWorkspace.tsx
@@ -9,6 +9,7 @@ import { InspectorPanel } from '../components/Query/InspectorPanel';
 import { PromptSection } from '../components/Query/PromptSection';
 import { ResultSection } from '../components/Query/ResultSection';
 import { SaveQueryDialog, type SaveQueryDialogValues } from '../components/Query/SaveQueryDialog';
+import { SavedQueryParamsPanel, type ParamValues } from '../components/Query/SavedQueryParamsPanel';
 import { SqlSection } from '../components/Query/SqlSection';
 import type {
     LlmProvider,
@@ -81,6 +82,8 @@ export const QueryWorkspace = () => {
     const [timeout, setTimeout] = useState(60);
     const [isDryRun, setIsDryRun] = useState(false);
     const [loadedSavedQuery, setLoadedSavedQuery] = useState<SavedQuery | null>(null);
+    const [paramValues, setParamValues] = useState<ParamValues>({});
+    const [paramErrors, setParamErrors] = useState<Record<string, string> | null>(null);
     const [saveDialogOpen, setSaveDialogOpen] = useState(false);
     const [isSubmittingSave, setIsSubmittingSave] = useState(false);
 
@@ -197,7 +200,72 @@ export const QueryWorkspace = () => {
         }
     };
 
+    const useSavedQueryRunPath = Boolean(
+        loadedSavedQuery
+        && loadedSavedQuery.parameter_schema?.length
+        && generatedSql.trim() === originalSql.trim()
+    );
+
+    const runSavedQueryWithParams = async () => {
+        if (!loadedSavedQuery) return;
+        setIsRunning(true);
+        setParamErrors(null);
+        try {
+            const { data, error, response } = await client.POST('/v1/saved-queries/{savedQueryId}/run', {
+                params: { path: { savedQueryId: loadedSavedQuery.id } },
+                body: {
+                    params: paramValues,
+                    max_rows: maxRows,
+                    timeout_ms: Math.max(1000, Math.round(timeout * 1000)),
+                },
+            });
+
+            if (data) {
+                setGeneratedSql(data.sql);
+                setQueryResult({
+                    sql: data.sql,
+                    columns: data.columns,
+                    rows: data.rows,
+                    row_count: data.row_count,
+                    duration_ms: data.duration_ms,
+                    attempt_id: loadedSavedQuery.id,
+                    preview: false,
+                } as RunResponse);
+                toast.success('Query executed successfully');
+                return;
+            }
+
+            if (error) {
+                const payload = error as { errors?: Array<{ param?: string | null; message: string }>; message?: string };
+                if (response.status === 400 && Array.isArray(payload.errors)) {
+                    const nextErrors: Record<string, string> = {};
+                    for (const item of payload.errors) {
+                        if (item.param) {
+                            nextErrors[item.param] = item.message;
+                        }
+                    }
+                    if (Object.keys(nextErrors).length > 0) {
+                        setParamErrors(nextErrors);
+                        toast.error('Invalid parameters');
+                        return;
+                    }
+                }
+                toast.error(payload.message || 'Run failed');
+            }
+        } catch (caught) {
+            console.error(caught);
+            toast.error('Run failed');
+        } finally {
+            setIsRunning(false);
+        }
+    };
+
     const handleRun = async () => {
+        if (useSavedQueryRunPath) {
+            await runSavedQueryWithParams();
+            return;
+        }
+
         const sqlOverride = generatedSql.trim();
         if (!sqlOverride) {
             return;
@@ -269,6 +337,13 @@ export const QueryWorkspace = () => {
         setOriginalSql(savedQuery.sql);
         setQueryResult(null);
         setLoadedSavedQuery(savedQuery);
+
+        const seededParams: ParamValues = {};
+        for (const param of savedQuery.parameter_schema ?? []) {
+            seededParams[param.name] = param.default ?? null;
+        }
+        setParamValues(seededParams);
+        setParamErrors(null);
 
         if (typeof defaultRunParams.max_rows === 'number') {
             setMaxRows(defaultRunParams.max_rows);
@@ -508,6 +583,18 @@ export const QueryWorkspace = () => {
                     onPromptHistorySelect={handlePromptHistorySelect}
                     onAsk={handleAsk}
                 />
+
+                {loadedSavedQuery && loadedSavedQuery.parameter_schema?.length > 0 && (
+                    <SavedQueryParamsPanel
+                        parameters={loadedSavedQuery.parameter_schema}
+                        values={paramValues}
+                        errors={paramErrors}
+                        onChange={(next) => {
+                            setParamValues(next);
+                            setParamErrors(null);
+                        }}
+                    />
+                )}
 
                 <SqlSection
                     generatedSql={generatedSql}


### PR DESCRIPTION
Closes #39.

## Summary
- Adds `SavedQueryParamsPanel` rendered between the prompt bar and SQL editor whenever a loaded saved query declares a non-empty `parameter_schema`. Inputs are typed (text / number / date / datetime / boolean / allowed-value select), seeded from each parameter's `default`, and surface per-parameter validation errors returned by the backend.
- Routes the workspace's Run button through `POST /v1/saved-queries/{id}/run` whenever a saved query with parameters is loaded **and** the user has not edited the SQL — so placeholder substitution and parameter validation happen server-side. Editing the SQL falls back to the existing session-based execution path, leaving citations / feedback / dry-run flows unchanged.
- Inspector now shows the loaded query's source (name, description, last-updated timestamp) above the data source row, satisfying the "loaded query source and last modified info" acceptance criterion.

## Test plan
- [x] `npx tsc -b` (frontend, no errors)
- [x] `npm run lint` (frontend, clean)
- [x] `npm run build` (frontend, builds)
- [x] `npm test` (backend, 179/179 passing)
- [ ] Manual browser test deferred — please verify: open a saved query that has parameters from `/queries`, confirm the parameter panel appears with defaults, change a value, click Run, confirm results render. Then edit the SQL and confirm Run falls back to the session path. Also verify the Inspector shows the saved query's name, description, and "Updated …" timestamp.