### PR TITLE
QUERY-005 saved query revision history and restore

### DIFF
--- a/app/src/lib/routePolicy.js
+++ b/app/src/lib/routePolicy.js
@@ -89,6 +89,8 @@ const POLICIES = [
   { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/run$/, permission: "query.run" },
   { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/share$/, permission: "saved_queries.share" },
   { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+\/access$/, permission: "saved_queries.read" },
+  { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+\/versions$/, permission: "saved_queries.read" },
+  { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/versions\/[^/]+\/restore$/, permission: "saved_queries.write" },
   { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.read" },
   { method: "PUT", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.write" },
   { method: "DELETE", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.write" },

--- a/app/src/routes/savedQueries.js
+++ b/app/src/routes/savedQueries.js
@@ -225,6 +225,43 @@ async function handleGetSavedQueryAccess(req, res, savedQueryId) {
   return writeResult(res, result);
 }
 
+async function handleListSavedQueryVersions(req, res, savedQueryId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
+    return undefined;
+  }
+  const result = await savedQueryService.listSavedQueryVersions(savedQueryId, {
+    callerUserId: callerId(req)
+  });
+  return writeResult(res, result);
+}
+
+async function handleRestoreSavedQueryVersion(req, res, savedQueryId, versionId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) {
+    return undefined;
+  }
+  const result = await savedQueryService.restoreSavedQueryVersion(savedQueryId, versionId, {
+    callerUserId: callerId(req)
+  });
+
+  if (result.ok) {
+    auditService.writeEvent({
+      actorUserId: callerId(req),
+      action: "saved_query.version.restored",
+      details: {
+        saved_query_id: savedQueryId,
+        restored_from_version_number: result.body.restored_from_version_number,
+        new_version_number: result.body.new_version.version_number
+      },
+      ipAddress: requestClientIp(req),
+      userAgent: req.headers["user-agent"] || null
+    }).catch(() => {});
+  }
+
+  return writeResult(res, result);
+}
+
 module.exports = {
   handleCreateSavedQuery,
   handleListSavedQueries,
@@ -234,5 +271,7 @@ module.exports = {
   handleValidateParams,
   handleRunSavedQuery,
   handleShareSavedQuery,
-  handleGetSavedQueryAccess
+  handleGetSavedQueryAccess,
+  handleListSavedQueryVersions,
+  handleRestoreSavedQueryVersion
 };

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -53,7 +53,9 @@ const {
   handleValidateParams,
   handleRunSavedQuery,
   handleShareSavedQuery,
-  handleGetSavedQueryAccess
+  handleGetSavedQueryAccess,
+  handleListSavedQueryVersions,
+  handleRestoreSavedQueryVersion
 } = require("./routes/savedQueries");
 const {
   handleExportSession,
@@ -450,6 +452,16 @@ async function routeRequest(req, res) {
   const savedQueryAccessMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/access$/);
   if (req.method === "GET" && savedQueryAccessMatch) {
     return handleGetSavedQueryAccess(req, res, savedQueryAccessMatch[1]);
+  }
+
+  const savedQueryVersionsMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/versions$/);
+  if (req.method === "GET" && savedQueryVersionsMatch) {
+    return handleListSavedQueryVersions(req, res, savedQueryVersionsMatch[1]);
+  }
+
+  const savedQueryRestoreMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/versions\/([^/]+)\/restore$/);
+  if (req.method === "POST" && savedQueryRestoreMatch) {
+    return handleRestoreSavedQueryVersion(req, res, savedQueryRestoreMatch[1], savedQueryRestoreMatch[2]);
   }
 
   const savedQueryMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)$/);

--- a/app/src/services/savedQueryService.js
+++ b/app/src/services/savedQueryService.js
@@ -1,4 +1,5 @@
 const appDb = require("../lib/appDb");
