### PR TITLE
QUERY-006 sharing and access control for saved queries

### DIFF
--- a/app/src/lib/routePolicy.js
+++ b/app/src/lib/routePolicy.js
@@ -81,11 +81,14 @@ const POLICIES = [
   { method: "POST", pattern: /^\/v1\/query\/sessions\/[^/]+\/export\/deliver$/, permission: "query.run" },
   { method: "GET", pattern: /^\/v1\/exports\/[^/]+\/status$/, permission: "query.run" },
 
-  // Saved queries — list/get/validate are reads, write/delete are writes, run is query.run
+  // Saved queries — list/get/validate are reads, write/delete are writes, run is query.run,
+  // share is QUERY-006's owner-only re-distribution permission.
   { method: "GET", pattern: /^\/v1\/saved-queries$/, permission: "saved_queries.read" },
   { method: "POST", pattern: /^\/v1\/saved-queries$/, permission: "saved_queries.write" },
   { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/validate-params$/, permission: "saved_queries.read" },
   { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/run$/, permission: "query.run" },
+  { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/share$/, permission: "saved_queries.share" },
+  { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+\/access$/, permission: "saved_queries.read" },
   { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.read" },
   { method: "PUT", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.write" },
   { method: "DELETE", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.write" },

--- a/app/src/routes/savedQueries.js
+++ b/app/src/routes/savedQueries.js
@@ -2,7 +2,16 @@ const appDb = require("../lib/appDb");
 const { json, readJsonBody } = require("../lib/http");
 const { isUuid } = require("../lib/validation");
 const savedQueryService = require("../services/savedQueryService");
+const auditService = require("../services/auditService");
 const { enforceDataSourceAccess, listAccessibleDataSourceIds } = require("../lib/authGate");
+
+function callerId(req) {
+  return (req.user && req.user.id) || null;
+}
+
+function requestClientIp(req) {
+  return (req.socket && req.socket.remoteAddress) || null;
+}
 
 function writeResult(res, result) {
   return json(res, result.statusCode, result.body);
@@ -31,14 +40,15 @@ async function handleCreateSavedQuery(req, res) {
     }
   }
   const result = await savedQueryService.createSavedQuery({
-    ownerId: req.user && req.user.id ? req.user.id : null,
+    ownerId: callerId(req),
     name: body.name,
     description: body.description,
     dataSourceId: body.data_source_id,
     sql: body.sql,
     defaultRunParams: body.default_run_params,
     parameterSchema: body.parameter_schema,
-    tags: body.tags
+    tags: body.tags,
+    visibility: body.visibility
   });
   return writeResult(res, result);
 }
@@ -51,7 +61,8 @@ async function handleListSavedQueries(req, res, requestUrl) {
   const accessible = await listAccessibleDataSourceIds(req);
   const result = await savedQueryService.listSavedQueries(
     dataSourceId,
-    requestUrl.searchParams.get("tag")
+    requestUrl.searchParams.get("tag"),
+    { callerUserId: callerId(req) }
   );
   if (accessible !== null && Array.isArray(result.body && result.body.items)) {
     const accessibleSet = new Set(accessible);
@@ -68,7 +79,7 @@ async function handleGetSavedQuery(req, res, savedQueryId) {
   if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
     return undefined;
   }
-  const result = await savedQueryService.getSavedQuery(savedQueryId);
+  const result = await savedQueryService.getSavedQuery(savedQueryId, { callerUserId: callerId(req) });
   return writeResult(res, result);
 }
 
@@ -91,7 +102,9 @@ async function handleUpdateSavedQuery(req, res, savedQueryId) {
     sql: body.sql,
     defaultRunParams: body.default_run_params,
     parameterSchema: body.parameter_schema,
-    tags: body.tags
+    tags: body.tags,
+    visibility: body.visibility,
+    callerUserId: callerId(req)
   });
   return writeResult(res, result);
 }
@@ -101,7 +114,7 @@ async function handleDeleteSavedQuery(req, res, savedQueryId) {
   if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
     return undefined;
   }
-  const result = await savedQueryService.deleteSavedQuery(savedQueryId);
+  const result = await savedQueryService.deleteSavedQuery(savedQueryId, { callerUserId: callerId(req) });
   return writeResult(res, result);
 }
 
@@ -111,7 +124,9 @@ async function handleValidateParams(req, res, savedQueryId) {
     return undefined;
   }
   const body = await readJsonBody(req);
-  const result = await savedQueryService.validateSavedQueryParams(savedQueryId, body.params);
+  const result = await savedQueryService.validateSavedQueryParams(savedQueryId, body.params, {
+    callerUserId: callerId(req)
+  });
   return writeResult(res, result);
 }
 
@@ -124,7 +139,88 @@ async function handleRunSavedQuery(req, res, savedQueryId) {
   const result = await savedQueryService.executeSavedQuery(savedQueryId, {
     params: body.params,
     maxRows: body.max_rows,
-    timeoutMs: body.timeout_ms
+    timeoutMs: body.timeout_ms,
+    callerUserId: callerId(req)
+  });
+  return writeResult(res, result);
+}
+
+async function handleShareSavedQuery(req, res, savedQueryId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
+    return undefined;
+  }
+  const body = await readJsonBody(req);
+  const result = await savedQueryService.shareSavedQuery(savedQueryId, {
+    callerUserId: callerId(req),
+    visibility: body.visibility,
+    shares: body.shares
+  });
+
+  if (result.ok) {
+    const actor = callerId(req);
+    const summary = result.body;
+    const ip = requestClientIp(req);
+    const userAgent = req.headers["user-agent"] || null;
+    if (summary.previous_visibility !== summary.visibility) {
+      auditService.writeEvent({
+        actorUserId: actor,
+        action: "saved_query.visibility.changed",
+        details: {
+          saved_query_id: savedQueryId,
+          previous: summary.previous_visibility,
+          next: summary.visibility
+        },
+        ipAddress: ip,
+        userAgent
+      }).catch(() => {});
+    }
+    for (const entry of summary.diff.added) {
+      auditService.writeEvent({
+        actorUserId: actor,
+        targetUserId: entry.user_id,
+        action: "saved_query.share.granted",
+        details: { saved_query_id: savedQueryId, permission: entry.permission },
+        ipAddress: ip,
+        userAgent
+      }).catch(() => {});
+    }
+    for (const entry of summary.diff.updated) {
+      auditService.writeEvent({
+        actorUserId: actor,
+        targetUserId: entry.user_id,
+        action: "saved_query.share.updated",
+        details: {
+          saved_query_id: savedQueryId,
+          previous_permission: entry.previous_permission,
+          permission: entry.permission
+        },
+        ipAddress: ip,
+        userAgent
+      }).catch(() => {});
+    }
+    for (const entry of summary.diff.removed) {
+      auditService.writeEvent({
+        actorUserId: actor,
+        targetUserId: entry.user_id,
+        action: "saved_query.share.revoked",
+        details: { saved_query_id: savedQueryId, permission: entry.permission },
+        ipAddress: ip,
+        userAgent
+      }).catch(() => {});
+    }
+  }
+
+  return writeResult(res, result);
+}
+
+async function handleGetSavedQueryAccess(req, res, savedQueryId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
+    return undefined;
+  }
+  const result = await savedQueryService.getSavedQueryAccess(savedQueryId, {
+    callerUserId: callerId(req)
   });
   return writeResult(res, result);
 }
@@ -136,5 +232,7 @@ module.exports = {
   handleUpdateSavedQuery,
   handleDeleteSavedQuery,
   handleValidateParams,
-  handleRunSavedQuery
+  handleRunSavedQuery,
+  handleShareSavedQuery,
+  handleGetSavedQueryAccess
 };

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -51,7 +51,9 @@ const {
   handleUpdateSavedQuery,
   handleDeleteSavedQuery,
   handleValidateParams,
-  handleRunSavedQuery
+  handleRunSavedQuery,
+  handleShareSavedQuery,
+  handleGetSavedQueryAccess
 } = require("./routes/savedQueries");
 const {
   handleExportSession,
@@ -438,6 +440,16 @@ async function routeRequest(req, res) {
   const savedQueryRunMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/run$/);
   if (req.method === "POST" && savedQueryRunMatch) {
     return handleRunSavedQuery(req, res, savedQueryRunMatch[1]);
+  }
+
+  const savedQueryShareMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/share$/);
+  if (req.method === "POST" && savedQueryShareMatch) {
+    return handleShareSavedQuery(req, res, savedQueryShareMatch[1]);
+  }
+
+  const savedQueryAccessMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/access$/);
+  if (req.method === "GET" && savedQueryAccessMatch) {
+    return handleGetSavedQueryAccess(req, res, savedQueryAccessMatch[1]);
   }
 
   const savedQueryMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)$/);

--- a/app/src/services/savedQueryService.js
+++ b/app/src/services/savedQueryService.js
@@ -42,9 +42,13 @@ const SAVED_QUERY_COLUMNS = `
   default_run_params,
   parameter_schema,
   tags,
+  visibility,
   created_at,
   updated_at
 `;
