### PR TITLE
QUERY-008 saved report foldering model

### DIFF
--- a/app/src/lib/routePolicy.js
+++ b/app/src/lib/routePolicy.js
@@ -91,6 +91,15 @@ const POLICIES = [
   { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+\/access$/, permission: "saved_queries.read" },
   { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+\/versions$/, permission: "saved_queries.read" },
   { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/versions\/[^/]+\/restore$/, permission: "saved_queries.write" },
+  // QUERY-008: foldering. CRUD on folders + the move endpoint share the
+  // saved_queries.write permission with create/update/delete on saved queries
+  // — there's no point being able to author a query but not file it. List is
+  // a read so viewers still see the tree shape if they have read access.
+  { method: "POST", pattern: /^\/v1\/saved-query-folders$/, permission: "saved_queries.write" },
+  { method: "GET", pattern: /^\/v1\/saved-query-folders$/, permission: "saved_queries.read" },
+  { method: "PUT", pattern: /^\/v1\/saved-query-folders\/[^/]+$/, permission: "saved_queries.write" },
+  { method: "DELETE", pattern: /^\/v1\/saved-query-folders\/[^/]+$/, permission: "saved_queries.write" },
+  { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/move$/, permission: "saved_queries.write" },
   { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.read" },
   { method: "PUT", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.write" },
   { method: "DELETE", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.write" },

--- a/app/src/routes/savedQueryFolders.js
+++ b/app/src/routes/savedQueryFolders.js
@@ -1,0 +1,61 @@
+const { json, readJsonBody } = require("../lib/http");
+const savedQueryFolderService = require("../services/savedQueryFolderService");
+
+function callerId(req) {
+  return (req.user && req.user.id) || null;
+}
+
+function writeResult(res, result) {
+  return json(res, result.statusCode, result.body);
+}
+
+async function handleCreateSavedQueryFolder(req, res) {
+  const body = await readJsonBody(req);
+  const result = await savedQueryFolderService.createFolder({
+    ownerId: callerId(req),
+    name: body.name,
+    parentId: body.parent_id
+  });
+  return writeResult(res, result);
+}
+
+async function handleListSavedQueryFolders(req, res) {
+  const result = await savedQueryFolderService.listFolders({
+    ownerId: callerId(req)
+  });
+  return writeResult(res, result);
+}
+
+async function handleUpdateSavedQueryFolder(req, res, folderId) {
+  const body = await readJsonBody(req);
+  const result = await savedQueryFolderService.updateFolder(folderId, {
+    ownerId: callerId(req),
+    name: body.name,
+    parentId: body.parent_id
+  });
+  return writeResult(res, result);
+}
+
+async function handleDeleteSavedQueryFolder(req, res, folderId) {
+  const result = await savedQueryFolderService.deleteFolder(folderId, {
+    ownerId: callerId(req)
+  });
+  return writeResult(res, result);
+}
+
+async function handleMoveSavedQuery(req, res, savedQueryId) {
+  const body = await readJsonBody(req);
+  const result = await savedQueryFolderService.moveSavedQuery(savedQueryId, {
+    ownerId: callerId(req),
+    folderId: body.folder_id
+  });
+  return writeResult(res, result);
+}
+
+module.exports = {
+  handleCreateSavedQueryFolder,
+  handleListSavedQueryFolders,
+  handleUpdateSavedQueryFolder,
+  handleDeleteSavedQueryFolder,
+  handleMoveSavedQuery
+};

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -58,6 +58,13 @@ const {
   handleRestoreSavedQueryVersion
 } = require("./routes/savedQueries");
 const {
+  handleCreateSavedQueryFolder,
+  handleListSavedQueryFolders,
+  handleUpdateSavedQueryFolder,
+  handleDeleteSavedQueryFolder,
+  handleMoveSavedQuery
+} = require("./routes/savedQueryFolders");
+const {
   handleExportSession,
   handleExportDeliver,
   handleExportStatus
@@ -462,6 +469,30 @@ async function routeRequest(req, res) {
   const savedQueryRestoreMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/versions\/([^/]+)\/restore$/);
   if (req.method === "POST" && savedQueryRestoreMatch) {
     return handleRestoreSavedQueryVersion(req, res, savedQueryRestoreMatch[1], savedQueryRestoreMatch[2]);
+  }
+
+  // QUERY-008: saved-query foldering. The /move route on a saved-query id
+  // lives here so it's matched before the generic /v1/saved-queries/:id
+  // catch-all below. Folder CRUD is a sibling resource.
+  const savedQueryMoveMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/move$/);
+  if (req.method === "POST" && savedQueryMoveMatch) {
+    return handleMoveSavedQuery(req, res, savedQueryMoveMatch[1]);
+  }
+
+  if (req.method === "POST" && pathname === "/v1/saved-query-folders") {
+    return handleCreateSavedQueryFolder(req, res);
+  }
+
+  if (req.method === "GET" && pathname === "/v1/saved-query-folders") {
+    return handleListSavedQueryFolders(req, res);
+  }
+
+  const savedQueryFolderMatch = pathname.match(/^\/v1\/saved-query-folders\/([^/]+)$/);
+  if (req.method === "PUT" && savedQueryFolderMatch) {
+    return handleUpdateSavedQueryFolder(req, res, savedQueryFolderMatch[1]);
+  }
+  if (req.method === "DELETE" && savedQueryFolderMatch) {
+    return handleDeleteSavedQueryFolder(req, res, savedQueryFolderMatch[1]);
   }
 
   const savedQueryMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)$/);

--- a/app/src/services/savedQueryFolderService.js
+++ b/app/src/services/savedQueryFolderService.js
@@ -1,0 +1,438 @@
+// QUERY-008: folder organisation for saved reports.
+//
+// Folders are per-owner; non-owners do not see them (a saved query shared
+// org-wide still appears in the recipient's library via the existing
+// list query — it just isn't filed under the recipient's folder tree).
+//
+// Hierarchy rules enforced here:
+//   * parent_id must belong to the same owner.
+//   * A folder cannot be its own parent.
+//   * Moving a folder into one of its own descendants is rejected.
+//   * Sibling-name collisions (case-insensitive) are rejected with 409.
+//   * Folder depth is capped at MAX_FOLDER_DEPTH to keep the sidebar shallow.
+//
+// Folder-delete policy (chosen: REASSIGN):
+//   When a folder is deleted, its direct children — both child folders and
+//   any saved queries that pointed at it — are reparented to the deleted
+//   folder's parent (NULL if it was a root folder). The reparent + delete
+//   happen in a single transaction so the move is atomic.
+
+const appDb = require("../lib/appDb");
+const { isUuid, isPgUniqueViolation } = require("../lib/validation");
+
+const FOLDER_NAME_MAX_LENGTH = 120;
+const MAX_FOLDER_DEPTH = 10;
+
+const FOLDER_COLUMNS = `
+  id,
+  owner_id,
+  parent_id,
+  name,
+  created_at,
+  updated_at
+`;
+
+function success(body, statusCode = 200) {
+  return { ok: true, statusCode, body };
+}
+
+function failure(statusCode, body) {
+  return { ok: false, statusCode, body };
+}
+
+function normalizeName(value) {
+  if (typeof value !== "string") return "";
+  return value.trim();
+}
+
+function normalizeParentId(value) {
+  if (value === undefined) return { ok: true, value: undefined };
+  if (value === null) return { ok: true, value: null };
+  if (typeof value === "string" && value.trim() === "") return { ok: true, value: null };
+  if (typeof value !== "string" || !isUuid(value)) {
+    return { ok: false, message: "parent_id must be a UUID or null" };
+  }
+  return { ok: true, value };
+}
+
+async function loadFolder(folderId) {
+  if (!isUuid(folderId)) return null;
+  const result = await appDb.query(
+    `SELECT ${FOLDER_COLUMNS} FROM saved_query_folders WHERE id = $1`,
+    [folderId]
+  );
+  return result.rows[0] || null;
+}
+
+// Returns the path from root → folder as an array of ids (inclusive).
+// Used both for depth checking and cycle detection on move.
+async function loadAncestorChain(folderId) {
+  if (!isUuid(folderId)) return [];
+  const result = await appDb.query(
+    `
+      WITH RECURSIVE chain AS (
+        SELECT id, parent_id, 1 AS depth
+          FROM saved_query_folders
+         WHERE id = $1
+        UNION ALL
+        SELECT f.id, f.parent_id, c.depth + 1
+          FROM saved_query_folders f
+          JOIN chain c ON c.parent_id = f.id
+         WHERE c.depth < $2
+      )
+      SELECT id FROM chain
+    `,
+    [folderId, MAX_FOLDER_DEPTH + 1]
+  );
+  // Result is leaf-first; return as-is (callers only care about membership + length).
+  return result.rows.map((row) => row.id);
+}
+
+async function isDescendantOf(candidateId, ancestorId) {
+  // True if `candidateId` lives somewhere under `ancestorId`.
+  if (!isUuid(candidateId) || !isUuid(ancestorId)) return false;
+  if (candidateId === ancestorId) return true;
+  const result = await appDb.query(
+    `
+      WITH RECURSIVE subtree AS (
+        SELECT id FROM saved_query_folders WHERE id = $1
+        UNION ALL
+        SELECT f.id FROM saved_query_folders f
+          JOIN subtree s ON f.parent_id = s.id
+      )
+      SELECT 1 FROM subtree WHERE id = $2 LIMIT 1
+    `,
+    [ancestorId, candidateId]
+  );
+  return result.rowCount > 0;
+}
+
+async function validateParent(ownerId, parentId, { folderBeingMoved = null } = {}) {
+  if (parentId === null || parentId === undefined) {
+    return { ok: true, value: null };
+  }
+  const parent = await loadFolder(parentId);
+  if (!parent) {
+    return { ok: false, statusCode: 404, message: "parent_id folder not found" };
+  }
+  if (parent.owner_id !== ownerId) {
+    return { ok: false, statusCode: 403, message: "parent_id belongs to another owner" };
+  }
+  if (folderBeingMoved) {
+    if (parent.id === folderBeingMoved) {
+      return { ok: false, statusCode: 400, message: "A folder cannot be its own parent" };
+    }
+    // Reject moves into the folder's own subtree to prevent cycles.
+    if (await isDescendantOf(parent.id, folderBeingMoved)) {
+      return {
+        ok: false,
+        statusCode: 400,
+        message: "Cannot move a folder under one of its own descendants"
+      };
+    }
+  }
+  // Depth guard: chain length to root + 1 (for the new folder) must not
+  // exceed the cap.
+  const ancestors = await loadAncestorChain(parent.id);
+  if (ancestors.length >= MAX_FOLDER_DEPTH) {
+    return {
+      ok: false,
+      statusCode: 400,
+      message: `Folder depth cannot exceed ${MAX_FOLDER_DEPTH}`
+    };
+  }
+  return { ok: true, value: parent.id };
+}
+
+async function createFolder({ ownerId, name, parentId }) {
+  const ownerTrimmed = String(ownerId || "").trim();
+  if (!ownerTrimmed) {
+    return failure(401, { error: "unauthenticated" });
+  }
+  const folderName = normalizeName(name);
+  if (!folderName) {
+    return failure(400, { error: "bad_request", message: "name is required" });
+  }
+  if (folderName.length > FOLDER_NAME_MAX_LENGTH) {
+    return failure(400, {
+      error: "bad_request",
+      message: `name cannot exceed ${FOLDER_NAME_MAX_LENGTH} characters`
+    });
+  }
+  const parentValidation = normalizeParentId(parentId);
+  if (!parentValidation.ok) {
+    return failure(400, { error: "bad_request", message: parentValidation.message });
+  }
+  const parentCheck = await validateParent(ownerTrimmed, parentValidation.value);
+  if (!parentCheck.ok) {
+    return failure(parentCheck.statusCode, { error: "bad_request", message: parentCheck.message });
+  }
+
+  try {
+    const insertResult = await appDb.query(
+      `
+        INSERT INTO saved_query_folders (owner_id, parent_id, name)
+        VALUES ($1, $2, $3)
+        RETURNING ${FOLDER_COLUMNS}
+      `,
+      [ownerTrimmed, parentCheck.value, folderName]
+    );
+    return success(insertResult.rows[0], 201);
+  } catch (err) {
+    if (isPgUniqueViolation(err)) {
+      return failure(409, {
+        error: "conflict",
+        message: "A folder with that name already exists at this level"
+      });
+    }
+    throw err;
+  }
+}
+
+async function listFolders({ ownerId }) {
+  const ownerTrimmed = String(ownerId || "").trim();
+  if (!ownerTrimmed) {
+    return failure(401, { error: "unauthenticated" });
+  }
+  const result = await appDb.query(
+    `
+      SELECT ${FOLDER_COLUMNS}
+        FROM saved_query_folders
+       WHERE owner_id = $1
+       ORDER BY (parent_id IS NULL) DESC, lower(name) ASC
+    `,
+    [ownerTrimmed]
+  );
+  const rows = result.rows;
+
+  // Tree shape: same rows, nested for callers (sidebar) that want a ready
+  // tree. Each node carries a `children` array of folder nodes. Saved-query
+  // membership lives on the saved-queries response (`folder_id`), so the
+  // sidebar can join them in a single render pass.
+  const byId = new Map();
+  for (const row of rows) {
+    byId.set(row.id, { ...row, children: [] });
+  }
+  const tree = [];
+  for (const row of rows) {
+    const node = byId.get(row.id);
+    if (row.parent_id && byId.has(row.parent_id)) {
+      byId.get(row.parent_id).children.push(node);
+    } else {
+      tree.push(node);
+    }
+  }
+
+  return success({ items: rows, tree });
+}
+
+async function updateFolder(folderId, { ownerId, name, parentId }) {
+  if (!isUuid(folderId)) {
+    return failure(400, { error: "bad_request", message: "folderId must be a valid UUID" });
+  }
+  const ownerTrimmed = String(ownerId || "").trim();
+  if (!ownerTrimmed) {
+    return failure(401, { error: "unauthenticated" });
+  }
+  const existing = await loadFolder(folderId);
+  if (!existing) {
+    return failure(404, { error: "not_found", message: "Folder not found" });
+  }
+  if (existing.owner_id !== ownerTrimmed) {
+    return failure(403, { error: "forbidden", message: "Only the owner can update this folder" });
+  }
+
+  let nextName = existing.name;
+  if (name !== undefined) {
+    nextName = normalizeName(name);
+    if (!nextName) {
+      return failure(400, { error: "bad_request", message: "name cannot be empty" });
+    }
+    if (nextName.length > FOLDER_NAME_MAX_LENGTH) {
+      return failure(400, {
+        error: "bad_request",
+        message: `name cannot exceed ${FOLDER_NAME_MAX_LENGTH} characters`
+      });
+    }
+  }
+
+  let nextParentId = existing.parent_id;
+  if (parentId !== undefined) {
+    const parentValidation = normalizeParentId(parentId);
+    if (!parentValidation.ok) {
+      return failure(400, { error: "bad_request", message: parentValidation.message });
+    }
+    const parentCheck = await validateParent(ownerTrimmed, parentValidation.value, {
+      folderBeingMoved: folderId
+    });
+    if (!parentCheck.ok) {
+      return failure(parentCheck.statusCode, { error: "bad_request", message: parentCheck.message });
+    }
+    nextParentId = parentCheck.value;
+  }
+
+  try {
+    const updateResult = await appDb.query(
+      `
+        UPDATE saved_query_folders
+           SET name = $2,
+               parent_id = $3,
+               updated_at = NOW()
+         WHERE id = $1
+         RETURNING ${FOLDER_COLUMNS}
+      `,
+      [folderId, nextName, nextParentId]
+    );
+    if (updateResult.rowCount === 0) {
+      return failure(404, { error: "not_found", message: "Folder not found" });
+    }
+    return success(updateResult.rows[0]);
+  } catch (err) {
+    if (isPgUniqueViolation(err)) {
+      return failure(409, {
+        error: "conflict",
+        message: "A folder with that name already exists at this level"
+      });
+    }
+    throw err;
+  }
+}
+
+async function deleteFolder(folderId, { ownerId }) {
+  if (!isUuid(folderId)) {
+    return failure(400, { error: "bad_request", message: "folderId must be a valid UUID" });
+  }
+  const ownerTrimmed = String(ownerId || "").trim();
+  if (!ownerTrimmed) {
+    return failure(401, { error: "unauthenticated" });
+  }
+  const existing = await loadFolder(folderId);
+  if (!existing) {
+    return failure(404, { error: "not_found", message: "Folder not found" });
+  }
+  if (existing.owner_id !== ownerTrimmed) {
+    return failure(403, { error: "forbidden", message: "Only the owner can delete this folder" });
+  }
+
+  // REASSIGN policy: reparent direct children (sub-folders + saved queries)
+  // to the deleted folder's parent, then delete the folder itself. Done in
+  // a single transaction so a partial failure doesn't leave the tree
+  // half-rewritten.
+  const reassignedTo = existing.parent_id; // may be null (root)
+  const summary = await appDb.withTransaction(async (client) => {
+    const childFolders = await client.query(
+      `
+        UPDATE saved_query_folders
+           SET parent_id = $2,
+               updated_at = NOW()
+         WHERE parent_id = $1
+         RETURNING id
+      `,
+      [folderId, reassignedTo]
+    );
+    const childQueries = await client.query(
+      `
+        UPDATE saved_queries
+           SET folder_id = $2,
+               updated_at = NOW()
+         WHERE folder_id = $1
+         RETURNING id
+      `,
+      [folderId, reassignedTo]
+    );
+    await client.query(
+      `DELETE FROM saved_query_folders WHERE id = $1`,
+      [folderId]
+    );
+    return {
+      reassigned_to: reassignedTo,
+      reassigned_folder_ids: childFolders.rows.map((row) => row.id),
+      reassigned_saved_query_ids: childQueries.rows.map((row) => row.id)
+    };
+  });
+
+  return success({ ok: true, id: folderId, ...summary });
+}
+
+// QUERY-008: move a saved query into a folder (or to root). Returns the
+// updated saved-query row plus the resolved folder reference so the sidebar
+// tree can patch state without a follow-up GET.
+async function moveSavedQuery(savedQueryId, { ownerId, folderId }) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+  const ownerTrimmed = String(ownerId || "").trim();
+  if (!ownerTrimmed) {
+    return failure(401, { error: "unauthenticated" });
+  }
+  const folderValidation = normalizeParentId(folderId);
+  if (!folderValidation.ok) {
+    return failure(400, { error: "bad_request", message: folderValidation.message.replace("parent_id", "folder_id") });
+  }
+
+  // Load the saved query and verify ownership. Folders are per-owner so a
+  // recipient of a share grant cannot relocate someone else's query.
+  const queryRow = await appDb.query(
+    `SELECT id, owner_id, folder_id FROM saved_queries WHERE id = $1`,
+    [savedQueryId]
+  );
+  if (queryRow.rowCount === 0) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  const savedQuery = queryRow.rows[0];
+  if (savedQuery.owner_id !== ownerTrimmed) {
+    return failure(403, { error: "forbidden", message: "Only the owner can move this saved query" });
+  }
+
+  let resolvedFolderId = null;
+  if (folderValidation.value) {
+    const folder = await loadFolder(folderValidation.value);
+    if (!folder) {
+      return failure(404, { error: "not_found", message: "folder_id not found" });
+    }
+    if (folder.owner_id !== ownerTrimmed) {
+      return failure(403, { error: "forbidden", message: "folder_id belongs to another owner" });
+    }
+    resolvedFolderId = folder.id;
+  }
+
+  const updateResult = await appDb.query(
+    `
+      UPDATE saved_queries
+         SET folder_id = $2,
+             updated_at = NOW()
+       WHERE id = $1
+       RETURNING
+         id,
+         owner_id,
+         name,
+         description,
+         data_source_id,
+         sql,
+         default_run_params,
+         parameter_schema,
+         tags,
+         visibility,
+         folder_id,
+         created_at,
+         updated_at
+    `,
+    [savedQueryId, resolvedFolderId]
+  );
+
+  return success({
+    saved_query: updateResult.rows[0],
+    previous_folder_id: savedQuery.folder_id || null,
+    folder_id: resolvedFolderId
+  });
+}
+
+module.exports = {
+  createFolder,
+  listFolders,
+  updateFolder,
+  deleteFolder,
+  moveSavedQuery,
+  FOLDER_NAME_MAX_LENGTH,
+  MAX_FOLDER_DEPTH
+};

--- a/app/src/services/savedQueryService.js
+++ b/app/src/services/savedQueryService.js
@@ -44,6 +44,7 @@ const SAVED_QUERY_COLUMNS = `
   parameter_schema,
   tags,
   visibility,
+  folder_id,
   created_at,
   updated_at
 `;

--- a/app/test/savedQueriesApi.test.js
+++ b/app/test/savedQueriesApi.test.js
@@ -181,6 +181,7 @@ before(async () => {
         parameter_schema: JSON.parse(parameterSchemaJson),
         tags: Array.isArray(tags) ? tags : [],
         visibility: visibility || "private",
+        folder_id: null,
         created_at: now,
         updated_at: now
       };
@@ -190,7 +191,7 @@ before(async () => {
 
     // Caller-aware list (the new QUERY-006 variant) — restricts to
     // owner + visibility='shared' + explicit grant.
-    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, created_at, updated_at from saved_queries sq where ($1::uuid is null or sq.data_source_id = $1::uuid)")) {
+    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, folder_id, created_at, updated_at from saved_queries sq where ($1::uuid is null or sq.data_source_id = $1::uuid)")) {
       const [dataSourceId, tagFilter, callerUserId] = params;
       const rows = sortSavedQueries(
         [...savedQueries.values()].filter((entry) => {
@@ -205,7 +206,7 @@ before(async () => {
       return { rowCount: rows.length, rows };
     }
 
-    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, created_at, updated_at from saved_queries where ($1::uuid is null or data_source_id = $1::uuid)")) {
+    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, folder_id, created_at, updated_at from saved_queries where ($1::uuid is null or data_source_id = $1::uuid)")) {
       const [dataSourceId, tagFilter] = params;
       const rows = sortSavedQueries(
         [...savedQueries.values()].filter((entry) => {
@@ -221,7 +222,7 @@ before(async () => {
       return { rowCount: rows.length, rows };
     }
 
-    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, created_at, updated_at from saved_queries where id = $1")) {
+    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, folder_id, created_at, updated_at from saved_queries where id = $1")) {
       const [id] = params;
       const row = savedQueries.get(id);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };

--- a/app/test/savedQueryFoldersApi.test.js
+++ b/app/test/savedQueryFoldersApi.test.js
@@ -1,0 +1,662 @@
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+process.env.PORT = "0";
+process.env.AUTH_COOKIE_SECURE = "false";
+
+const appDb = require("../src/lib/appDb");
+const dbAdapterFactory = require("../src/adapters/dbAdapterFactory");
+const { createAuthTestStub } = require("./helpers/authTestStub");
+
+const DATA_SOURCE_ID = "00000000-0000-4000-8000-000000000111";
+
+let server;
+let baseUrl;
+let savedQueries;
+let savedQueryVersions;
+let folders;
+let savedQueryCounter;
+let folderCounter;
+let savedQueryVersionCounter;
+let originalQuery;
+let originalWithTransaction;
+let originalCreateDatabaseAdapter;
+let originalIsSupportedDbType;
+let authStub;
+const testUsers = {};
+
+function nextSavedQueryId() {
+  savedQueryCounter += 1;
+  return `00000000-0000-4000-8000-${String(savedQueryCounter).padStart(12, "0")}`;
+}
+
+function nextFolderId() {
+  folderCounter += 1;
+  return `00000000-0000-4000-8000-ffff${String(folderCounter).padStart(8, "0")}`;
+}
+
+function nextVersionId() {
+  savedQueryVersionCounter += 1;
+  return `00000000-0000-4000-8000-cccc${String(savedQueryVersionCounter).padStart(8, "0")}`;
+}
+
+function normalizeSql(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function duplicateError() {
+  const err = new Error("duplicate key value violates unique constraint");
+  err.code = "23505";
+  return err;
+}
+
+function ensureTestUser(label, role = "analyst") {
+  if (testUsers[label]) return testUsers[label];
+  const user = authStub.seedUser({
+    email: `${label}@example.com`,
+    roles: [role],
+    dataSourceAccess: [DATA_SOURCE_ID]
+  });
+  const cookie = authStub.cookieFor(authStub.seedSession(user.id).token);
+  testUsers[label] = { id: user.id, cookie, role };
+  return testUsers[label];
+}
+
+function userId(label) {
+  return ensureTestUser(label).id;
+}
+
+async function api(method, path, body, label = "test-user", { role = "analyst" } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (label !== null) {
+    const fixture = ensureTestUser(label, role);
+    headers.Cookie = fixture.cookie;
+  }
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+  return { status: response.status, payload };
+}
+
+// In-memory implementation of the SQL surface area used by the folder
+// service. We share the same `savedQueries` map so the move endpoint can
+// flip the `folder_id` column.
+function buildSqlHandler() {
+  return async (sql, params = []) => {
+    const auth = authStub.handleSql(sql, params);
+    if (auth) return auth;
+
+    const normalized = normalizeSql(sql);
+
+    if (normalized === "select id from data_sources where id = $1") {
+      const [id] = params;
+      if (id === DATA_SOURCE_ID) return { rowCount: 1, rows: [{ id }] };
+      return { rowCount: 0, rows: [] };
+    }
+
+    if (normalized === "select data_source_id from saved_queries where id = $1") {
+      const [id] = params;
+      const row = savedQueries.get(id);
+      return row
+        ? { rowCount: 1, rows: [{ data_source_id: row.data_source_id }] }
+        : { rowCount: 0, rows: [] };
+    }
+
+    if (normalized === "select id, owner_id, folder_id from saved_queries where id = $1") {
+      const [id] = params;
+      const row = savedQueries.get(id);
+      return row
+        ? { rowCount: 1, rows: [{ id: row.id, owner_id: row.owner_id, folder_id: row.folder_id || null }] }
+        : { rowCount: 0, rows: [] };
+    }
+
+    if (normalized.startsWith("insert into saved_queries")) {
+      const [ownerId, name, description, dataSourceId, querySql, defaultRunParamsJson, parameterSchemaJson, tags, visibility] = params;
+      const duplicate = [...savedQueries.values()].find((entry) => (
+        entry.owner_id === ownerId
+        && entry.data_source_id === dataSourceId
+        && entry.name.toLowerCase() === String(name).toLowerCase()
+      ));
+      if (duplicate) throw duplicateError();
+      const now = new Date().toISOString();
+      const row = {
+        id: nextSavedQueryId(),
+        owner_id: ownerId,
+        name,
+        description,
+        data_source_id: dataSourceId,
+        sql: querySql,
+        default_run_params: JSON.parse(defaultRunParamsJson),
+        parameter_schema: JSON.parse(parameterSchemaJson),
+        tags: Array.isArray(tags) ? tags : [],
+        visibility: visibility || "private",
+        folder_id: null,
+        created_at: now,
+        updated_at: now
+      };
+      savedQueries.set(row.id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, folder_id, created_at, updated_at from saved_queries sq where ($1::uuid is null or sq.data_source_id = $1::uuid)")) {
+      const [dataSourceId, tagFilter, callerUserId] = params;
+      const rows = [...savedQueries.values()].filter((entry) => {
+        if (dataSourceId && entry.data_source_id !== dataSourceId) return false;
+        if (tagFilter && !(entry.tags || []).includes(tagFilter)) return false;
+        if (entry.owner_id === callerUserId) return true;
+        if (entry.visibility === "shared") return true;
+        return false;
+      });
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith("select id, owner_id, name, description, data_source_id, sql, default_run_params, parameter_schema, tags, visibility, folder_id, created_at, updated_at from saved_queries where id = $1")) {
+      const [id] = params;
+      const row = savedQueries.get(id);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    // Move endpoint: UPDATE WHERE id = $1 (single-row) — RETURNING includes
+    // folder_id. The bulk WHERE folder_id = $1 form used by the delete path
+    // has its own matcher below.
+    if (normalized.startsWith("update saved_queries set folder_id = $2, updated_at = now() where id = $1")) {
+      const [id, folderId] = params;
+      const existing = savedQueries.get(id);
+      if (!existing) return { rowCount: 0, rows: [] };
+      const updated = { ...existing, folder_id: folderId, updated_at: new Date().toISOString() };
+      savedQueries.set(id, updated);
+      return { rowCount: 1, rows: [updated] };
+    }
+
+    if (normalized.startsWith("update saved_queries set folder_id = $2, updated_at = now() where folder_id = $1")) {
+      const [oldFolderId, newFolderId] = params;
+      const ids = [];
+      for (const row of savedQueries.values()) {
+        if (row.folder_id === oldFolderId) {
+          row.folder_id = newFolderId || null;
+          row.updated_at = new Date().toISOString();
+          ids.push({ id: row.id });
+        }
+      }
+      return { rowCount: ids.length, rows: ids };
+    }
+
+    if (normalized.startsWith("delete from saved_queries where id = $1 returning id")) {
+      const [id] = params;
+      if (!savedQueries.has(id)) return { rowCount: 0, rows: [] };
+      savedQueries.delete(id);
+      return { rowCount: 1, rows: [{ id }] };
+    }
+
+    // Version-service writes (savedQueryService records a v1 on create).
+    if (normalized.startsWith("select coalesce(max(version_number), 0) as max_version from saved_query_versions where saved_query_id = $1")) {
+      const [savedQueryId] = params;
+      const maxVersion = [...savedQueryVersions.values()]
+        .filter((row) => row.saved_query_id === savedQueryId)
+        .reduce((max, row) => Math.max(max, row.version_number), 0);
+      return { rowCount: 1, rows: [{ max_version: maxVersion }] };
+    }
+    if (normalized.startsWith("insert into saved_query_versions")) {
+      const [savedQueryId, versionNumber, name, description, dataSourceId, sqlText, defaultRunParamsJson, parameterSchemaJson, tags, visibility, changeSummary, createdByUserId] = params;
+      const now = new Date().toISOString();
+      const row = {
+        id: nextVersionId(),
+        saved_query_id: savedQueryId,
+        version_number: versionNumber,
+        name,
+        description,
+        data_source_id: dataSourceId,
+        sql: sqlText,
+        default_run_params: JSON.parse(defaultRunParamsJson),
+        parameter_schema: JSON.parse(parameterSchemaJson),
+        tags: Array.isArray(tags) ? tags : [],
+        visibility: visibility || "private",
+        change_summary: changeSummary,
+        created_by_user_id: createdByUserId,
+        created_at: now
+      };
+      savedQueryVersions.set(row.id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+
+    // ---- Folder SQL ---------------------------------------------------------
+
+    if (normalized.startsWith("select id, owner_id, parent_id, name, created_at, updated_at from saved_query_folders where id = $1")) {
+      const [id] = params;
+      const row = folders.get(id);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    if (normalized.startsWith("insert into saved_query_folders")) {
+      const [ownerId, parentId, name] = params;
+      // Mirror the partial UNIQUE indexes for sibling-name collisions.
+      const duplicate = [...folders.values()].find((entry) => (
+        entry.owner_id === ownerId
+        && (entry.parent_id || null) === (parentId || null)
+        && entry.name.toLowerCase() === String(name).toLowerCase()
+      ));
+      if (duplicate) throw duplicateError();
+      const now = new Date().toISOString();
+      const row = {
+        id: nextFolderId(),
+        owner_id: ownerId,
+        parent_id: parentId || null,
+        name,
+        created_at: now,
+        updated_at: now
+      };
+      folders.set(row.id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (normalized.startsWith("select id, owner_id, parent_id, name, created_at, updated_at from saved_query_folders where owner_id = $1")) {
+      const [ownerId] = params;
+      const rows = [...folders.values()]
+        .filter((entry) => entry.owner_id === ownerId)
+        .sort((a, b) => {
+          const aRoot = a.parent_id == null ? 0 : 1;
+          const bRoot = b.parent_id == null ? 0 : 1;
+          if (aRoot !== bRoot) return aRoot - bRoot;
+          return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+        });
+      return { rowCount: rows.length, rows };
+    }
+
+    // Ancestor / descendant walks issued by the folder service.
+    if (normalized.startsWith("with recursive chain as")) {
+      const [folderId] = params;
+      const chain = [];
+      let cursor = folders.get(folderId);
+      let safety = 0;
+      while (cursor && safety < 100) {
+        chain.push({ id: cursor.id });
+        if (!cursor.parent_id) break;
+        cursor = folders.get(cursor.parent_id);
+        safety += 1;
+      }
+      return { rowCount: chain.length, rows: chain };
+    }
+
+    if (normalized.startsWith("with recursive subtree as")) {
+      const [ancestorId, candidateId] = params;
+      const subtree = new Set();
+      const queue = [ancestorId];
+      while (queue.length) {
+        const id = queue.shift();
+        if (subtree.has(id)) continue;
+        subtree.add(id);
+        for (const folder of folders.values()) {
+          if (folder.parent_id === id) queue.push(folder.id);
+        }
+      }
+      if (subtree.has(candidateId)) {
+        return { rowCount: 1, rows: [{ "?column?": 1 }] };
+      }
+      return { rowCount: 0, rows: [] };
+    }
+
+    if (normalized.startsWith("update saved_query_folders set name = $2")) {
+      const [id, name, parentId] = params;
+      const existing = folders.get(id);
+      if (!existing) return { rowCount: 0, rows: [] };
+      const duplicate = [...folders.values()].find((entry) => (
+        entry.id !== id
+        && entry.owner_id === existing.owner_id
+        && (entry.parent_id || null) === (parentId || null)
+        && entry.name.toLowerCase() === String(name).toLowerCase()
+      ));
+      if (duplicate) throw duplicateError();
+      const updated = {
+        ...existing,
+        name,
+        parent_id: parentId || null,
+        updated_at: new Date().toISOString()
+      };
+      folders.set(id, updated);
+      return { rowCount: 1, rows: [updated] };
+    }
+
+    if (normalized.startsWith("update saved_query_folders set parent_id = $2")) {
+      const [oldParentId, newParentId] = params;
+      const ids = [];
+      for (const folder of folders.values()) {
+        if (folder.parent_id === oldParentId) {
+          folder.parent_id = newParentId || null;
+          folder.updated_at = new Date().toISOString();
+          ids.push({ id: folder.id });
+        }
+      }
+      return { rowCount: ids.length, rows: ids };
+    }
+
+    if (normalized.startsWith("delete from saved_query_folders where id = $1")) {
+      const [id] = params;
+      if (!folders.has(id)) return { rowCount: 0, rows: [] };
+      folders.delete(id);
+      return { rowCount: 1, rows: [] };
+    }
+
+    if (normalized.startsWith("insert into auth_audit_log")) {
+      return { rowCount: 1, rows: [] };
+    }
+
+    throw new Error(`Unexpected SQL in folders stub: ${normalized}`);
+  };
+}
+
+before(async () => {
+  originalQuery = appDb.query;
+  originalWithTransaction = appDb.withTransaction;
+  originalCreateDatabaseAdapter = dbAdapterFactory.createDatabaseAdapter;
+  originalIsSupportedDbType = dbAdapterFactory.isSupportedDbType;
+  savedQueries = new Map();
+  savedQueryVersions = new Map();
+  folders = new Map();
+  savedQueryCounter = 0;
+  folderCounter = 0;
+  savedQueryVersionCounter = 0;
+  authStub = createAuthTestStub();
+
+  dbAdapterFactory.createDatabaseAdapter = () => ({
+    async validateSql() { return { ok: true, errors: [], refs: [] }; },
+    async executeParameterizedReadOnly() {
+      return { columns: [], rows: [], rowCount: 0, durationMs: 1 };
+    },
+    async close() {}
+  });
+  dbAdapterFactory.isSupportedDbType = (dbType) => dbType === "postgres" || dbType === "mssql";
+
+  const sqlHandler = buildSqlHandler();
+  appDb.query = sqlHandler;
+  // The folder delete path uses appDb.withTransaction; route the client.query
+  // calls back through the same stub so the in-memory state stays consistent.
+  appDb.withTransaction = async (handler) => handler({ query: sqlHandler });
+
+  delete require.cache[require.resolve("../src/server")];
+  const { startServer } = require("../src/server");
+  server = await startServer();
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+beforeEach(() => {
+  savedQueries.clear();
+  savedQueryVersions.clear();
+  folders.clear();
+  savedQueryCounter = 0;
+  folderCounter = 0;
+  savedQueryVersionCounter = 0;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  appDb.query = originalQuery;
+  appDb.withTransaction = originalWithTransaction;
+  dbAdapterFactory.createDatabaseAdapter = originalCreateDatabaseAdapter;
+  dbAdapterFactory.isSupportedDbType = originalIsSupportedDbType;
+});
+
+test("QUERY-008 create folder at root and list returns flat + tree shape", async () => {
+  const created = await api("POST", "/v1/saved-query-folders", { name: "Finance" }, "alice");
+  assert.equal(created.status, 201);
+  assert.equal(created.payload.name, "Finance");
+  assert.equal(created.payload.parent_id, null);
+  assert.equal(created.payload.owner_id, userId("alice"));
+
+  const child = await api("POST", "/v1/saved-query-folders", {
+    name: "Q1",
+    parent_id: created.payload.id
+  }, "alice");
+  assert.equal(child.status, 201);
+  assert.equal(child.payload.parent_id, created.payload.id);
+
+  const list = await api("GET", "/v1/saved-query-folders", undefined, "alice");
+  assert.equal(list.status, 200);
+  assert.equal(list.payload.items.length, 2);
+  assert.equal(list.payload.tree.length, 1);
+  assert.equal(list.payload.tree[0].id, created.payload.id);
+  assert.equal(list.payload.tree[0].children.length, 1);
+  assert.equal(list.payload.tree[0].children[0].id, child.payload.id);
+});
+
+test("QUERY-008 sibling-name collisions are rejected; different parents allow same name", async () => {
+  const root = await api("POST", "/v1/saved-query-folders", { name: "Reports" }, "owner-c");
+  const conflict = await api("POST", "/v1/saved-query-folders", { name: " reports " }, "owner-c");
+  assert.equal(conflict.status, 409);
+
+  const other = await api("POST", "/v1/saved-query-folders", { name: "Q1" }, "owner-c");
+  // Same name "Q1" is fine under a *different* parent...
+  const nestedA = await api("POST", "/v1/saved-query-folders", {
+    name: "Q1",
+    parent_id: root.payload.id
+  }, "owner-c");
+  assert.equal(nestedA.status, 201);
+  // ...but a duplicate under the same parent fails.
+  const nestedConflict = await api("POST", "/v1/saved-query-folders", {
+    name: "q1",
+    parent_id: root.payload.id
+  }, "owner-c");
+  assert.equal(nestedConflict.status, 409);
+  // And the root-level "Q1" is unaffected by the nested-level "Q1".
+  assert.equal(other.status, 201);
+});
+
+test("QUERY-008 parent_id must belong to caller; cross-owner moves are 403", async () => {
+  const myFolder = await api("POST", "/v1/saved-query-folders", { name: "Mine" }, "owner-self");
+  const theirFolder = await api("POST", "/v1/saved-query-folders", { name: "Theirs" }, "owner-other");
+
+  const attempt = await api("POST", "/v1/saved-query-folders", {
+    name: "Nested",
+    parent_id: theirFolder.payload.id
+  }, "owner-self");
+  assert.equal(attempt.status, 403);
+
+  // Same applies to PUT.
+  const renamed = await api("PUT", `/v1/saved-query-folders/${myFolder.payload.id}`, {
+    parent_id: theirFolder.payload.id
+  }, "owner-self");
+  assert.equal(renamed.status, 403);
+});
+
+test("QUERY-008 update can rename and move a folder", async () => {
+  const a = await api("POST", "/v1/saved-query-folders", { name: "A" }, "rename-owner");
+  const b = await api("POST", "/v1/saved-query-folders", { name: "B" }, "rename-owner");
+
+  const renamed = await api("PUT", `/v1/saved-query-folders/${a.payload.id}`, {
+    name: "Alpha",
+    parent_id: b.payload.id
+  }, "rename-owner");
+  assert.equal(renamed.status, 200);
+  assert.equal(renamed.payload.name, "Alpha");
+  assert.equal(renamed.payload.parent_id, b.payload.id);
+});
+
+test("QUERY-008 moving a folder into its own descendant is rejected", async () => {
+  const root = await api("POST", "/v1/saved-query-folders", { name: "Root" }, "cycle-owner");
+  const child = await api("POST", "/v1/saved-query-folders", {
+    name: "Child",
+    parent_id: root.payload.id
+  }, "cycle-owner");
+  const grand = await api("POST", "/v1/saved-query-folders", {
+    name: "Grand",
+    parent_id: child.payload.id
+  }, "cycle-owner");
+
+  const cycle = await api("PUT", `/v1/saved-query-folders/${root.payload.id}`, {
+    parent_id: grand.payload.id
+  }, "cycle-owner");
+  assert.equal(cycle.status, 400);
+  assert.match(cycle.payload.message, /descendant/i);
+});
+
+test("QUERY-008 a folder cannot be its own parent", async () => {
+  const folder = await api("POST", "/v1/saved-query-folders", { name: "Loop" }, "self-loop-owner");
+  const attempt = await api("PUT", `/v1/saved-query-folders/${folder.payload.id}`, {
+    parent_id: folder.payload.id
+  }, "self-loop-owner");
+  assert.equal(attempt.status, 400);
+});
+
+test("QUERY-008 delete reparents child folders and saved queries to the deleted folder's parent", async () => {
+  const root = await api("POST", "/v1/saved-query-folders", { name: "Root" }, "del-owner");
+  const middle = await api("POST", "/v1/saved-query-folders", {
+    name: "Middle",
+    parent_id: root.payload.id
+  }, "del-owner");
+  const leaf = await api("POST", "/v1/saved-query-folders", {
+    name: "Leaf",
+    parent_id: middle.payload.id
+  }, "del-owner");
+
+  // Park a saved query under "Middle" so we can confirm it gets reparented.
+  const query = await api("POST", "/v1/saved-queries", {
+    name: "Revenue",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "del-owner");
+  assert.equal(query.status, 201);
+  const moved = await api("POST", `/v1/saved-queries/${query.payload.id}/move`, {
+    folder_id: middle.payload.id
+  }, "del-owner");
+  assert.equal(moved.status, 200);
+  assert.equal(moved.payload.folder_id, middle.payload.id);
+
+  // Delete Middle — Leaf and the saved query should reparent to Root.
+  const del = await api("DELETE", `/v1/saved-query-folders/${middle.payload.id}`, undefined, "del-owner");
+  assert.equal(del.status, 200);
+  assert.equal(del.payload.reassigned_to, root.payload.id);
+  assert.deepEqual(del.payload.reassigned_folder_ids, [leaf.payload.id]);
+  assert.deepEqual(del.payload.reassigned_saved_query_ids, [query.payload.id]);
+
+  const listAfter = await api("GET", "/v1/saved-query-folders", undefined, "del-owner");
+  const leafNow = listAfter.payload.items.find((row) => row.id === leaf.payload.id);
+  assert.equal(leafNow.parent_id, root.payload.id);
+
+  const queryAfter = await api("GET", `/v1/saved-queries/${query.payload.id}`, undefined, "del-owner");
+  assert.equal(queryAfter.payload.folder_id, root.payload.id);
+});
+
+test("QUERY-008 deleting a root folder reparents children to root (NULL)", async () => {
+  const root = await api("POST", "/v1/saved-query-folders", { name: "Root" }, "root-del-owner");
+  const child = await api("POST", "/v1/saved-query-folders", {
+    name: "Child",
+    parent_id: root.payload.id
+  }, "root-del-owner");
+
+  const del = await api("DELETE", `/v1/saved-query-folders/${root.payload.id}`, undefined, "root-del-owner");
+  assert.equal(del.status, 200);
+  assert.equal(del.payload.reassigned_to, null);
+
+  const listAfter = await api("GET", "/v1/saved-query-folders", undefined, "root-del-owner");
+  const childNow = listAfter.payload.items.find((row) => row.id === child.payload.id);
+  assert.equal(childNow.parent_id, null);
+});
+
+test("QUERY-008 only the folder owner can update or delete", async () => {
+  const created = await api("POST", "/v1/saved-query-folders", { name: "Mine" }, "owner-x");
+  const updated = await api("PUT", `/v1/saved-query-folders/${created.payload.id}`, {
+    name: "Stolen"
+  }, "owner-y");
+  assert.equal(updated.status, 403);
+  const deleted = await api("DELETE", `/v1/saved-query-folders/${created.payload.id}`, undefined, "owner-y");
+  assert.equal(deleted.status, 403);
+});
+
+test("QUERY-008 move endpoint relocates the saved query and returns folder context", async () => {
+  const folder = await api("POST", "/v1/saved-query-folders", { name: "Inbox" }, "move-owner");
+  const query = await api("POST", "/v1/saved-queries", {
+    name: "Move Me",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "move-owner");
+  assert.equal(query.payload.folder_id, null);
+
+  const moved = await api("POST", `/v1/saved-queries/${query.payload.id}/move`, {
+    folder_id: folder.payload.id
+  }, "move-owner");
+  assert.equal(moved.status, 200);
+  assert.equal(moved.payload.folder_id, folder.payload.id);
+  assert.equal(moved.payload.previous_folder_id, null);
+  assert.equal(moved.payload.saved_query.id, query.payload.id);
+  assert.equal(moved.payload.saved_query.folder_id, folder.payload.id);
+
+  // Moving back to root accepts `folder_id: null`.
+  const back = await api("POST", `/v1/saved-queries/${query.payload.id}/move`, {
+    folder_id: null
+  }, "move-owner");
+  assert.equal(back.status, 200);
+  assert.equal(back.payload.folder_id, null);
+  assert.equal(back.payload.previous_folder_id, folder.payload.id);
+});
+
+test("QUERY-008 move endpoint rejects non-owners and cross-owner folders", async () => {
+  const ownerFolder = await api("POST", "/v1/saved-query-folders", { name: "Mine" }, "move-owner-2");
+  const query = await api("POST", "/v1/saved-queries", {
+    name: "Move Me 2",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "move-owner-2");
+
+  // Non-owner can't move someone else's query.
+  const stranger = await api("POST", `/v1/saved-queries/${query.payload.id}/move`, {
+    folder_id: ownerFolder.payload.id
+  }, "stranger-mover");
+  assert.equal(stranger.status, 403);
+
+  // Owner can't park their query in someone else's folder.
+  const otherOwnersFolder = await api("POST", "/v1/saved-query-folders", { name: "Theirs" }, "another-owner");
+  const cross = await api("POST", `/v1/saved-queries/${query.payload.id}/move`, {
+    folder_id: otherOwnersFolder.payload.id
+  }, "move-owner-2");
+  assert.equal(cross.status, 403);
+});
+
+test("QUERY-008 move endpoint returns 404 for unknown folder", async () => {
+  const query = await api("POST", "/v1/saved-queries", {
+    name: "Missing Target",
+    data_source_id: DATA_SOURCE_ID,
+    sql: "SELECT 1"
+  }, "missing-folder-owner");
+
+  const missing = await api("POST", `/v1/saved-queries/${query.payload.id}/move`, {
+    folder_id: "00000000-0000-4000-8000-ffff99999999"
+  }, "missing-folder-owner");
+  assert.equal(missing.status, 404);
+});
+
+test("QUERY-008 create validates name length and parent shape", async () => {
+  const blank = await api("POST", "/v1/saved-query-folders", { name: "   " }, "validate-owner");
+  assert.equal(blank.status, 400);
+
+  const tooLong = await api("POST", "/v1/saved-query-folders", { name: "x".repeat(200) }, "validate-owner");
+  assert.equal(tooLong.status, 400);
+
+  const badParent = await api("POST", "/v1/saved-query-folders", {
+    name: "ok",
+    parent_id: "not-a-uuid"
+  }, "validate-owner");
+  assert.equal(badParent.status, 400);
+
+  const missingParent = await api("POST", "/v1/saved-query-folders", {
+    name: "ok",
+    parent_id: "00000000-0000-4000-8000-ffff99999999"
+  }, "validate-owner");
+  assert.equal(missingParent.status, 404);
+});
+
+test("QUERY-008 viewer role cannot create folders", async () => {
+  const created = await api("POST", "/v1/saved-query-folders", {
+    name: "Viewer Folder"
+  }, "viewer-folder", { role: "viewer" });
+  assert.equal(created.status, 403);
+});

--- a/db/migrations/0026_saved_query_folders.sql
+++ b/db/migrations/0026_saved_query_folders.sql
@@ -1,0 +1,58 @@
+-- QUERY-008: foldering for saved queries.
+--
+-- Adds a per-user folder tree plus a nullable `folder_id` on `saved_queries`.
+--
+-- Conventions:
+--   * `owner_id` mirrors the `saved_queries.owner_id` shape (TEXT). A folder
+--     is private to its owner; there's no folder sharing in this milestone —
+--     visibility of the *query* still drives whether someone else can see it,
+--     and a shared query simply appears under its owner's folder (or at root
+--     for non-owners, which is what the existing list query already returns).
+--   * `parent_id` is a self-FK; NULL means the folder lives at the user's root.
+--     ON DELETE SET NULL lets the service reassign children when a folder is
+--     deleted (see below) without violating the FK during the cascade.
+--   * `UNIQUE (owner_id, COALESCE(parent_id, '...'), lower(name))` is approximated
+--     via a partial-index pair below so siblings can't collide while folders
+--     under different parents (or in different roots) can share a name.
+--
+-- Folder-delete policy (chosen: REASSIGN):
+--   When a folder is deleted, its direct children (sub-folders and saved
+--   queries that point at it) are reassigned to the deleted folder's parent
+--   (NULL if it was at root). This is implemented in the service layer in a
+--   single transaction so the move + delete are atomic. The `ON DELETE SET NULL`
+--   here is the safety net — if a row somehow slips past the service it still
+--   ends up at root rather than orphaned.
+
+CREATE TABLE IF NOT EXISTS saved_query_folders (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  owner_id TEXT NOT NULL,
+  parent_id UUID REFERENCES saved_query_folders(id) ON DELETE SET NULL,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_query_folders_owner
+  ON saved_query_folders (owner_id);
+
+CREATE INDEX IF NOT EXISTS idx_saved_query_folders_parent
+  ON saved_query_folders (parent_id);
+
+-- Sibling-name uniqueness, split into two partial indexes because NULL is
+-- not considered equal in UNIQUE constraints. The first covers root-level
+-- folders (parent IS NULL), the second covers nested folders.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_query_folders_owner_root_name
+  ON saved_query_folders (owner_id, lower(name))
+  WHERE parent_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_query_folders_owner_parent_name
+  ON saved_query_folders (owner_id, parent_id, lower(name))
+  WHERE parent_id IS NOT NULL;
+
+-- Attach saved queries to a folder. NULL means "root" for that owner.
+ALTER TABLE saved_queries
+  ADD COLUMN IF NOT EXISTS folder_id UUID
+    REFERENCES saved_query_folders(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_saved_queries_folder
+  ON saved_queries (folder_id);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1265,6 +1265,117 @@ paths:
           description: Caller is not the owner
         "404":
           description: Saved query or version not found
+  /v1/saved-query-folders:
+    post:
+      tags: [Query]
+      summary: Create a saved-query folder (per-owner)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSavedQueryFolderRequest"
+      responses:
+        "201":
+          description: Folder created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQueryFolder"
+        "400":
+          description: Invalid name or parent_id shape
+        "403":
+          description: parent_id belongs to another owner
+        "404":
+          description: parent_id folder not found
+        "409":
+          description: A sibling folder with that name already exists
+    get:
+      tags: [Query]
+      summary: List the caller's folders, flat plus pre-built tree
+      responses:
+        "200":
+          description: Folder list and tree
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQueryFolderListResponse"
+  /v1/saved-query-folders/{folderId}:
+    put:
+      tags: [Query]
+      summary: Rename or move a folder (owner-only)
+      parameters:
+        - in: path
+          name: folderId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateSavedQueryFolderRequest"
+      responses:
+        "200":
+          description: Updated folder
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQueryFolder"
+        "400":
+          description: Invalid name or self/descendant parent move
+        "403":
+          description: Caller is not the folder owner, or parent_id belongs to another owner
+        "404":
+          description: Folder not found
+        "409":
+          description: Sibling-name collision under the target parent
+    delete:
+      tags: [Query]
+      summary: Delete a folder; direct children are reparented to its parent (REASSIGN policy)
+      parameters:
+        - in: path
+          name: folderId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Folder deleted; response lists what was reparented and the new parent (null for root).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteSavedQueryFolderResponse"
+        "403":
+          description: Caller is not the folder owner
+        "404":
+          description: Folder not found
+  /v1/saved-queries/{savedQueryId}/move:
+    post:
+      tags: [Query]
+      summary: "Move a saved query into a folder (owner-only). `folder_id: null` moves to root."
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveSavedQueryRequest"
+      responses:
+        "200":
+          description: Updated saved query plus the resolved folder context
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MoveSavedQueryResponse"
+        "400":
+          description: folder_id is not a UUID
+        "403":
+          description: Caller is not the owner, or folder_id belongs to another owner
+        "404":
+          description: Saved query or folder_id not found
   /v1/query/sessions:
     post:
       tags: [Query]
@@ -2720,6 +2831,10 @@ components:
         visibility:
           type: string
           enum: [private, shared]
+        folder_id:
+          type: string
+          nullable: true
+          description: QUERY-008 folder placement. NULL means the saved query lives at the owner's root.
         created_at:
           type: string
           format: date-time
@@ -3000,6 +3115,108 @@ components:
                 required: [user_id, permission]
           required: [added, updated, removed]
       required: [visibility, previous_visibility, shares, diff]
+    SavedQueryFolder:
+      type: object
+      properties:
+        id:
+          type: string
+        owner_id:
+          type: string
+        parent_id:
+          type: string
+          nullable: true
+        name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required: [id, owner_id, name, created_at, updated_at]
+    SavedQueryFolderTreeNode:
+      allOf:
+        - $ref: "#/components/schemas/SavedQueryFolder"
+        - type: object
+          properties:
+            children:
+              type: array
+              items:
+                $ref: "#/components/schemas/SavedQueryFolderTreeNode"
+          required: [children]
+    SavedQueryFolderListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SavedQueryFolder"
+        tree:
+          type: array
+          items:
+            $ref: "#/components/schemas/SavedQueryFolderTreeNode"
+      required: [items, tree]
+    CreateSavedQueryFolderRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 120
+        parent_id:
+          type: string
+          nullable: true
+      required: [name]
+    UpdateSavedQueryFolderRequest:
+      type: object
+      description: >
+        Patch-style: any field omitted is left as-is. `parent_id: null` moves
+        the folder back to the user's root.
+      properties:
+        name:
+          type: string
+          maxLength: 120
+        parent_id:
+          type: string
+          nullable: true
+    DeleteSavedQueryFolderResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        id:
+          type: string
+        reassigned_to:
+          type: string
+          nullable: true
+          description: New parent for the deleted folder's direct children (NULL = root).
+        reassigned_folder_ids:
+          type: array
+          items:
+            type: string
+        reassigned_saved_query_ids:
+          type: array
+          items:
+            type: string
+      required: [ok, id, reassigned_to, reassigned_folder_ids, reassigned_saved_query_ids]
+    MoveSavedQueryRequest:
+      type: object
+      properties:
+        folder_id:
+          type: string
+          nullable: true
+      required: [folder_id]
+    MoveSavedQueryResponse:
+      type: object
+      properties:
+        saved_query:
+          $ref: "#/components/schemas/SavedQuery"
+        previous_folder_id:
+          type: string
+          nullable: true
+        folder_id:
+          type: string
+          nullable: true
+      required: [saved_query, folder_id]
     ValidateParamsRequest:
       type: object
       properties:

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -4245,10 +4245,52 @@ export interface components {
             tags: string[];
             /** @enum {string} */
             visibility: "private" | "shared";
+            /** @description QUERY-008 folder placement. NULL means the saved query lives at the owner's root. */
+            folder_id?: string | null;
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
             updated_at: string;
+        };
+        SavedQueryFolder: {
+            id: string;
+            owner_id: string;
+            parent_id?: string | null;
+            name: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        SavedQueryFolderTreeNode: components["schemas"]["SavedQueryFolder"] & {
+            children: components["schemas"]["SavedQueryFolderTreeNode"][];
+        };
+        SavedQueryFolderListResponse: {
+            items: components["schemas"]["SavedQueryFolder"][];
+            tree: components["schemas"]["SavedQueryFolderTreeNode"][];
+        };
+        CreateSavedQueryFolderRequest: {
+            name: string;
+            parent_id?: string | null;
+        };
+        UpdateSavedQueryFolderRequest: {
+            name?: string;
+            parent_id?: string | null;
+        };
+        DeleteSavedQueryFolderResponse: {
+            ok: boolean;
+            id: string;
+            reassigned_to: string | null;
+            reassigned_folder_ids: string[];
+            reassigned_saved_query_ids: string[];
+        };
+        MoveSavedQueryRequest: {
+            folder_id: string | null;
+        };
+        MoveSavedQueryResponse: {
+            saved_query: components["schemas"]["SavedQuery"];
+            previous_folder_id?: string | null;
+            folder_id: string | null;
         };
         SavedQueryListResponse: {
             items: components["schemas"]["SavedQuery"][];


### PR DESCRIPTION
Closes #43.

## Summary

Folder-based organisation for saved queries — per-owner hierarchy, plus a move endpoint that fits the existing sidebar workflow.

### Storage (migration `0026_saved_query_folders.sql`)
- New table `saved_query_folders` with `owner_id` (TEXT, mirrors `saved_queries.owner_id`), self-FK `parent_id` (`ON DELETE SET NULL` as a safety net), `name`, timestamps.
- Sibling-name uniqueness via **two partial indexes** (one for `parent_id IS NULL`, one for `parent_id IS NOT NULL`) — Postgres treats NULL as unequal in UNIQUE constraints, so this is the idiomatic split.
- New nullable column `saved_queries.folder_id` (FK with `SET NULL`). NULL means the query lives at the owner's root.

### Service (`savedQueryFolderService.js`)
- CRUD with explicit ownership checks: a folder's `parent_id` must belong to the same owner.
- Cycle prevention on move: a recursive CTE rejects moves that would put a folder under one of its own descendants. A folder also cannot be its own parent.
- Depth cap (`MAX_FOLDER_DEPTH = 10`) keeps the sidebar tree shallow.
- `folder_id` exposed through `SAVED_QUERY_COLUMNS` so list/get already include placement — the frontend doesn't need a follow-up call to render the tree.

### Folder-delete policy: **REASSIGN** (chosen)
When a folder is deleted, its direct children — both sub-folders and saved queries that point at it — are reparented to the deleted folder's parent (NULL if it was at root). The reparent + delete happen in a single `appDb.withTransaction` block so the move is atomic.

Why this over `block` or `cascade`:
- **Cascade** silently deletes work — the team would discover later that a stray delete wiped a department's queries.
- **Block** forces empty-the-folder dances that don't translate well to drag-and-drop in the sidebar.
- **Reassign** preserves user data, behaves predictably under accidental clicks, and stays trivially undoable from the UI (the user can recreate the folder and drag the queries back). The response body lists `reassigned_folder_ids` and `reassigned_saved_query_ids` so the sidebar can refresh in place.

### API
- `POST /v1/saved-query-folders` — create
- `GET /v1/saved-query-folders` — flat `items` plus a pre-built `tree`
- `PUT /v1/saved-query-folders/{id}` — rename + move (patch-style; omit fields to leave them as-is)
- `DELETE /v1/saved-query-folders/{id}` — REASSIGN + delete, returns the reparent summary
- `POST /v1/saved-queries/{id}/move` — body `{ folder_id: string | null }`. Returns `{ saved_query, previous_folder_id, folder_id }` so the sidebar can splice state without a follow-up GET.

All under `saved_queries.write` / `saved_queries.read` permissions (folders are an authoring concern; viewers don't get folder CRUD but can still read the tree if they later need to see where a shared query is filed).

### Notes / scope discipline
- No folder-level sharing in this milestone. A saved query with `visibility: 'shared'` (or an explicit share grant) still appears in the recipient's library via the existing list query — it just isn't filed under the recipient's folder tree. QUERY-009 (sidebar) owns the UI rendering choice here.
- No audit events for folder CRUD (the team's existing audit log focuses on access changes, not organisation). Easy to add later if compliance asks.

## Test plan
- [x] `npm test` (203/203 passing; +14 new folder tests covering create/list, sibling-collision splits, cross-owner refusal, cycle/self-parent rejection, REASSIGN delete from middle-of-tree, REASSIGN from root, owner-only update/delete, move + move-to-root, cross-owner folder rejection, unknown folder, validation, viewer-role policy denial)
- [x] `npx tsc -b` (frontend, clean)
- [x] `npm run lint` (frontend, clean)
- [ ] Manual browser test deferred — verify: (1) create a folder, nest a sub-folder, drag a saved query in via the move endpoint, confirm sidebar tree updates; (2) delete the middle folder and confirm the saved query + sub-folder both pop up one level; (3) attempt to drag a folder under one of its own descendants and confirm the API returns 400; (4) confirm a viewer can read the folder list but not create/move.