+const versionService = require("./savedQueryVersionService");
 const {
   SAVED_QUERY_NAME_MAX_LENGTH,
   SAVED_QUERY_DESCRIPTION_MAX_LENGTH,
@@ -352,7 +353,13 @@ async function createSavedQuery({
       ]
     );
 
-    return success(insertResult.rows[0], 201);
+    const created = insertResult.rows[0];
+    await versionService.recordVersion(
+      created.id,
+      versionService.snapshotFromSavedQuery(created),
+      { actorUserId: isUuid(trimmedOwnerId) ? trimmedOwnerId : null, changeSummary: "created" }
+    );
+    return success(created, 201);
   } catch (err) {
     if (isPgUniqueViolation(err)) {
       return failure(409, {
@@ -463,7 +470,13 @@ async function updateSavedQuery(savedQueryId, {
       ]
     );
 
-    return success(updateResult.rows[0]);
+    const updated = updateResult.rows[0];
+    await versionService.recordVersion(
+      updated.id,
+      versionService.snapshotFromSavedQuery(updated),
+      { actorUserId: callerUserId || null, changeSummary: "updated" }
+    );
+    return success(updated);
   } catch (err) {
     if (isPgUniqueViolation(err)) {
       return failure(409, {
@@ -798,6 +811,93 @@ async function getSavedQueryAccess(savedQueryId, { callerUserId } = {}) {
   });
 }
 
+async function listSavedQueryVersions(savedQueryId, { callerUserId } = {}) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (callerUserId) {
+    const access = await resolveCallerAccess(savedQuery, callerUserId);
+    if (!access) {
+      return failure(403, { error: "forbidden", message: "You do not have access to this saved query" });
+    }
+  }
+  const versions = await versionService.listVersions(savedQueryId);
+  return success({ items: versions });
+}
+
+async function restoreSavedQueryVersion(savedQueryId, versionId, { callerUserId } = {}) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+  if (!isUuid(versionId)) {
+    return failure(400, { error: "bad_request", message: "versionId must be a valid UUID" });
+  }
+  const existing = await loadSavedQuery(savedQueryId);
+  if (!existing) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (callerUserId && existing.owner_id !== callerUserId) {
+    return failure(403, { error: "forbidden", message: "Only the owner can restore versions of this saved query" });
+  }
+  const version = await versionService.getVersionById(versionId);
+  if (!version || version.saved_query_id !== savedQueryId) {
+    return failure(404, { error: "not_found", message: "Version not found" });
+  }
+
+  // Apply the version's snapshot to the live row. We re-use the standard
+  // UPDATE shape so visibility/tags/parameter_schema all flow through the
+  // existing column list. The restore itself becomes a new version row so
+  // the timeline reads top-to-bottom.
+  const updateResult = await appDb.query(
+    `
+      UPDATE saved_queries
+      SET
+        name = $2,
+        description = $3,
+        data_source_id = $4,
+        sql = $5,
+        default_run_params = $6::jsonb,
+        parameter_schema = $7::jsonb,
+        tags = $8::text[],
+        visibility = $9,
+        updated_at = NOW()
+      WHERE id = $1
+      RETURNING ${SAVED_QUERY_COLUMNS}
+    `,
+    [
+      savedQueryId,
+      version.name,
+      version.description,
+      version.data_source_id,
+      version.sql,
+      JSON.stringify(version.default_run_params || {}),
+      JSON.stringify(version.parameter_schema || []),
+      version.tags || [],
+      version.visibility || "private"
+    ]
+  );
+  const restored = updateResult.rows[0];
+
+  const newVersion = await versionService.recordVersion(
+    savedQueryId,
+    versionService.snapshotFromSavedQuery(restored),
+    {
+      actorUserId: callerUserId || null,
+      changeSummary: `restored from version ${version.version_number}`
+    }
+  );
+
+  return success({
+    saved_query: restored,
+    restored_from_version_number: version.version_number,
+    new_version: newVersion
+  });
+}
+
 module.exports = {
   getSavedQuery,
   listSavedQueries,
@@ -808,5 +908,7 @@ module.exports = {
   executeSavedQuery,
   shareSavedQuery,
   getSavedQueryAccess,
+  listSavedQueryVersions,
+  restoreSavedQueryVersion,
   resolveCallerAccess
 };

--- a/app/src/services/savedQueryVersionService.js
+++ b/app/src/services/savedQueryVersionService.js
@@ -1,0 +1,140 @@
+// QUERY-005: revision history for saved queries.
+//
+// `recordVersion` writes the next-numbered row using the UNIQUE
+// (saved_query_id, version_number) constraint as the locking mechanism —
+// on collision (rare race) the caller can retry. Since the existing API
+// surface serialises edits per saved_query (one HTTP request at a time),
+// collisions are unlikely in practice, but the retry loop keeps it safe.
+
+const appDb = require("../lib/appDb");
+const { isUuid, isPgUniqueViolation } = require("../lib/validation");
+
+const VERSION_COLUMNS = `
+  id,
+  saved_query_id,
+  version_number,
+  name,
+  description,
+  data_source_id,
+  sql,
+  default_run_params,
+  parameter_schema,
+  tags,
+  visibility,
+  change_summary,
+  created_by_user_id,
+  created_at
+`;
+
+function snapshotFromSavedQuery(savedQuery) {
+  return {
+    name: savedQuery.name,
+    description: savedQuery.description ?? null,
+    data_source_id: savedQuery.data_source_id,
+    sql: savedQuery.sql,
+    default_run_params: savedQuery.default_run_params || {},
+    parameter_schema: savedQuery.parameter_schema || [],
+    tags: savedQuery.tags || [],
+    visibility: savedQuery.visibility || "private"
+  };
+}
+
+async function nextVersionNumber(savedQueryId) {
+  const result = await appDb.query(
+    `SELECT COALESCE(MAX(version_number), 0) AS max_version
+       FROM saved_query_versions
+      WHERE saved_query_id = $1`,
+    [savedQueryId]
+  );
+  return (result.rows[0]?.max_version ?? 0) + 1;
+}
+
+async function recordVersion(savedQueryId, snapshot, { actorUserId = null, changeSummary = null } = {}) {
+  if (!isUuid(savedQueryId)) {
+    throw new Error("recordVersion: savedQueryId must be a UUID");
+  }
+  if (!snapshot || typeof snapshot !== "object") {
+    throw new Error("recordVersion: snapshot is required");
+  }
+
+  // Retry once on UNIQUE violation: two concurrent edits could both try to
+  // claim the same version_number. Reading the max again and re-inserting
+  // is safe because the body is identical to what we'd have written.
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const versionNumber = await nextVersionNumber(savedQueryId);
+    try {
+      const result = await appDb.query(
+        `
+          INSERT INTO saved_query_versions (
+            saved_query_id,
+            version_number,
+            name,
+            description,
+            data_source_id,
+            sql,
+            default_run_params,
+            parameter_schema,
+            tags,
+            visibility,
+            change_summary,
+            created_by_user_id
+          ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9::text[], $10, $11, $12
+          )
+          RETURNING ${VERSION_COLUMNS}
+        `,
+        [
+          savedQueryId,
+          versionNumber,
+          snapshot.name,
+          snapshot.description,
+          snapshot.data_source_id,
+          snapshot.sql,
+          JSON.stringify(snapshot.default_run_params || {}),
+          JSON.stringify(snapshot.parameter_schema || []),
+          snapshot.tags || [],
+          snapshot.visibility || "private",
+          changeSummary,
+          actorUserId
+        ]
+      );
+      return result.rows[0];
+    } catch (err) {
+      if (isPgUniqueViolation(err) && attempt < 2) {
+        // Another writer took our version_number — loop and pick the next.
+        continue;
+      }
+      throw err;
+    }
+  }
+  // Unreachable: the loop either returns or throws above.
+  throw new Error("recordVersion: failed to claim a version_number after retries");
+}
+
+async function listVersions(savedQueryId) {
+  const result = await appDb.query(
+    `
+      SELECT ${VERSION_COLUMNS}
+        FROM saved_query_versions
+       WHERE saved_query_id = $1
+       ORDER BY version_number DESC
+    `,
+    [savedQueryId]
+  );
+  return result.rows;
+}
+
+async function getVersionById(versionId) {
+  const result = await appDb.query(
+    `SELECT ${VERSION_COLUMNS} FROM saved_query_versions WHERE id = $1`,
+    [versionId]
+  );
+  return result.rows[0] || null;
+}
+
+module.exports = {
+  snapshotFromSavedQuery,
+  recordVersion,
+  listVersions,
+  getVersionById
+};

--- a/app/test/savedQueriesApi.test.js
+++ b/app/test/savedQueriesApi.test.js
@@ -17,7 +17,9 @@ let server;
 let baseUrl;
 let savedQueries;
 let savedQueryShares;
+let savedQueryVersions;
 let savedQueryCounter;
+let savedQueryVersionCounter;
 let originalQuery;
 let originalCreateDatabaseAdapter;
 let originalIsSupportedDbType;
@@ -27,6 +29,11 @@ const testUsers = {};
 
 function shareKey(savedQueryId, userId) {
   return `${savedQueryId}::${userId}`;
+}
+
+function nextVersionId() {
+  savedQueryVersionCounter += 1;
+  return `00000000-0000-4000-8000-cccc${String(savedQueryVersionCounter).padStart(8, "0")}`;
 }
 
 function normalizeSql(sql) {
@@ -103,7 +110,9 @@ before(async () => {
   originalIsSupportedDbType = dbAdapterFactory.isSupportedDbType;
   savedQueries = new Map();
   savedQueryShares = new Map();
+  savedQueryVersions = new Map();
   savedQueryCounter = 0;
+  savedQueryVersionCounter = 0;
   adapterCalls = [];
   authStub = createAuthTestStub();
 
@@ -336,6 +345,71 @@ before(async () => {
       return { rowCount: 1, rows: [] };
     }
 
+    if (normalized.startsWith("select coalesce(max(version_number), 0) as max_version from saved_query_versions where saved_query_id = $1")) {
+      const [savedQueryId] = params;
+      const maxVersion = [...savedQueryVersions.values()]
+        .filter((row) => row.saved_query_id === savedQueryId)
+        .reduce((max, row) => Math.max(max, row.version_number), 0);
+      return { rowCount: 1, rows: [{ max_version: maxVersion }] };
+    }
+
+    if (normalized.startsWith("insert into saved_query_versions")) {
+      const [
+        savedQueryId,
+        versionNumber,
+        name,
+        description,
+        dataSourceId,
+        sqlText,
+        defaultRunParamsJson,
+        parameterSchemaJson,
+        tags,
+        visibility,
+        changeSummary,
+        createdByUserId
+      ] = params;
+      // Mirror the UNIQUE (saved_query_id, version_number) constraint.
+      const duplicate = [...savedQueryVersions.values()].some(
+        (row) => row.saved_query_id === savedQueryId && row.version_number === versionNumber
+      );
+      if (duplicate) {
+        throw duplicateError();
+      }
+      const now = new Date().toISOString();
+      const row = {
+        id: nextVersionId(),
+        saved_query_id: savedQueryId,
+        version_number: versionNumber,
+        name,
+        description,
+        data_source_id: dataSourceId,
+        sql: sqlText,
+        default_run_params: JSON.parse(defaultRunParamsJson),
+        parameter_schema: JSON.parse(parameterSchemaJson),
+        tags: Array.isArray(tags) ? tags : [],
+        visibility: visibility || "private",
+        change_summary: changeSummary,
+        created_by_user_id: createdByUserId,
+        created_at: now
+      };
+      savedQueryVersions.set(row.id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (normalized.startsWith("select id, saved_query_id, version_number, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, change_summary, created_by_user_id, created_at from saved_query_versions where saved_query_id = $1")) {
+      const [savedQueryId] = params;
+      const rows = [...savedQueryVersions.values()]
+        .filter((row) => row.saved_query_id === savedQueryId)
+        .sort((a, b) => b.version_number - a.version_number);
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith("select id, saved_query_id, version_number, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, change_summary, created_by_user_id, created_at from saved_query_versions where id = $1")) {
+      const [id] = params;
+      const row = savedQueryVersions.get(id);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
     throw new Error(`Unexpected SQL in test stub: ${normalized}`);
   };
 
@@ -348,7 +422,9 @@ before(async () => {
 beforeEach(() => {
   savedQueries.clear();
   savedQueryShares.clear();
+  savedQueryVersions.clear();
   savedQueryCounter = 0;
+  savedQueryVersionCounter = 0;
   adapterCalls = [];
 });
 
@@ -908,6 +984,133 @@ test("QUERY-006 share endpoint validates the grant payload", async () => {
     shares: [{ user_id: "not-a-uuid", permission: "view" }]
   }, "share-owner");
   assert.equal(badUserId.status, 400);
+});
+
+test("QUERY-005 create records version 1 and update appends a new version", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Versioned Revenue",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "version-owner");
+  assert.equal(created.status, 201);
+  const id = created.payload.id;
+
+  const initialList = await api("GET", `/v1/saved-queries/${id}/versions`, undefined, "version-owner");
+  assert.equal(initialList.status, 200);
+  assert.equal(initialList.payload.items.length, 1);
+  assert.equal(initialList.payload.items[0].version_number, 1);
+  assert.equal(initialList.payload.items[0].change_summary, "created");
+  assert.equal(initialList.payload.items[0].sql, "SELECT 1");
+
+  const updated = await api("PUT", `/v1/saved-queries/${id}`, {
+    name: "Versioned Revenue",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 2"
+  }, "version-owner");
+  assert.equal(updated.status, 200);
+
+  const afterUpdate = await api("GET", `/v1/saved-queries/${id}/versions`, undefined, "version-owner");
+  assert.equal(afterUpdate.status, 200);
+  assert.equal(afterUpdate.payload.items.length, 2);
+  // Listed newest-first.
+  assert.equal(afterUpdate.payload.items[0].version_number, 2);
+  assert.equal(afterUpdate.payload.items[0].sql, "SELECT 2");
+  assert.equal(afterUpdate.payload.items[0].change_summary, "updated");
+  assert.equal(afterUpdate.payload.items[1].version_number, 1);
+  assert.equal(afterUpdate.payload.items[1].sql, "SELECT 1");
+});
+
+test("QUERY-005 owner can restore a previous version; restore itself is recorded", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Restore Target",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 'v1'"
+  }, "restore-owner");
+  const id = created.payload.id;
+
+  await api("PUT", `/v1/saved-queries/${id}`, {
+    name: "Restore Target",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 'v2'"
+  }, "restore-owner");
+
+  const listBefore = await api("GET", `/v1/saved-queries/${id}/versions`, undefined, "restore-owner");
+  assert.equal(listBefore.payload.items.length, 2);
+  const v1 = listBefore.payload.items.find((row) => row.version_number === 1);
+  assert.ok(v1, "expected version 1 to exist");
+
+  const restore = await api("POST", `/v1/saved-queries/${id}/versions/${v1.id}/restore`, {}, "restore-owner");
+  assert.equal(restore.status, 200);
+  assert.equal(restore.payload.restored_from_version_number, 1);
+  assert.equal(restore.payload.new_version.version_number, 3);
+  assert.equal(restore.payload.saved_query.sql, "SELECT 'v1'");
+
+  const finalGet = await api("GET", `/v1/saved-queries/${id}`, undefined, "restore-owner");
+  assert.equal(finalGet.payload.sql, "SELECT 'v1'");
+
+  const listAfter = await api("GET", `/v1/saved-queries/${id}/versions`, undefined, "restore-owner");
+  assert.equal(listAfter.payload.items.length, 3);
+  assert.equal(listAfter.payload.items[0].version_number, 3);
+  assert.match(listAfter.payload.items[0].change_summary, /restored from version 1/);
+});
+
+test("QUERY-005 non-owner cannot restore a version; granted reader can list", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Restricted Restore",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "restore-owner-private");
+  const id = created.payload.id;
+
+  await api("PUT", `/v1/saved-queries/${id}`, {
+    name: "Restricted Restore",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 2"
+  }, "restore-owner-private");
+
+  // Stranger cannot even list.
+  const strangerList = await api("GET", `/v1/saved-queries/${id}/versions`, undefined, "stranger-restore");
+  assert.equal(strangerList.status, 403);
+
+  // Grant a view share to a teammate.
+  const teammate = ensureTestUser("restore-teammate");
+  await api("POST", `/v1/saved-queries/${id}/share`, {
+    shares: [{ user_id: teammate.id, permission: "view" }]
+  }, "restore-owner-private");
+
+  const teammateList = await api("GET", `/v1/saved-queries/${id}/versions`, undefined, "restore-teammate");
+  assert.equal(teammateList.status, 200);
+  assert.equal(teammateList.payload.items.length, 2);
+
+  // Teammate cannot restore, only the owner can.
+  const target = teammateList.payload.items.find((row) => row.version_number === 1);
+  const teammateRestore = await api("POST", `/v1/saved-queries/${id}/versions/${target.id}/restore`, {}, "restore-teammate");
+  assert.equal(teammateRestore.status, 403);
+});
+
+test("QUERY-005 restoring with a mismatched or missing version returns 404", async () => {
+  const created = await api("POST", "/v1/saved-queries", {
+    name: "Mismatch",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "mismatch-owner");
+  const id = created.payload.id;
+
+  const other = await api("POST", "/v1/saved-queries", {
+    name: "Other",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 2"
+  }, "mismatch-other-owner");
+  const otherList = await api("GET", `/v1/saved-queries/${other.payload.id}/versions`, undefined, "mismatch-other-owner");
+  const otherVersionId = otherList.payload.items[0].id;
+
+  // Wrong saved_query_id for that version → 404.
+  const crossed = await api("POST", `/v1/saved-queries/${id}/versions/${otherVersionId}/restore`, {}, "mismatch-owner");
+  assert.equal(crossed.status, 404);
+
+  // Unknown version id → 404.
+  const missing = await api("POST", `/v1/saved-queries/${id}/versions/00000000-0000-4000-8000-cccc99999999/restore`, {}, "mismatch-owner");
+  assert.equal(missing.status, 404);
 });
 
 test("QUERY-006 viewer role is denied by the share permission policy", async () => {

--- a/db/migrations/0025_saved_query_versions.sql
+++ b/db/migrations/0025_saved_query_versions.sql
@@ -1,0 +1,34 @@
+-- QUERY-005: revision history for saved queries.
+--
+-- Every create / edit / restore writes a row to `saved_query_versions`
+-- containing a full snapshot of the saved-query fields plus an optional
+-- `change_summary`. `version_number` is monotonic per saved_query_id
+-- (the service computes the next number under the UNIQUE constraint).
+--
+-- `data_source_id` is stored as a plain UUID (no FK) so deleting or moving
+-- a data source doesn't orphan the version row — the history is meant to
+-- survive even if the live row is later deleted (CASCADE clears it then).
+-- The owner-restore path applies the snapshot back to `saved_queries` and
+-- records a new version row so the timeline stays linear.
+
+CREATE TABLE IF NOT EXISTS saved_query_versions (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  saved_query_id UUID NOT NULL REFERENCES saved_queries(id) ON DELETE CASCADE,
+  version_number INT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  data_source_id UUID NOT NULL,
+  sql TEXT NOT NULL,
+  default_run_params JSONB NOT NULL DEFAULT '{}'::jsonb,
+  parameter_schema JSONB NOT NULL DEFAULT '[]'::jsonb,
+  tags TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+  visibility TEXT NOT NULL DEFAULT 'private'
+    CHECK (visibility IN ('private', 'shared')),
+  change_summary TEXT,
+  created_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (saved_query_id, version_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_query_versions_query_created_at
+  ON saved_query_versions (saved_query_id, created_at DESC);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1226,6 +1226,45 @@ paths:
           description: Caller does not have access to this saved query
         "404":
           description: Saved query not found
+  /v1/saved-queries/{savedQueryId}/versions:
+    get:
+      tags: [Query]
+      summary: List revisions of a saved query (newest first)
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+      responses:
+        "200":
+          description: Version list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQueryVersionListResponse"
+        "403":
+          description: Caller does not have access to this saved query
+        "404":
+          description: Saved query not found
+  /v1/saved-queries/{savedQueryId}/versions/{versionId}/restore:
+    post:
+      tags: [Query]
+      summary: Restore a saved query to a previous version (owner-only)
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+        - in: path
+          name: versionId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Restored. Body includes the new live row plus the version that was just appended.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQueryRestoreResponse"
+        "403":
+          description: Caller is not the owner
+        "404":
+          description: Saved query or version not found
   /v1/query/sessions:
     post:
       tags: [Query]
@@ -2847,6 +2886,66 @@ components:
           items:
             $ref: "#/components/schemas/SavedQueryShareRecord"
       required: [saved_query_id, owner_id, visibility, shares]
+    SavedQueryVersion:
+      type: object
+      properties:
+        id:
+          type: string
+        saved_query_id:
+          type: string
+        version_number:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        data_source_id:
+          type: string
+        sql:
+          type: string
+        default_run_params:
+          type: object
+          additionalProperties: true
+        parameter_schema:
+          type: array
+          items:
+            $ref: "#/components/schemas/QueryParameter"
+        tags:
+          type: array
+          items:
+            type: string
+        visibility:
+          type: string
+          enum: [private, shared]
+        change_summary:
+          type: string
+          nullable: true
+        created_by_user_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+      required: [id, saved_query_id, version_number, name, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, created_at]
+    SavedQueryVersionListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SavedQueryVersion"
+      required: [items]
+    SavedQueryRestoreResponse:
+      type: object
+      properties:
+        saved_query:
+          $ref: "#/components/schemas/SavedQuery"
+        restored_from_version_number:
+          type: integer
+        new_version:
+          $ref: "#/components/schemas/SavedQueryVersion"
+      required: [saved_query, restored_from_version_number, new_version]
     SavedQueryShareResponse:
       type: object
       properties:

--- a/frontend/src/components/Query/VersionHistoryDialog.tsx
+++ b/frontend/src/components/Query/VersionHistoryDialog.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useMemo, useState } from 'react';
+import { History, Loader2, RotateCcw, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { client } from '../../lib/api/client';
+import type { components } from '../../lib/api/types';
+import type { SavedQuery } from './types';
+
+type SavedQueryVersion = components['schemas']['SavedQueryVersion'];
+
+interface VersionHistoryDialogProps {
+    savedQuery: SavedQuery;
+    canRestore: boolean;
+    isOpen: boolean;
+    onClose: () => void;
+    onRestored: () => void;
+}
+
+function formatTimestamp(value: string) {
+    try {
+        return new Date(value).toLocaleString();
+    } catch {
+        return value;
+    }
+}
+
+export function VersionHistoryDialog({
+    savedQuery,
+    canRestore,
+    isOpen,
+    onClose,
+    onRestored,
+}: VersionHistoryDialogProps) {
+    const [versions, setVersions] = useState<SavedQueryVersion[]>([]);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [pendingRestoreId, setPendingRestoreId] = useState<string | null>(null);
+
+    const refresh = async () => {
+        setIsLoading(true);
+        setErrorMessage(null);
+        const { data, error } = await client.GET('/v1/saved-queries/{savedQueryId}/versions', {
+            params: { path: { savedQueryId: savedQuery.id } },
+        });
+        if (error || !data) {
+            setErrorMessage('Failed to load version history.');
+            setIsLoading(false);
+            return;
+        }
+        const items = data.items as SavedQueryVersion[];
+        setVersions(items);
+        setSelectedId((current) => {
+            if (current && items.some((row) => row.id === current)) return current;
+            return items[0]?.id ?? null;
+        });
+        setIsLoading(false);
+    };
+
+    useEffect(() => {
+        if (!isOpen) return;
+        void refresh();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isOpen, savedQuery.id]);
+
+    const selectedVersion = useMemo(
+        () => versions.find((row) => row.id === selectedId) ?? null,
+        [versions, selectedId],
+    );
+
+    if (!isOpen) return null;
+
+    const handleRestore = async (versionId: string) => {
+        if (!canRestore) return;
+        setPendingRestoreId(versionId);
+        try {
+            const { data, error } = await client.POST(
+                '/v1/saved-queries/{savedQueryId}/versions/{versionId}/restore',
+                { params: { path: { savedQueryId: savedQuery.id, versionId } } },
+            );
+            if (error || !data) {
+                toast.error('Restore failed.');
+                return;
+            }
+            toast.success(`Restored from version ${data.restored_from_version_number}.`);
+            onRestored();
+            await refresh();
+        } finally {
+            setPendingRestoreId(null);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+            <div className="flex h-[80vh] w-full max-w-4xl flex-col overflow-hidden rounded-lg bg-white shadow-xl">
+                <div className="flex items-center justify-between border-b border-outline-variant px-4 py-3">
+                    <div className="flex items-center gap-2">
+                        <History size={16} className="text-oxblood" />
+                        <div>
+                            <h2 className="text-base font-semibold text-on-surface">Version History</h2>
+                            <p className="text-xs text-slate-500">{savedQuery.name}</p>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="text-slate-500 hover:text-slate-800"
+                        aria-label="Close version history"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+
+                <div className="flex flex-1 overflow-hidden">
+                    <aside className="flex w-72 shrink-0 flex-col border-r border-outline-variant">
+                        <div className="flex-1 overflow-y-auto">
+                            {isLoading ? (
+                                <div className="flex h-32 items-center justify-center text-sm text-slate-500">
+                                    <Loader2 size={16} className="mr-2 animate-spin" />
+                                    Loading…
+                                </div>
+                            ) : errorMessage ? (
+                                <div className="m-4 rounded border border-red-200 bg-red-50 p-3 text-xs text-red-700">{errorMessage}</div>
+                            ) : versions.length === 0 ? (
+                                <div className="p-4 text-xs text-slate-500">No versions recorded yet.</div>
+                            ) : (
+                                <ul className="divide-y divide-outline-variant">
+                                    {versions.map((row) => {
+                                        const isSelected = row.id === selectedId;
+                                        return (
+                                            <li key={row.id}>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setSelectedId(row.id)}
+                                                    className={[
+                                                        'flex w-full flex-col gap-0.5 px-3 py-2 text-left text-xs transition-colors',
+                                                        isSelected ? 'bg-oxblood/5' : 'hover:bg-surface-container-low',
+                                                    ].join(' ')}
+                                                >
+                                                    <div className="flex items-center justify-between gap-2">
+                                                        <span className="font-mono text-[11px] font-semibold text-on-surface">
+                                                            v{row.version_number}
+                                                        </span>
+                                                        <span className="text-[10px] text-slate-500">{formatTimestamp(row.created_at)}</span>
+                                                    </div>
+                                                    {row.change_summary && (
+                                                        <span className="text-[11px] text-slate-600">{row.change_summary}</span>
+                                                    )}
+                                                    {row.created_by_user_id && (
+                                                        <span className="font-mono text-[10px] text-slate-400">
+                                                            {row.created_by_user_id.slice(0, 8)}…
+                                                        </span>
+                                                    )}
+                                                </button>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            )}
+                        </div>
+                    </aside>
+
+                    <section className="flex flex-1 flex-col overflow-hidden">
+                        {selectedVersion ? (
+                            <>
+                                <div className="flex items-center justify-between border-b border-outline-variant px-4 py-2">
+                                    <div className="text-xs text-slate-600">
+                                        <span className="font-mono text-[11px] font-semibold text-on-surface">
+                                            v{selectedVersion.version_number}
+                                        </span>
+                                        <span className="ml-2 text-slate-500">{formatTimestamp(selectedVersion.created_at)}</span>
+                                    </div>
+                                    {canRestore && (
+                                        <button
+                                            type="button"
+                                            onClick={() => void handleRestore(selectedVersion.id)}
+                                            disabled={pendingRestoreId === selectedVersion.id}
+                                            className="flex items-center gap-1 rounded bg-oxblood px-3 py-1 text-xs font-medium text-white hover:bg-oxblood-soft disabled:cursor-not-allowed disabled:opacity-50"
+                                        >
+                                            {pendingRestoreId === selectedVersion.id ? (
+                                                <Loader2 size={12} className="animate-spin" />
+                                            ) : (
+                                                <RotateCcw size={12} />
+                                            )}
+                                            Restore this version
+                                        </button>
+                                    )}
+                                </div>
+                                <div className="grid flex-1 grid-cols-2 overflow-hidden">
+                                    <div className="flex flex-col overflow-hidden border-r border-outline-variant">
+                                        <div className="border-b border-outline-variant bg-surface-container-low px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                                            Current
+                                        </div>
+                                        <pre className="flex-1 overflow-auto whitespace-pre-wrap break-words bg-white p-3 font-mono text-[11px] leading-relaxed text-slate-800">
+                                            {savedQuery.sql}
+                                        </pre>
+                                    </div>
+                                    <div className="flex flex-col overflow-hidden">
+                                        <div className="border-b border-outline-variant bg-surface-container-low px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                                            v{selectedVersion.version_number}
+                                            {savedQuery.sql === selectedVersion.sql && (
+                                                <span className="ml-2 font-normal normal-case tracking-normal text-emerald-600">matches current</span>
+                                            )}
+                                        </div>
+                                        <pre className="flex-1 overflow-auto whitespace-pre-wrap break-words bg-white p-3 font-mono text-[11px] leading-relaxed text-slate-800">
+                                            {selectedVersion.sql}
+                                        </pre>
+                                    </div>
+                                </div>
+                            </>
+                        ) : (
+                            <div className="flex flex-1 items-center justify-center text-sm text-slate-500">
+                                Select a version on the left to compare.
+                            </div>
+                        )}
+                    </section>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -2452,6 +2452,111 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/saved-queries/{savedQueryId}/versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List revisions of a saved query (newest first) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Version list */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQueryVersionListResponse"];
+                    };
+                };
+                /** @description Caller does not have access to this saved query */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Saved query not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/saved-queries/{savedQueryId}/versions/{versionId}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Restore a saved query to a previous version (owner-only) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                    versionId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Restored. Body includes the new live row plus the version that was just appended. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQueryRestoreResponse"];
+                    };
+                };
+                /** @description Caller is not the owner */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Saved query or version not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/query/sessions": {
         parameters: {
             query?: never;
@@ -4211,6 +4316,34 @@ export interface components {
             /** @enum {string} */
             visibility: "private" | "shared";
             shares: components["schemas"]["SavedQueryShareRecord"][];
+        };
+        SavedQueryVersion: {
+            id: string;
+            saved_query_id: string;
+            version_number: number;
+            name: string;
+            description?: string | null;
+            data_source_id: string;
+            sql: string;
+            default_run_params: {
+                [key: string]: unknown;
+            };
+            parameter_schema: components["schemas"]["QueryParameter"][];
+            tags: string[];
+            /** @enum {string} */
+            visibility: "private" | "shared";
+            change_summary?: string | null;
+            created_by_user_id?: string | null;
+            /** Format: date-time */
+            created_at: string;
+        };
+        SavedQueryVersionListResponse: {
+            items: components["schemas"]["SavedQueryVersion"][];
+        };
+        SavedQueryRestoreResponse: {
+            saved_query: components["schemas"]["SavedQuery"];
+            restored_from_version_number: number;
+            new_version: components["schemas"]["SavedQueryVersion"];
         };
         SavedQueryShareResponse: {
             /** @enum {string} */

--- a/frontend/src/pages/SavedQueries.tsx
+++ b/frontend/src/pages/SavedQueries.tsx
@@ -8,6 +8,7 @@ import {
     FileText,
     Filter,
     Globe,
+    History,
     Loader2,
     Lock,
     MoreVertical,
@@ -24,6 +25,7 @@ import { useDataSource } from '../hooks/useDataSource';
 import { useSavedQueries } from '../hooks/useSavedQueries';
 import { SaveQueryDialog, type SaveQueryDialogValues } from '../components/Query/SaveQueryDialog';
 import { ShareSavedQueryDialog } from '../components/Query/ShareSavedQueryDialog';
+import { VersionHistoryDialog } from '../components/Query/VersionHistoryDialog';
 import type { SavedQuery } from '../components/Query/types';
 
 type FilterMode = 'current' | 'all';
@@ -54,6 +56,7 @@ export const SavedQueries = () => {
     } = useSavedQueries();
 
     const [sharingQuery, setSharingQuery] = useState<SavedQuery | null>(null);
+    const [historyQuery, setHistoryQuery] = useState<SavedQuery | null>(null);
 
     const [searchText, setSearchText] = useState('');
     const [filterMode, setFilterMode] = useState<FilterMode>('all');
@@ -391,6 +394,14 @@ export const SavedQueries = () => {
                                     <div className="flex gap-1">
                                         <button
                                             type="button"
+                                            onClick={() => setHistoryQuery(selectedQuery)}
+                                            className="rounded border border-transparent p-1.5 text-slate-500 hover:border-outline-variant hover:bg-surface-container-low hover:text-on-surface"
+                                            title="Version history"
+                                        >
+                                            <History size={16} />
+                                        </button>
+                                        <button
+                                            type="button"
                                             onClick={() => void handleDuplicate(selectedQuery)}
                                             disabled={pendingId === selectedQuery.id}
                                             className="rounded border border-transparent p-1.5 text-slate-500 hover:border-outline-variant hover:bg-surface-container-low hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
@@ -551,6 +562,16 @@ export const SavedQueries = () => {
                     isOpen
                     onClose={() => setSharingQuery(null)}
                     onUpdated={() => { void refresh(); }}
+                />
+            )}
+
+            {historyQuery && (
+                <VersionHistoryDialog
+                    savedQuery={historyQuery}
+                    canRestore={currentUserId === historyQuery.owner_id}
+                    isOpen
+                    onClose={() => setHistoryQuery(null)}
+                    onRestored={() => { void refresh(); }}
                 />
             )}
 


### PR DESCRIPTION
Closes #40.

## Summary
- **Storage** (migration `0025_saved_query_versions.sql`): new `saved_query_versions` table that stores a full snapshot per revision — name / description / sql / default_run_params / parameter_schema / tags / visibility / data_source_id — plus `version_number` (monotonic per query, UNIQUE-constrained), optional `change_summary`, `created_by_user_id`, and `created_at`. `data_source_id` is a plain UUID (no FK), so history survives a data-source move/delete.
- **Service** (new `savedQueryVersionService.js`): `recordVersion(savedQueryId, snapshot, { actorUserId, changeSummary })` claims the next version_number with a retry-on-unique-violation loop; `listVersions` returns newest-first; `getVersionById` for the restore path. `savedQueryService` now records a version on every successful create (`"created"`) and update (`"updated"`); restore is implemented in `savedQueryService.restoreSavedQueryVersion` which applies the snapshot via the existing UPDATE shape and appends a new version (`"restored from version N"`), so the timeline stays linear.
- **API**: `GET /v1/saved-queries/{id}/versions` (read-gated by caller access — owner, shared visibility, or explicit grant); `POST /v1/saved-queries/{id}/versions/{versionId}/restore` (owner-only; emits `saved_query.version.restored` audit event with `restored_from_version_number` + `new_version_number`).
- **Frontend**: new `VersionHistoryDialog` with a left-rail version list and a side-by-side SQL comparison against the current row. History button is exposed in the saved-queries side panel for anyone with write permission; the Restore button inside the dialog is gated to the owner.

## Test plan
- [x] `npm test` (189/189 passing; +4 new versioning tests covering create→v1, update→vN, owner-restore appends, non-owner forbidden, mismatched/missing version → 404)
- [x] `npx tsc -b` (frontend, clean)
- [x] `npm run lint` (frontend, clean)
- [x] `npm run build` (frontend, builds)
- [ ] Manual browser test deferred — please verify: (1) save a new query, open History, see v1 with "created" summary; (2) edit and save, History now shows two rows newest-first; (3) as the owner, click Restore on v1, confirm the live SQL flips back and v3 appears with "restored from version 1"; (4) as a non-owner with a `view` share, confirm you can open History but the Restore button is hidden.