+
+const ALLOWED_VISIBILITY = new Set(["private", "shared"]);
+const ALLOWED_SHARE_PERMISSIONS = new Set(["view", "run"]);
 
 function normalizeTags(value) {
   if (value === undefined || value === null) {
@@ -110,6 +114,7 @@ async function loadSavedQueryForExecution(savedQueryId) {
         sq.default_run_params,
         sq.parameter_schema,
         sq.tags,
+        sq.visibility,
         sq.created_at,
         sq.updated_at,
         ds.connection_ref,
@@ -181,7 +186,7 @@ function resolveRunOptions(defaultRunParams, requested) {
   };
 }
 
-async function getSavedQuery(savedQueryId) {
+async function getSavedQuery(savedQueryId, { callerUserId } = {}) {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -189,10 +194,16 @@ async function getSavedQuery(savedQueryId) {
   if (!savedQuery) {
     return failure(404, { error: "not_found", message: "Saved query not found" });
   }
+  if (callerUserId) {
+    const access = await resolveCallerAccess(savedQuery, callerUserId);
+    if (!access) {
+      return failure(403, { error: "forbidden", message: "You do not have access to this saved query" });
+    }
+  }
   return success(savedQuery);
 }
 
-async function listSavedQueries(dataSourceId, tag) {
+async function listSavedQueries(dataSourceId, tag, { callerUserId } = {}) {
   const filter = typeof dataSourceId === "string" ? dataSourceId.trim() : "";
   if (filter && !isUuid(filter)) {
     return failure(400, { error: "bad_request", message: "data_source_id must be a valid UUID" });
@@ -204,6 +215,34 @@ async function listSavedQueries(dataSourceId, tag) {
       error: "bad_request",
       message: `tag exceeds ${SAVED_QUERY_TAG_MAX_LENGTH} characters`
     });
+  }
+
+  // When a caller is supplied, restrict to:
+  //   - queries the caller owns
+  //   - queries with visibility = 'shared'
+  //   - queries with an explicit share row for the caller
+  // The data-source-access filter still runs in the route layer so an admin
+  // doesn't suddenly leak queries from sources they were never granted.
+  if (callerUserId) {
+    const result = await appDb.query(
+      `
+        SELECT ${SAVED_QUERY_COLUMNS}
+        FROM saved_queries sq
+        WHERE ($1::uuid IS NULL OR sq.data_source_id = $1::uuid)
+          AND ($2::text IS NULL OR $2::text = ANY(sq.tags))
+          AND (
+            sq.owner_id = $3
+            OR sq.visibility = 'shared'
+            OR EXISTS (
+              SELECT 1 FROM saved_query_shares s
+              WHERE s.saved_query_id = sq.id AND s.user_id = $3
+            )
+          )
+        ORDER BY sq.updated_at DESC, sq.created_at DESC
+      `,
+      [filter || null, tagFilter || null, callerUserId]
+    );
+    return success({ items: result.rows });
   }
 
   const result = await appDb.query(
@@ -220,6 +259,14 @@ async function listSavedQueries(dataSourceId, tag) {
   return success({ items: result.rows });
 }
 
+function normalizeVisibility(value, fallback = "private") {
+  if (value === undefined) return { ok: true, value: fallback };
+  if (typeof value !== "string" || !ALLOWED_VISIBILITY.has(value)) {
+    return { ok: false, message: `visibility must be one of: ${[...ALLOWED_VISIBILITY].join(", ")}` };
+  }
+  return { ok: true, value };
+}
+
 async function createSavedQuery({
   ownerId,
   name,
@@ -228,7 +275,8 @@ async function createSavedQuery({
   sql,
   defaultRunParams,
   parameterSchema,
-  tags
+  tags,
+  visibility
 }) {
   const trimmedOwnerId = String(ownerId || "anonymous").trim() || "anonymous";
   const trimmedDataSourceId = String(dataSourceId || "").trim();
@@ -238,6 +286,7 @@ async function createSavedQuery({
   const defaultRunParamsValidation = validateSavedQueryDefaultRunParams(defaultRunParams);
   const parameterSchemaValidation = resolveParameterSchema(trimmedSql, parameterSchema, []);
   const tagsValidation = normalizeTags(tags);
+  const visibilityValidation = normalizeVisibility(visibility);
 
   if (!trimmedName || !trimmedDataSourceId || !trimmedSql) {
     return failure(400, { error: "bad_request", message: "name, data_source_id and sql are required" });
@@ -266,6 +315,9 @@ async function createSavedQuery({
   if (!tagsValidation.ok) {
     return failure(400, { error: "bad_request", message: tagsValidation.message });
   }
+  if (!visibilityValidation.ok) {
+    return failure(400, { error: "bad_request", message: visibilityValidation.message });
+  }
 
   if (!(await ensureDataSourceExists(trimmedDataSourceId))) {
     return failure(404, { error: "not_found", message: "Data source not found" });
@@ -282,8 +334,9 @@ async function createSavedQuery({
           sql,
           default_run_params,
           parameter_schema,
-          tags
-        ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::text[])
+          tags,
+          visibility
+        ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::text[], $9)
         RETURNING ${SAVED_QUERY_COLUMNS}
       `,
       [
@@ -294,7 +347,8 @@ async function createSavedQuery({
         trimmedSql,
         JSON.stringify(defaultRunParamsValidation.value),
         JSON.stringify(parameterSchemaValidation.value),
-        tagsValidation.value
+        tagsValidation.value,
+        visibilityValidation.value
       ]
     );
 
@@ -317,7 +371,9 @@ async function updateSavedQuery(savedQueryId, {
   sql,
   defaultRunParams,
   parameterSchema,
-  tags
+  tags,
+  visibility,
+  callerUserId
 }) {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
@@ -326,6 +382,9 @@ async function updateSavedQuery(savedQueryId, {
   const existing = await loadSavedQuery(savedQueryId);
   if (!existing) {
     return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (callerUserId && existing.owner_id !== callerUserId) {
+    return failure(403, { error: "forbidden", message: "Only the owner can update this saved query" });
   }
 
   const trimmedDataSourceId = String(dataSourceId || "").trim();
@@ -337,6 +396,7 @@ async function updateSavedQuery(savedQueryId, {
   const tagsValidation = tags === undefined
     ? { ok: true, value: existing.tags || [] }
     : normalizeTags(tags);
+  const visibilityValidation = normalizeVisibility(visibility, existing.visibility || "private");
 
   if (!trimmedName || !trimmedDataSourceId || !trimmedSql) {
     return failure(400, { error: "bad_request", message: "name, data_source_id and sql are required" });
@@ -365,6 +425,9 @@ async function updateSavedQuery(savedQueryId, {
   if (!tagsValidation.ok) {
     return failure(400, { error: "bad_request", message: tagsValidation.message });
   }
+  if (!visibilityValidation.ok) {
+    return failure(400, { error: "bad_request", message: visibilityValidation.message });
+  }
 
   if (!(await ensureDataSourceExists(trimmedDataSourceId))) {
     return failure(404, { error: "not_found", message: "Data source not found" });
@@ -382,6 +445,7 @@ async function updateSavedQuery(savedQueryId, {
           default_run_params = $6::jsonb,
           parameter_schema = $7::jsonb,
           tags = $8::text[],
+          visibility = $9,
           updated_at = NOW()
         WHERE id = $1
         RETURNING ${SAVED_QUERY_COLUMNS}
@@ -394,7 +458,8 @@ async function updateSavedQuery(savedQueryId, {
         trimmedSql,
         JSON.stringify(defaultRunParamsValidation.value),
         JSON.stringify(parameterSchemaValidation.value),
-        tagsValidation.value
+        tagsValidation.value,
+        visibilityValidation.value
       ]
     );
 
@@ -410,9 +475,19 @@ async function updateSavedQuery(savedQueryId, {
   }
 }
 
-async function deleteSavedQuery(savedQueryId) {
+async function deleteSavedQuery(savedQueryId, { callerUserId } = {}) {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+
+  if (callerUserId) {
+    const existing = await loadSavedQuery(savedQueryId);
+    if (!existing) {
+      return failure(404, { error: "not_found", message: "Saved query not found" });
+    }
+    if (existing.owner_id !== callerUserId) {
+      return failure(403, { error: "forbidden", message: "Only the owner can delete this saved query" });
+    }
   }
 
   const deleteResult = await appDb.query(
@@ -427,7 +502,29 @@ async function deleteSavedQuery(savedQueryId) {
   return success({ ok: true, id: deleteResult.rows[0].id });
 }
 
-async function validateSavedQueryParams(savedQueryId, providedParams) {
+async function loadShareRecord(savedQueryId, userId) {
+  if (!isUuid(savedQueryId) || !userId) return null;
+  const result = await appDb.query(
+    `SELECT permission FROM saved_query_shares WHERE saved_query_id = $1 AND user_id = $2`,
+    [savedQueryId, userId]
+  );
+  return result.rows[0] || null;
+}
+
+// Effective access for the caller. Owner is always full. Visibility 'shared'
+// gives view; explicit share row gives view-or-run. Returns one of:
+// 'owner' | 'run' | 'view' | null
+async function resolveCallerAccess(savedQuery, callerUserId) {
+  if (!savedQuery) return null;
+  if (!callerUserId) return null;
+  if (savedQuery.owner_id === callerUserId) return "owner";
+  const share = await loadShareRecord(savedQuery.id, callerUserId);
+  if (share) return share.permission;
+  if (savedQuery.visibility === "shared") return "view";
+  return null;
+}
+
+async function validateSavedQueryParams(savedQueryId, providedParams, { callerUserId } = {}) {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -435,6 +532,12 @@ async function validateSavedQueryParams(savedQueryId, providedParams) {
   const savedQuery = await loadSavedQuery(savedQueryId);
   if (!savedQuery) {
     return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (callerUserId) {
+    const access = await resolveCallerAccess(savedQuery, callerUserId);
+    if (!access) {
+      return failure(403, { error: "forbidden", message: "You do not have access to this saved query" });
+    }
   }
 
   const validation = validateParameterValues(savedQuery.parameter_schema, providedParams);
@@ -445,7 +548,7 @@ async function validateSavedQueryParams(savedQueryId, providedParams) {
   return success({ ok: true, resolved_values: validation.resolvedValues });
 }
 
-async function executeSavedQuery(savedQueryId, { params, maxRows, timeoutMs } = {}) {
+async function executeSavedQuery(savedQueryId, { params, maxRows, timeoutMs, callerUserId } = {}) {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -453,6 +556,17 @@ async function executeSavedQuery(savedQueryId, { params, maxRows, timeoutMs } = 
   const savedQuery = await loadSavedQueryForExecution(savedQueryId);
   if (!savedQuery) {
     return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (callerUserId) {
+    const access = await resolveCallerAccess(savedQuery, callerUserId);
+    if (!access || access === "view") {
+      return failure(403, {
+        error: "forbidden",
+        message: access === "view"
+          ? "You can view this saved query but not run it"
+          : "You do not have access to this saved query"
+      });
+    }
   }
   if (!isSupportedDbType(savedQuery.db_type)) {
     return failure(400, {
@@ -525,6 +639,165 @@ async function executeSavedQuery(savedQueryId, { params, maxRows, timeoutMs } = 
   }
 }
 
+async function listSharesForQuery(savedQueryId) {
+  const result = await appDb.query(
+    `
+      SELECT saved_query_id, user_id, permission, granted_by_user_id, created_at
+      FROM saved_query_shares
+      WHERE saved_query_id = $1
+      ORDER BY created_at ASC
+    `,
+    [savedQueryId]
+  );
+  return result.rows;
+}
+
+function normalizeShareGrants(grants) {
+  if (grants === undefined) return { ok: true, value: undefined };
+  if (!Array.isArray(grants)) {
+    return { ok: false, message: "shares must be an array" };
+  }
+  const seen = new Set();
+  const normalized = [];
+  for (const entry of grants) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return { ok: false, message: "each share entry must be an object" };
+    }
+    const userId = typeof entry.user_id === "string" ? entry.user_id.trim() : "";
+    if (!isUuid(userId)) {
+      return { ok: false, message: "each share entry must include a user_id UUID" };
+    }
+    if (seen.has(userId)) {
+      return { ok: false, message: `duplicate share entry for user ${userId}` };
+    }
+    seen.add(userId);
+    const permission = typeof entry.permission === "string" ? entry.permission : "";
+    if (!ALLOWED_SHARE_PERMISSIONS.has(permission)) {
+      return {
+        ok: false,
+        message: `permission must be one of: ${[...ALLOWED_SHARE_PERMISSIONS].join(", ")}`
+      };
+    }
+    normalized.push({ user_id: userId, permission });
+  }
+  return { ok: true, value: normalized };
+}
+
+// Replace-semantics: the body's `shares` array fully replaces whatever
+// rows exist for this query. Pass `shares: []` to revoke everyone.
+// Visibility is optional and only changed when present in the body.
+// Returns the new access summary plus a diff so callers can audit each change.
+async function shareSavedQuery(savedQueryId, { callerUserId, visibility, shares } = {}) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+  if (!callerUserId) {
+    return failure(401, { error: "unauthenticated" });
+  }
+
+  const existing = await loadSavedQuery(savedQueryId);
+  if (!existing) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (existing.owner_id !== callerUserId) {
+    return failure(403, { error: "forbidden", message: "Only the owner can share this saved query" });
+  }
+
+  const visibilityValidation = visibility === undefined
+    ? { ok: true, value: existing.visibility || "private" }
+    : normalizeVisibility(visibility, existing.visibility || "private");
+  if (!visibilityValidation.ok) {
+    return failure(400, { error: "bad_request", message: visibilityValidation.message });
+  }
+
+  const sharesValidation = normalizeShareGrants(shares);
+  if (!sharesValidation.ok) {
+    return failure(400, { error: "bad_request", message: sharesValidation.message });
+  }
+
+  const previousVisibility = existing.visibility || "private";
+  const previousShares = await listSharesForQuery(savedQueryId);
+  const previousByUser = new Map(previousShares.map((row) => [row.user_id, row.permission]));
+
+  if (visibility !== undefined && visibilityValidation.value !== previousVisibility) {
+    await appDb.query(
+      `UPDATE saved_queries SET visibility = $2, updated_at = NOW() WHERE id = $1`,
+      [savedQueryId, visibilityValidation.value]
+    );
+  }
+
+  const added = [];
+  const updated = [];
+  const removed = [];
+
+  if (sharesValidation.value !== undefined) {
+    const nextByUser = new Map(sharesValidation.value.map((row) => [row.user_id, row.permission]));
+
+    for (const [userId, permission] of nextByUser) {
+      const prev = previousByUser.get(userId);
+      if (!prev) {
+        added.push({ user_id: userId, permission });
+      } else if (prev !== permission) {
+        updated.push({ user_id: userId, permission, previous_permission: prev });
+      }
+    }
+    for (const [userId, permission] of previousByUser) {
+      if (!nextByUser.has(userId)) {
+        removed.push({ user_id: userId, permission });
+      }
+    }
+
+    if (removed.length > 0) {
+      await appDb.query(
+        `DELETE FROM saved_query_shares WHERE saved_query_id = $1 AND user_id = ANY($2::uuid[])`,
+        [savedQueryId, removed.map((entry) => entry.user_id)]
+      );
+    }
+    for (const row of [...added, ...updated]) {
+      await appDb.query(
+        `
+          INSERT INTO saved_query_shares (saved_query_id, user_id, permission, granted_by_user_id)
+          VALUES ($1, $2, $3, $4)
+          ON CONFLICT (saved_query_id, user_id)
+            DO UPDATE SET permission = EXCLUDED.permission, granted_by_user_id = EXCLUDED.granted_by_user_id
+        `,
+        [savedQueryId, row.user_id, row.permission, callerUserId]
+      );
+    }
+  }
+
+  const finalShares = await listSharesForQuery(savedQueryId);
+  return success({
+    visibility: visibilityValidation.value,
+    previous_visibility: previousVisibility,
+    shares: finalShares,
+    diff: { added, updated, removed }
+  });
+}
+
+async function getSavedQueryAccess(savedQueryId, { callerUserId } = {}) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (callerUserId) {
+    const access = await resolveCallerAccess(savedQuery, callerUserId);
+    if (!access) {
+      return failure(403, { error: "forbidden", message: "You do not have access to this saved query" });
+    }
+  }
+  const shares = await listSharesForQuery(savedQueryId);
+  return success({
+    saved_query_id: savedQueryId,
+    owner_id: savedQuery.owner_id,
+    visibility: savedQuery.visibility || "private",
+    shares
+  });
+}
+
 module.exports = {
   getSavedQuery,
   listSavedQueries,
@@ -532,5 +805,8 @@ module.exports = {
   updateSavedQuery,
   deleteSavedQuery,
   validateSavedQueryParams,
-  executeSavedQuery
+  executeSavedQuery,
+  shareSavedQuery,
+  getSavedQueryAccess,
+  resolveCallerAccess
 };

--- a/app/test/helpers/authTestStub.js
+++ b/app/test/helpers/authTestStub.js
@@ -37,6 +37,7 @@ const ROLE_PERMISSIONS = {
     "query.run",
     "saved_queries.read",
     "saved_queries.write",
+    "saved_queries.share",
     "observability.read",
     "observability.write",
     ...SELF_PERMS
@@ -49,6 +50,7 @@ const ROLE_PERMISSIONS = {
     "query.run",
     "saved_queries.read",
     "saved_queries.write",
+    "saved_queries.share",
     "observability.read",
     ...SELF_PERMS
   ],

--- a/app/test/savedQueriesApi.test.js
+++ b/app/test/savedQueriesApi.test.js
@@ -16,6 +16,7 @@ const MISSING_SOURCE_ID = "00000000-0000-4000-8000-000000009999";
 let server;
 let baseUrl;
 let savedQueries;
+let savedQueryShares;
 let savedQueryCounter;
 let originalQuery;
 let originalCreateDatabaseAdapter;
@@ -23,6 +24,10 @@ let originalIsSupportedDbType;
 let adapterCalls;
 let authStub;
 const testUsers = {};
+
+function shareKey(savedQueryId, userId) {
+  return `${savedQueryId}::${userId}`;
+}
 
 function normalizeSql(sql) {
   return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
@@ -97,6 +102,7 @@ before(async () => {
   originalCreateDatabaseAdapter = dbAdapterFactory.createDatabaseAdapter;
   originalIsSupportedDbType = dbAdapterFactory.isSupportedDbType;
   savedQueries = new Map();
+  savedQueryShares = new Map();
   savedQueryCounter = 0;
   adapterCalls = [];
   authStub = createAuthTestStub();
@@ -144,7 +150,7 @@ before(async () => {
     }
 
     if (normalized.startsWith("insert into saved_queries")) {
-      const [ownerId, name, description, dataSourceId, querySql, defaultRunParamsJson, parameterSchemaJson, tags] = params;
+      const [ownerId, name, description, dataSourceId, querySql, defaultRunParamsJson, parameterSchemaJson, tags, visibility] = params;
       const duplicate = [...savedQueries.values()].find((entry) => (
         entry.owner_id === ownerId
         && entry.data_source_id === dataSourceId
@@ -165,6 +171,7 @@ before(async () => {
         default_run_params: JSON.parse(defaultRunParamsJson),
         parameter_schema: JSON.parse(parameterSchemaJson),
         tags: Array.isArray(tags) ? tags : [],
+        visibility: visibility || "private",
         created_at: now,
         updated_at: now
       };
@@ -172,7 +179,24 @@ before(async () => {
       return { rowCount: 1, rows: [row] };
     }
 
-    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, created_at, updated_at from saved_queries where ($1::uuid is null or data_source_id = $1::uuid)")) {
+    // Caller-aware list (the new QUERY-006 variant) — restricts to
+    // owner + visibility='shared' + explicit grant.
+    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, created_at, updated_at from saved_queries sq where ($1::uuid is null or sq.data_source_id = $1::uuid)")) {
+      const [dataSourceId, tagFilter, callerUserId] = params;
+      const rows = sortSavedQueries(
+        [...savedQueries.values()].filter((entry) => {
+          if (dataSourceId && entry.data_source_id !== dataSourceId) return false;
+          if (tagFilter && !(entry.tags || []).includes(tagFilter)) return false;
+          if (entry.owner_id === callerUserId) return true;
+          if (entry.visibility === "shared") return true;
+          if (savedQueryShares.has(shareKey(entry.id, callerUserId))) return true;
+          return false;
+        })
+      );
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, created_at, updated_at from saved_queries where ($1::uuid is null or data_source_id = $1::uuid)")) {
       const [dataSourceId, tagFilter] = params;
       const rows = sortSavedQueries(
         [...savedQueries.values()].filter((entry) => {
@@ -188,13 +212,13 @@ before(async () => {
       return { rowCount: rows.length, rows };
     }
 
-    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, created_at, updated_at from saved_queries where id = $1")) {
+    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, created_at, updated_at from saved_queries where id = $1")) {
       const [id] = params;
       const row = savedQueries.get(id);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
 
-    if (normalized.startsWith("select sq.id, sq.owner_id, sq.name, sq.description, sq.data_source_id, sq.sql, sq.default_run_params, sq.parameter_schema, sq.tags, sq.created_at, sq.updated_at, ds.connection_ref, ds.db_type from saved_queries sq join data_sources ds on ds.id = sq.data_source_id where sq.id = $1")) {
+    if (normalized.startsWith("select sq.id, sq.owner_id, sq.name, sq.description, sq.data_source_id, sq.sql, sq.default_run_params, sq.parameter_schema, sq.tags, sq.visibility, sq.created_at, sq.updated_at, ds.connection_ref, ds.db_type from saved_queries sq join data_sources ds on ds.id = sq.data_source_id where sq.id = $1")) {
       const [id] = params;
       const row = savedQueries.get(id);
       if (!row) {
@@ -215,7 +239,18 @@ before(async () => {
     }
 
     if (normalized.startsWith("update saved_queries set")) {
-      const [id, name, description, dataSourceId, querySql, defaultRunParamsJson, parameterSchemaJson, tags] = params;
+      // Two callers: the full update flow (9 params) and the visibility-only
+      // toggle from shareSavedQuery (2 params: id + visibility).
+      if (params.length === 2) {
+        const [id, visibility] = params;
+        const existing = savedQueries.get(id);
+        if (!existing) return { rowCount: 0, rows: [] };
+        const updated = { ...existing, visibility, updated_at: new Date().toISOString() };
+        savedQueries.set(id, updated);
+        return { rowCount: 1, rows: [updated] };
+      }
+
+      const [id, name, description, dataSourceId, querySql, defaultRunParamsJson, parameterSchemaJson, tags, visibility] = params;
       const existing = savedQueries.get(id);
       if (!existing) {
         return { rowCount: 0, rows: [] };
@@ -240,6 +275,7 @@ before(async () => {
         default_run_params: JSON.parse(defaultRunParamsJson),
         parameter_schema: JSON.parse(parameterSchemaJson),
         tags: Array.isArray(tags) ? tags : (existing.tags || []),
+        visibility: visibility || existing.visibility || "private",
         updated_at: new Date().toISOString()
       };
       savedQueries.set(id, updated);
@@ -254,7 +290,50 @@ before(async () => {
       }
 
       savedQueries.delete(id);
+      // Cascade clean-up of shares (matches the FK ON DELETE CASCADE).
+      for (const key of [...savedQueryShares.keys()]) {
+        if (key.startsWith(`${id}::`)) savedQueryShares.delete(key);
+      }
       return { rowCount: 1, rows: [{ id }] };
+    }
+
+    if (normalized.startsWith("select permission from saved_query_shares where saved_query_id = $1 and user_id = $2")) {
+      const [savedQueryId, userId2] = params;
+      const row = savedQueryShares.get(shareKey(savedQueryId, userId2));
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    if (normalized.startsWith("select saved_query_id, user_id, permission, granted_by_user_id, created_at from saved_query_shares where saved_query_id = $1")) {
+      const [savedQueryId] = params;
+      const rows = [...savedQueryShares.values()]
+        .filter((row) => row.saved_query_id === savedQueryId)
+        .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith("delete from saved_query_shares where saved_query_id = $1 and user_id = any($2::uuid[])")) {
+      const [savedQueryId, userIds] = params;
+      for (const uid of userIds || []) savedQueryShares.delete(shareKey(savedQueryId, uid));
+      return { rowCount: (userIds || []).length, rows: [] };
+    }
+
+    if (normalized.startsWith("insert into saved_query_shares")) {
+      const [savedQueryId, userId2, permission, grantedBy] = params;
+      const now = new Date().toISOString();
+      const existing = savedQueryShares.get(shareKey(savedQueryId, userId2));
+      const row = {
+        saved_query_id: savedQueryId,
+        user_id: userId2,
+        permission,
+        granted_by_user_id: grantedBy,
+        created_at: existing ? existing.created_at : now
+      };
+      savedQueryShares.set(shareKey(savedQueryId, userId2), row);
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (normalized.startsWith("insert into auth_audit_log")) {
+      return { rowCount: 1, rows: [] };
     }
 
     throw new Error(`Unexpected SQL in test stub: ${normalized}`);
@@ -268,6 +347,7 @@ before(async () => {
 
 beforeEach(() => {
   savedQueries.clear();
+  savedQueryShares.clear();
   savedQueryCounter = 0;
   adapterCalls = [];
 });
@@ -313,12 +393,12 @@ test("saved queries create/list/get/update/delete happy path", async () => {
 
   const savedQueryId = create.payload.id;
 
-  const list = await api("GET", "/v1/saved-queries", undefined, "bob");
+  const list = await api("GET", "/v1/saved-queries", undefined, "alice");
   assert.equal(list.status, 200);
   assert.equal(list.payload.items.length, 1);
   assert.equal(list.payload.items[0].id, savedQueryId);
 
-  const getById = await api("GET", `/v1/saved-queries/${savedQueryId}`, undefined, "bob");
+  const getById = await api("GET", `/v1/saved-queries/${savedQueryId}`, undefined, "alice");
   assert.equal(getById.status, 200);
   assert.equal(getById.payload.id, savedQueryId);
   assert.equal(getById.payload.owner_id, userId("alice"));
@@ -332,7 +412,7 @@ test("saved queries create/list/get/update/delete happy path", async () => {
       model: "gpt-4.1-mini",
       no_execute: true
     }
-  }, "bob");
+  }, "alice");
   assert.equal(update.status, 200);
   assert.equal(update.payload.owner_id, userId("alice"));
   assert.equal(update.payload.data_source_id, OTHER_SOURCE_ID);
@@ -342,12 +422,12 @@ test("saved queries create/list/get/update/delete happy path", async () => {
   });
   assert.deepEqual(update.payload.parameter_schema, []);
 
-  const filteredList = await api("GET", `/v1/saved-queries?data_source_id=${OTHER_SOURCE_ID}`, undefined, "carol");
+  const filteredList = await api("GET", `/v1/saved-queries?data_source_id=${OTHER_SOURCE_ID}`, undefined, "alice");
   assert.equal(filteredList.status, 200);
   assert.equal(filteredList.payload.items.length, 1);
   assert.equal(filteredList.payload.items[0].id, savedQueryId);
 
-  const del = await api("DELETE", `/v1/saved-queries/${savedQueryId}`, undefined, "dave");
+  const del = await api("DELETE", `/v1/saved-queries/${savedQueryId}`, undefined, "alice");
   assert.equal(del.status, 200);
   assert.deepEqual(del.payload, { ok: true, id: savedQueryId });
 
@@ -356,30 +436,33 @@ test("saved queries create/list/get/update/delete happy path", async () => {
   assert.equal(listAfterDelete.payload.items.length, 0);
 });
 
-test("saved queries are publicly readable and openly writable", async () => {
+test("QUERY-006 private saved queries are hidden from non-owners and write-protected", async () => {
   const created = await api("POST", "/v1/saved-queries", {
     name: "Store Revenue",
     data_source_id: DATA_SOURCE_ID,
     sql: "SELECT * FROM store_revenue"
   }, "owner-a");
+  assert.equal(created.status, 201);
+  assert.equal(created.payload.visibility, "private");
 
   const savedQueryId = created.payload.id;
 
   const fetchedByOtherUser = await api("GET", `/v1/saved-queries/${savedQueryId}`, undefined, "owner-b");
-  assert.equal(fetchedByOtherUser.status, 200);
-  assert.equal(fetchedByOtherUser.payload.owner_id, userId("owner-a"));
+  assert.equal(fetchedByOtherUser.status, 403);
 
-  const updatedByOtherUser = await api("PUT", `/v1/saved-queries/${savedQueryId}`, {
-    name: "Store Revenue Updated",
+  const listFromStranger = await api("GET", "/v1/saved-queries", undefined, "owner-b");
+  assert.equal(listFromStranger.status, 200);
+  assert.equal(listFromStranger.payload.items.length, 0);
+
+  const updateByOther = await api("PUT", `/v1/saved-queries/${savedQueryId}`, {
+    name: "Stolen",
     data_source_id: DATA_SOURCE_ID,
-    sql: "SELECT store_id, revenue FROM store_revenue",
-    description: "updated by another user"
+    sql: "SELECT 1"
   }, "owner-b");
-  assert.equal(updatedByOtherUser.status, 200);
-  assert.equal(updatedByOtherUser.payload.owner_id, userId("owner-a"));
+  assert.equal(updateByOther.status, 403);
 
-  const deletedByOtherUser = await api("DELETE", `/v1/saved-queries/${savedQueryId}`, undefined, "owner-c");
-  assert.equal(deletedByOtherUser.status, 200);
+  const deletedByOther = await api("DELETE", `/v1/saved-queries/${savedQueryId}`, undefined, "owner-b");
+  assert.equal(deletedByOther.status, 403);
 });
 
 test("saved queries auto-extract placeholders and preserve schema customizations on update", async () => {
@@ -672,4 +755,167 @@ test("saved query tags are normalized, deduplicated, and filterable", async () =
     tags: "finance"
   });
   assert.equal(wrongShape.status, 400);
+});
+
+test("QUERY-006 visibility='shared' surfaces queries to other authenticated users (read-only)", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Org Revenue",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT * FROM revenue",
+    visibility: "shared"
+  }, "owner-x");
+  assert.equal(created.status, 201);
+  assert.equal(created.payload.visibility, "shared");
+
+  const id = created.payload.id;
+
+  // Other user can list + GET it.
+  const listForOther = await api("GET", "/v1/saved-queries", undefined, "viewer-y");
+  assert.equal(listForOther.status, 200);
+  assert.equal(listForOther.payload.items.length, 1);
+  assert.equal(listForOther.payload.items[0].id, id);
+
+  const getForOther = await api("GET", `/v1/saved-queries/${id}`, undefined, "viewer-y");
+  assert.equal(getForOther.status, 200);
+
+  // But cannot edit, delete, or share.
+  const updateByOther = await api("PUT", `/v1/saved-queries/${id}`, {
+    name: "Hijacked",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 0"
+  }, "viewer-y");
+  assert.equal(updateByOther.status, 403);
+
+  const deleteByOther = await api("DELETE", `/v1/saved-queries/${id}`, undefined, "viewer-y");
+  assert.equal(deleteByOther.status, 403);
+
+  const shareByOther = await api("POST", `/v1/saved-queries/${id}/share`, {
+    visibility: "private"
+  }, "viewer-y");
+  assert.equal(shareByOther.status, 403);
+});
+
+test("QUERY-006 explicit per-user share with 'view' permission cannot run", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Limited Revenue",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "owner-share");
+  const id = created.payload.id;
+  const recipient = ensureTestUser("viewer-recipient");
+
+  const share = await api("POST", `/v1/saved-queries/${id}/share`, {
+    shares: [{ user_id: recipient.id, permission: "view" }]
+  }, "owner-share");
+  assert.equal(share.status, 200);
+  assert.equal(share.payload.shares.length, 1);
+  assert.equal(share.payload.shares[0].user_id, recipient.id);
+  assert.equal(share.payload.shares[0].permission, "view");
+
+  const recipientSees = await api("GET", `/v1/saved-queries/${id}`, undefined, "viewer-recipient");
+  assert.equal(recipientSees.status, 200);
+
+  const recipientRuns = await api("POST", `/v1/saved-queries/${id}/run`, {
+    params: {}
+  }, "viewer-recipient");
+  assert.equal(recipientRuns.status, 403);
+
+  const strangerSees = await api("GET", `/v1/saved-queries/${id}`, undefined, "stranger");
+  assert.equal(strangerSees.status, 403);
+});
+
+test("QUERY-006 explicit 'run' share lets recipient execute; revoke removes both rights", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Runnable Revenue",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "owner-run");
+  const id = created.payload.id;
+  const recipient = ensureTestUser("runner-recipient");
+
+  const grant = await api("POST", `/v1/saved-queries/${id}/share`, {
+    shares: [{ user_id: recipient.id, permission: "run" }]
+  }, "owner-run");
+  assert.equal(grant.status, 200);
+
+  const recipientRuns = await api("POST", `/v1/saved-queries/${id}/run`, {
+    params: {}
+  }, "runner-recipient");
+  assert.equal(recipientRuns.status, 200);
+  assert.equal(recipientRuns.payload.row_count, 1);
+
+  // Now revoke by sending an empty shares list.
+  const revoke = await api("POST", `/v1/saved-queries/${id}/share`, {
+    shares: []
+  }, "owner-run");
+  assert.equal(revoke.status, 200);
+  assert.equal(revoke.payload.shares.length, 0);
+  assert.equal(revoke.payload.diff.removed.length, 1);
+
+  const recipientGets = await api("GET", `/v1/saved-queries/${id}`, undefined, "runner-recipient");
+  assert.equal(recipientGets.status, 403);
+});
+
+test("QUERY-006 access endpoint exposes visibility + grants to owner; non-owners are forbidden", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Access Test",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "access-owner");
+  const id = created.payload.id;
+  const recipient = ensureTestUser("access-recipient");
+
+  await api("POST", `/v1/saved-queries/${id}/share`, {
+    visibility: "private",
+    shares: [{ user_id: recipient.id, permission: "view" }]
+  }, "access-owner");
+
+  const ownerAccess = await api("GET", `/v1/saved-queries/${id}/access`, undefined, "access-owner");
+  assert.equal(ownerAccess.status, 200);
+  assert.equal(ownerAccess.payload.visibility, "private");
+  assert.equal(ownerAccess.payload.owner_id, userId("access-owner"));
+  assert.equal(ownerAccess.payload.shares.length, 1);
+  assert.equal(ownerAccess.payload.shares[0].permission, "view");
+
+  // Granted user can see the access summary (read access implies it).
+  const recipientAccess = await api("GET", `/v1/saved-queries/${id}/access`, undefined, "access-recipient");
+  assert.equal(recipientAccess.status, 200);
+
+  // Stranger can't.
+  const strangerAccess = await api("GET", `/v1/saved-queries/${id}/access`, undefined, "stranger-a");
+  assert.equal(strangerAccess.status, 403);
+});
+
+test("QUERY-006 share endpoint validates the grant payload", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Validate Share",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "share-owner");
+  const id = created.payload.id;
+
+  const badVisibility = await api("POST", `/v1/saved-queries/${id}/share`, {
+    visibility: "public"
+  }, "share-owner");
+  assert.equal(badVisibility.status, 400);
+
+  const badPermission = await api("POST", `/v1/saved-queries/${id}/share`, {
+    shares: [{ user_id: "00000000-0000-4000-8000-aaaa00000099", permission: "admin" }]
+  }, "share-owner");
+  assert.equal(badPermission.status, 400);
+
+  const badUserId = await api("POST", `/v1/saved-queries/${id}/share`, {
+    shares: [{ user_id: "not-a-uuid", permission: "view" }]
+  }, "share-owner");
+  assert.equal(badUserId.status, 400);
+});
+
+test("QUERY-006 viewer role is denied by the share permission policy", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Viewer Share",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "viewer-share-owner", { role: "viewer" });
+  // Viewers can't write saved queries, so creation itself is denied.
+  assert.equal(created.status, 403);
 });

--- a/db/migrations/0024_saved_query_sharing.sql
+++ b/db/migrations/0024_saved_query_sharing.sql
@@ -1,0 +1,49 @@
+-- QUERY-006: sharing and access control for saved queries.
+--
+-- Adds two layers of access on top of the existing `owner_id`:
+--   * `visibility = 'shared'` — read-only to every authenticated user who
+--     can already see the underlying data source. Owner remains the only
+--     editor. Mirrors the AUTH-007 prompt_presets convention.
+--   * `saved_query_shares` — explicit per-user grants with two levels:
+--       'view' — recipient sees the query in their library.
+--       'run'  — recipient can also execute it via /run.
+--     `view` is implicit in `run`, but we store the literal level so we
+--     can surface it in the UI and audit who got what.
+--
+-- Updating, deleting, or re-sharing a query is owner-only and continues to
+-- be enforced in the service layer; this migration only adds storage.
+
+ALTER TABLE saved_queries
+  ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'private'
+    CHECK (visibility IN ('private', 'shared'));
+
+CREATE INDEX IF NOT EXISTS idx_saved_queries_visibility
+  ON saved_queries (visibility, updated_at DESC)
+  WHERE visibility = 'shared';
+
+CREATE TABLE IF NOT EXISTS saved_query_shares (
+  saved_query_id UUID NOT NULL REFERENCES saved_queries(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  permission TEXT NOT NULL CHECK (permission IN ('view', 'run')),
+  granted_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (saved_query_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_query_shares_user
+  ON saved_query_shares (user_id);
+
+-- Permission seed: only owners (or admins) can re-share. Viewer never gets
+-- write access to authoring; they cannot redistribute someone else's work.
+INSERT INTO permissions (name, description) VALUES
+  ('saved_queries.share', 'Share saved queries with other users')
+ON CONFLICT DO NOTHING;
+
+WITH share_perm AS (
+  SELECT id FROM permissions WHERE name = 'saved_queries.share'
+)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, share_perm.id
+  FROM roles r, share_perm
+ WHERE lower(r.name) IN ('admin', 'analyst')
+ON CONFLICT DO NOTHING;

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1184,6 +1184,48 @@ paths:
                   message:
                     type: string
                 required: [error, message]
+  /v1/saved-queries/{savedQueryId}/share:
+    post:
+      tags: [Query]
+      summary: Replace the share grants for a saved query (owner-only)
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ShareSavedQueryRequest"
+      responses:
+        "200":
+          description: Updated visibility + share grants, with diff
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQueryShareResponse"
+        "400":
+          description: Invalid visibility or share grant payload
+        "403":
+          description: Caller is not the owner
+        "404":
+          description: Saved query not found
+  /v1/saved-queries/{savedQueryId}/access:
+    get:
+      tags: [Query]
+      summary: Get visibility + share grants for a saved query
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+      responses:
+        "200":
+          description: Current access summary
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQueryAccessResponse"
+        "403":
+          description: Caller does not have access to this saved query
+        "404":
+          description: Saved query not found
   /v1/query/sessions:
     post:
       tags: [Query]
@@ -2636,13 +2678,16 @@ components:
           type: array
           items:
             type: string
+        visibility:
+          type: string
+          enum: [private, shared]
         created_at:
           type: string
           format: date-time
         updated_at:
           type: string
           format: date-time
-      required: [id, owner_id, name, data_source_id, sql, default_run_params, parameter_schema, tags, created_at, updated_at]
+      required: [id, owner_id, name, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, created_at, updated_at]
     SavedQueryListResponse:
       type: object
       properties:
@@ -2700,6 +2745,9 @@ components:
             type: string
             maxLength: 40
           maxItems: 20
+        visibility:
+          type: string
+          enum: [private, shared]
       required: [name, data_source_id, sql]
     UpdateSavedQueryRequest:
       type: object
@@ -2742,7 +2790,117 @@ components:
             type: string
             maxLength: 40
           maxItems: 20
+        visibility:
+          type: string
+          enum: [private, shared]
       required: [name, data_source_id, sql]
+    ShareSavedQueryRequest:
+      type: object
+      description: >
+        Owner-only. Replace-semantics: the `shares` array fully replaces the
+        existing per-user grants for this query. Omit `shares` to leave grants
+        unchanged; pass `shares: []` to revoke everyone.
+      properties:
+        visibility:
+          type: string
+          enum: [private, shared]
+        shares:
+          type: array
+          items:
+            type: object
+            properties:
+              user_id:
+                type: string
+              permission:
+                type: string
+                enum: [view, run]
+            required: [user_id, permission]
+    SavedQueryShareRecord:
+      type: object
+      properties:
+        saved_query_id:
+          type: string
+        user_id:
+          type: string
+        permission:
+          type: string
+          enum: [view, run]
+        granted_by_user_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+      required: [saved_query_id, user_id, permission, created_at]
+    SavedQueryAccessResponse:
+      type: object
+      properties:
+        saved_query_id:
+          type: string
+        owner_id:
+          type: string
+        visibility:
+          type: string
+          enum: [private, shared]
+        shares:
+          type: array
+          items:
+            $ref: "#/components/schemas/SavedQueryShareRecord"
+      required: [saved_query_id, owner_id, visibility, shares]
+    SavedQueryShareResponse:
+      type: object
+      properties:
+        visibility:
+          type: string
+          enum: [private, shared]
+        previous_visibility:
+          type: string
+          enum: [private, shared]
+        shares:
+          type: array
+          items:
+            $ref: "#/components/schemas/SavedQueryShareRecord"
+        diff:
+          type: object
+          properties:
+            added:
+              type: array
+              items:
+                type: object
+                properties:
+                  user_id:
+                    type: string
+                  permission:
+                    type: string
+                    enum: [view, run]
+                required: [user_id, permission]
+            updated:
+              type: array
+              items:
+                type: object
+                properties:
+                  user_id:
+                    type: string
+                  permission:
+                    type: string
+                    enum: [view, run]
+                  previous_permission:
+                    type: string
+                    enum: [view, run]
+                required: [user_id, permission, previous_permission]
+            removed:
+              type: array
+              items:
+                type: object
+                properties:
+                  user_id:
+                    type: string
+                  permission:
+                    type: string
+                    enum: [view, run]
+                required: [user_id, permission]
+          required: [added, updated, removed]
+      required: [visibility, previous_visibility, shares, diff]
     ValidateParamsRequest:
       type: object
       properties:

--- a/frontend/src/components/Query/ShareSavedQueryDialog.tsx
+++ b/frontend/src/components/Query/ShareSavedQueryDialog.tsx
@@ -1,0 +1,265 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { Loader2, Plus, Share2, Trash2, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { client } from '../../lib/api/client';
+import type { components } from '../../lib/api/types';
+import type { SavedQuery } from './types';
+
+type AccessResponse = components['schemas']['SavedQueryAccessResponse'];
+type ShareRecord = components['schemas']['SavedQueryShareRecord'];
+type Visibility = NonNullable<components['schemas']['SavedQuery']['visibility']>;
+type Permission = 'view' | 'run';
+
+interface ShareSavedQueryDialogProps {
+    savedQuery: SavedQuery;
+    isOpen: boolean;
+    onClose: () => void;
+    onUpdated: (visibility: Visibility) => void;
+}
+
+interface DraftGrant {
+    user_id: string;
+    permission: Permission;
+}
+
+export function ShareSavedQueryDialog({
+    savedQuery,
+    isOpen,
+    onClose,
+    onUpdated,
+}: ShareSavedQueryDialogProps) {
+    const [visibility, setVisibility] = useState<Visibility>(savedQuery.visibility);
+    const [grants, setGrants] = useState<DraftGrant[]>([]);
+    const [newUserId, setNewUserId] = useState('');
+    const [newPermission, setNewPermission] = useState<Permission>('view');
+    const [isLoading, setIsLoading] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        let cancelled = false;
+        const load = async () => {
+            setIsLoading(true);
+            setError(null);
+            const { data, error: fetchError } = await client.GET('/v1/saved-queries/{savedQueryId}/access', {
+                params: { path: { savedQueryId: savedQuery.id } },
+            });
+            if (cancelled) return;
+            if (fetchError || !data) {
+                setError('Failed to load access information.');
+                setIsLoading(false);
+                return;
+            }
+            const access = data as AccessResponse;
+            setVisibility(access.visibility);
+            setGrants(access.shares.map((row: ShareRecord) => ({
+                user_id: row.user_id,
+                permission: row.permission as Permission,
+            })));
+            setIsLoading(false);
+        };
+        void load();
+        return () => { cancelled = true; };
+    }, [isOpen, savedQuery.id]);
+
+    if (!isOpen) return null;
+
+    const addGrant = () => {
+        const trimmed = newUserId.trim();
+        if (!trimmed) return;
+        if (grants.some((g) => g.user_id === trimmed)) {
+            toast.error('That user is already on the list.');
+            return;
+        }
+        setGrants((current) => [...current, { user_id: trimmed, permission: newPermission }]);
+        setNewUserId('');
+        setNewPermission('view');
+    };
+
+    const updateGrantPermission = (userId: string, permission: Permission) => {
+        setGrants((current) => current.map((g) => (g.user_id === userId ? { ...g, permission } : g)));
+    };
+
+    const removeGrant = (userId: string) => {
+        setGrants((current) => current.filter((g) => g.user_id !== userId));
+    };
+
+    const handleSubmit = async (event: FormEvent) => {
+        event.preventDefault();
+        setIsSubmitting(true);
+        setError(null);
+        try {
+            const { data, error: shareError, response } = await client.POST('/v1/saved-queries/{savedQueryId}/share', {
+                params: { path: { savedQueryId: savedQuery.id } },
+                body: { visibility, shares: grants },
+            });
+            if (shareError || !data) {
+                const payload = shareError as { message?: string } | undefined;
+                setError(payload?.message || `Share update failed (HTTP ${response.status}).`);
+                return;
+            }
+            toast.success('Sharing updated.');
+            onUpdated(data.visibility);
+            onClose();
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+            <div className="w-full max-w-lg overflow-hidden rounded-lg bg-white shadow-xl">
+                <div className="flex items-center justify-between border-b border-outline-variant px-4 py-3">
+                    <div className="flex items-center gap-2">
+                        <Share2 size={16} className="text-oxblood" />
+                        <div>
+                            <h2 className="text-base font-semibold text-on-surface">Share Saved Query</h2>
+                            <p className="text-xs text-slate-500">{savedQuery.name}</p>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="text-slate-500 hover:text-slate-800"
+                        aria-label="Close share dialog"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+
+                {isLoading ? (
+                    <div className="flex h-40 items-center justify-center text-sm text-slate-500">
+                        <Loader2 className="mr-2 animate-spin" size={16} />
+                        Loading…
+                    </div>
+                ) : (
+                    <form onSubmit={handleSubmit} className="space-y-5 p-4">
+                        <div>
+                            <label className="mb-1 block text-sm font-medium text-slate-700">Visibility</label>
+                            <div className="flex gap-3 text-sm">
+                                <label className="inline-flex items-center gap-1.5">
+                                    <input
+                                        type="radio"
+                                        name="visibility"
+                                        value="private"
+                                        checked={visibility === 'private'}
+                                        onChange={() => setVisibility('private')}
+                                    />
+                                    <span>Private</span>
+                                </label>
+                                <label className="inline-flex items-center gap-1.5">
+                                    <input
+                                        type="radio"
+                                        name="visibility"
+                                        value="shared"
+                                        checked={visibility === 'shared'}
+                                        onChange={() => setVisibility('shared')}
+                                    />
+                                    <span>Shared (read-only to everyone)</span>
+                                </label>
+                            </div>
+                            <p className="mt-1 text-[11px] text-slate-500">
+                                Private queries are visible only to you and the users granted access below. Shared queries
+                                are read-only to every authenticated user.
+                            </p>
+                        </div>
+
+                        <div>
+                            <label className="mb-1 block text-sm font-medium text-slate-700">
+                                Per-user grants
+                                <span className="ml-2 text-xs font-normal text-slate-400">{grants.length}</span>
+                            </label>
+                            <div className="space-y-2">
+                                {grants.length === 0 ? (
+                                    <p className="rounded border border-dashed border-outline-variant px-3 py-3 text-xs text-slate-500">
+                                        No per-user grants. Add one below to share with a specific user.
+                                    </p>
+                                ) : (
+                                    grants.map((grant) => (
+                                        <div
+                                            key={grant.user_id}
+                                            className="flex items-center gap-2 rounded border border-outline-variant px-2 py-1.5"
+                                        >
+                                            <span className="flex-1 truncate font-mono text-[11px] text-slate-700">
+                                                {grant.user_id}
+                                            </span>
+                                            <select
+                                                value={grant.permission}
+                                                onChange={(event) => updateGrantPermission(grant.user_id, event.target.value as Permission)}
+                                                className="rounded border border-outline-variant bg-white px-1.5 py-1 text-xs"
+                                            >
+                                                <option value="view">view</option>
+                                                <option value="run">run</option>
+                                            </select>
+                                            <button
+                                                type="button"
+                                                onClick={() => removeGrant(grant.user_id)}
+                                                className="rounded p-1 text-slate-500 hover:bg-red-50 hover:text-red-600"
+                                                aria-label="Remove grant"
+                                            >
+                                                <Trash2 size={12} />
+                                            </button>
+                                        </div>
+                                    ))
+                                )}
+                            </div>
+
+                            <div className="mt-3 flex items-center gap-2">
+                                <input
+                                    type="text"
+                                    value={newUserId}
+                                    onChange={(event) => setNewUserId(event.target.value)}
+                                    placeholder="user UUID"
+                                    className="flex-1 rounded border border-outline-variant px-2 py-1.5 font-mono text-[11px] focus:border-oxblood focus:outline-none focus:ring-1 focus:ring-oxblood"
+                                />
+                                <select
+                                    value={newPermission}
+                                    onChange={(event) => setNewPermission(event.target.value as Permission)}
+                                    className="rounded border border-outline-variant bg-white px-2 py-1.5 text-xs"
+                                >
+                                    <option value="view">view</option>
+                                    <option value="run">run</option>
+                                </select>
+                                <button
+                                    type="button"
+                                    onClick={addGrant}
+                                    disabled={!newUserId.trim()}
+                                    className="flex items-center gap-1 rounded bg-oxblood px-2.5 py-1.5 text-xs font-medium text-white hover:bg-oxblood-soft disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    <Plus size={12} />
+                                    Add
+                                </button>
+                            </div>
+                            <p className="mt-1 text-[11px] text-slate-500">
+                                Provide the user's UUID. `view` lets them see the query in their library; `run` also lets them execute it.
+                            </p>
+                        </div>
+
+                        {error && (
+                            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">{error}</div>
+                        )}
+
+                        <div className="flex justify-end gap-2 border-t border-outline-variant pt-4">
+                            <button
+                                type="button"
+                                onClick={onClose}
+                                disabled={isSubmitting}
+                                className="rounded-md border border-outline-variant bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="submit"
+                                disabled={isSubmitting}
+                                className="rounded-md bg-oxblood px-4 py-2 text-sm font-medium text-white hover:bg-oxblood-soft disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                {isSubmitting ? 'Saving…' : 'Save Sharing'}
+                            </button>
+                        </div>
+                    </form>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -2337,6 +2337,121 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/saved-queries/{savedQueryId}/share": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Replace the share grants for a saved query (owner-only) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ShareSavedQueryRequest"];
+                };
+            };
+            responses: {
+                /** @description Updated visibility + share grants, with diff */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQueryShareResponse"];
+                    };
+                };
+                /** @description Invalid visibility or share grant payload */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Caller is not the owner */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Saved query not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/saved-queries/{savedQueryId}/access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get visibility + share grants for a saved query */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Current access summary */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQueryAccessResponse"];
+                    };
+                };
+                /** @description Caller does not have access to this saved query */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Saved query not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/query/sessions": {
         parameters: {
             query?: never;
@@ -4023,6 +4138,8 @@ export interface components {
             };
             parameter_schema: components["schemas"]["QueryParameter"][];
             tags: string[];
+            /** @enum {string} */
+            visibility: "private" | "shared";
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -4049,6 +4166,8 @@ export interface components {
             };
             parameter_schema?: components["schemas"]["QueryParameter"][];
             tags?: string[];
+            /** @enum {string} */
+            visibility?: "private" | "shared";
         };
         UpdateSavedQueryRequest: {
             name: string;
@@ -4064,6 +4183,60 @@ export interface components {
             };
             parameter_schema?: components["schemas"]["QueryParameter"][];
             tags?: string[];
+            /** @enum {string} */
+            visibility?: "private" | "shared";
+        };
+        /** @description Owner-only. Replace-semantics: the `shares` array fully replaces the existing per-user grants for this query. Omit `shares` to leave grants unchanged; pass `shares: []` to revoke everyone. */
+        ShareSavedQueryRequest: {
+            /** @enum {string} */
+            visibility?: "private" | "shared";
+            shares?: {
+                user_id: string;
+                /** @enum {string} */
+                permission: "view" | "run";
+            }[];
+        };
+        SavedQueryShareRecord: {
+            saved_query_id: string;
+            user_id: string;
+            /** @enum {string} */
+            permission: "view" | "run";
+            granted_by_user_id?: string | null;
+            /** Format: date-time */
+            created_at: string;
+        };
+        SavedQueryAccessResponse: {
+            saved_query_id: string;
+            owner_id: string;
+            /** @enum {string} */
+            visibility: "private" | "shared";
+            shares: components["schemas"]["SavedQueryShareRecord"][];
+        };
+        SavedQueryShareResponse: {
+            /** @enum {string} */
+            visibility: "private" | "shared";
+            /** @enum {string} */
+            previous_visibility: "private" | "shared";
+            shares: components["schemas"]["SavedQueryShareRecord"][];
+            diff: {
+                added: {
+                    user_id: string;
+                    /** @enum {string} */
+                    permission: "view" | "run";
+                }[];
+                updated: {
+                    user_id: string;
+                    /** @enum {string} */
+                    permission: "view" | "run";
+                    /** @enum {string} */
+                    previous_permission: "view" | "run";
+                }[];
+                removed: {
+                    user_id: string;
+                    /** @enum {string} */
+                    permission: "view" | "run";
+                }[];
+            };
         };
         ValidateParamsRequest: {
             params: {

--- a/frontend/src/pages/SavedQueries.tsx
+++ b/frontend/src/pages/SavedQueries.tsx
@@ -7,12 +7,15 @@ import {
     Database,
     FileText,
     Filter,
+    Globe,
     Loader2,
+    Lock,
     MoreVertical,
     Pencil,
     Plus,
     RefreshCw,
     Search,
+    Share2,
     Trash2,
 } from 'lucide-react';
 import { toast } from 'sonner';
@@ -20,6 +23,7 @@ import { useAuth } from '../hooks/useAuth';
 import { useDataSource } from '../hooks/useDataSource';
 import { useSavedQueries } from '../hooks/useSavedQueries';
 import { SaveQueryDialog, type SaveQueryDialogValues } from '../components/Query/SaveQueryDialog';
+import { ShareSavedQueryDialog } from '../components/Query/ShareSavedQueryDialog';
 import type { SavedQuery } from '../components/Query/types';
 
 type FilterMode = 'current' | 'all';
@@ -34,8 +38,10 @@ function formatDate(value: string) {
 
 export const SavedQueries = () => {
     const navigate = useNavigate();
-    const { hasPermission } = useAuth();
+    const { user, hasPermission } = useAuth();
     const canWriteSavedQueries = hasPermission('saved_queries.write');
+    const canShareSavedQueries = hasPermission('saved_queries.share');
+    const currentUserId = user?.id ?? null;
     const { dataSources, selectedDataSourceId } = useDataSource();
     const {
         savedQueries,
@@ -46,6 +52,8 @@ export const SavedQueries = () => {
         duplicateSavedQuery,
         deleteSavedQuery,
     } = useSavedQueries();
+
+    const [sharingQuery, setSharingQuery] = useState<SavedQuery | null>(null);
 
     const [searchText, setSearchText] = useState('');
     const [filterMode, setFilterMode] = useState<FilterMode>('all');
@@ -297,16 +305,30 @@ export const SavedQueries = () => {
                                                         <span className="font-mono text-[9px] font-bold text-on-primary-fixed">SQL</span>
                                                     </div>
                                                     <div className="min-w-0">
-                                                        <button
-                                                            type="button"
-                                                            onClick={(event) => {
-                                                                event.stopPropagation();
-                                                                openInWorkspace(entry.id);
-                                                            }}
-                                                            className="truncate text-left text-[13px] font-semibold leading-tight text-on-surface hover:text-oxblood"
-                                                        >
-                                                            {entry.name}
-                                                        </button>
+                                                        <div className="flex items-center gap-1.5">
+                                                            <button
+                                                                type="button"
+                                                                onClick={(event) => {
+                                                                    event.stopPropagation();
+                                                                    openInWorkspace(entry.id);
+                                                                }}
+                                                                className="truncate text-left text-[13px] font-semibold leading-tight text-on-surface hover:text-oxblood"
+                                                            >
+                                                                {entry.name}
+                                                            </button>
+                                                            <span
+                                                                className={[
+                                                                    'inline-flex items-center gap-0.5 rounded-sm border px-1 py-0.5 text-[9px] font-medium uppercase',
+                                                                    entry.visibility === 'shared'
+                                                                        ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                                                                        : 'border-slate-200 bg-slate-100 text-slate-600',
+                                                                ].join(' ')}
+                                                                title={entry.visibility === 'shared' ? 'Shared with the organization' : 'Private to owner and explicit grants'}
+                                                            >
+                                                                {entry.visibility === 'shared' ? <Globe size={9} /> : <Lock size={9} />}
+                                                                {entry.visibility}
+                                                            </span>
+                                                        </div>
                                                         <div className="mt-0.5 flex items-center gap-1 text-[11px] text-slate-500">
                                                             <Database size={10} />
                                                             <span className="truncate">
@@ -376,6 +398,16 @@ export const SavedQueries = () => {
                                         >
                                             {pendingId === selectedQuery.id ? <Loader2 size={16} className="animate-spin" /> : <Copy size={16} />}
                                         </button>
+                                        {canShareSavedQueries && currentUserId === selectedQuery.owner_id && (
+                                            <button
+                                                type="button"
+                                                onClick={() => setSharingQuery(selectedQuery)}
+                                                className="rounded border border-transparent p-1.5 text-slate-500 hover:border-outline-variant hover:bg-surface-container-low hover:text-on-surface"
+                                                title="Share"
+                                            >
+                                                <Share2 size={16} />
+                                            </button>
+                                        )}
                                         <button
                                             type="button"
                                             onClick={() => setEditing(selectedQuery)}
@@ -512,6 +544,15 @@ export const SavedQueries = () => {
                 onClose={() => setEditing(null)}
                 onSave={handleSaveEdit}
             />
+
+            {sharingQuery && (
+                <ShareSavedQueryDialog
+                    savedQuery={sharingQuery}
+                    isOpen
+                    onClose={() => setSharingQuery(null)}
+                    onUpdated={() => { void refresh(); }}
+                />
+            )}
 
             {confirmDeleteId && (
                 <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">


### PR DESCRIPTION
Closes #41.

## Summary
- **Storage** (migration `0024_saved_query_sharing.sql`): adds `visibility` (`private`/`shared`) to `saved_queries`, creates `saved_query_shares` (per-user `view`/`run` grants), and seeds the new `saved_queries.share` permission (granted to admin + analyst, not viewer).
- **Service** (`savedQueryService.js`): introduces `resolveCallerAccess(query, user)` → `owner` / `run` / `view` / `null` and threads `callerUserId` through `get`, `list`, `update`, `delete`, `validateParams`, and `execute`. Update / delete / share are owner-only (403 otherwise). Read paths return only queries the caller owns, that are shared org-wide, or that have an explicit grant. Execute additionally requires owner or `run` grant — a `view` grant returns 403 with a clear message.
- **API**: `POST /v1/saved-queries/{id}/share` replaces visibility + grants in one call (omit `shares` to leave grants untouched; pass `[]` to revoke everyone); returns the new state plus an `added`/`updated`/`removed` diff that drives audit events. `GET /v1/saved-queries/{id}/access` returns the current visibility + grants for anyone who can read the query.
- **Audit**: every visibility flip and grant change writes a `saved_query.visibility.changed` / `saved_query.share.granted` / `saved_query.share.updated` / `saved_query.share.revoked` event with the target user and previous state, surfaceable in the existing audit log UI.
- **Frontend**: new `ShareSavedQueryDialog` (visibility radio + per-user UUID grants + run-vs-view selector); SavedQueries library row gets a visibility badge (private/shared); a Share button shows up on the side panel for the owner only.

## Test plan
- [x] `npm test` (185/185 passing; +6 new sharing tests)
- [x] `npx tsc -b` (frontend, clean)
- [x] `npm run lint` (frontend, clean)
- [x] `npm run build` (frontend, builds)
- [ ] Manual browser test deferred — please verify: (1) as the owner, share a private query with another user as `view`, sign in as that user and confirm it appears in their library + GET works + Run returns 403; (2) elevate to `run`, confirm Run succeeds; (3) revoke and confirm the query disappears from their library; (4) flip to `shared` visibility and confirm the badge updates and other users see it read-only.