### PR TITLE
QUERY-007 scheduled report delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,11 @@ SMTP_SECURE=false
 SMTP_USER=
 SMTP_PASS=
 SMTP_FROM=Report Pilot Reports <noreply@report-pilot.local>
+
+# QUERY-007: scheduled saved-query delivery worker.
+# Set to "true" to enable the in-process dispatcher that polls
+# saved_query_schedules every SCHEDULE_DISPATCHER_INTERVAL_MS milliseconds
+# (default 60s) and emails matching schedules. Off by default so tests and
+# bare `npm start` runs don't poll the DB.
+SCHEDULE_DISPATCHER_ENABLED=false
+SCHEDULE_DISPATCHER_INTERVAL_MS=60000

--- a/app/src/lib/routePolicy.js
+++ b/app/src/lib/routePolicy.js
@@ -91,6 +91,14 @@ const POLICIES = [
   { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+\/access$/, permission: "saved_queries.read" },
   { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+\/versions$/, permission: "saved_queries.read" },
   { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/versions\/[^/]+\/restore$/, permission: "saved_queries.write" },
+  // QUERY-007: scheduled delivery. Both create / read / update / delete and the
+  // explicit retry endpoint live under saved_queries.schedule (granted to admin
+  // + analyst by default). Service-layer enforcement adds owner-only on top.
+  { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/schedules$/, permission: "saved_queries.schedule" },
+  { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+\/schedules$/, permission: "saved_queries.schedule" },
+  { method: "PUT", pattern: /^\/v1\/saved-queries\/[^/]+\/schedules\/[^/]+$/, permission: "saved_queries.schedule" },
+  { method: "DELETE", pattern: /^\/v1\/saved-queries\/[^/]+\/schedules\/[^/]+$/, permission: "saved_queries.schedule" },
+  { method: "POST", pattern: /^\/v1\/saved-queries\/[^/]+\/schedules\/[^/]+\/retry$/, permission: "saved_queries.schedule" },
   { method: "GET", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.read" },
   { method: "PUT", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.write" },
   { method: "DELETE", pattern: /^\/v1\/saved-queries\/[^/]+$/, permission: "saved_queries.write" },

--- a/app/src/routes/savedQuerySchedules.js
+++ b/app/src/routes/savedQuerySchedules.js
@@ -1,0 +1,129 @@
+// QUERY-007: routes for managing scheduled saved-query delivery.
+
+const appDb = require("../lib/appDb");
+const { json, readJsonBody } = require("../lib/http");
+const { isUuid } = require("../lib/validation");
+const scheduleService = require("../services/savedQueryScheduleService");
+const auditService = require("../services/auditService");
+const { enforceDataSourceAccess } = require("../lib/authGate");
+
+function callerId(req) {
+  return (req.user && req.user.id) || null;
+}
+
+function requestClientIp(req) {
+  return (req.socket && req.socket.remoteAddress) || null;
+}
+
+function writeResult(res, result) {
+  return json(res, result.statusCode, result.body);
+}
+
+async function loadSavedQueryDataSourceId(savedQueryId) {
+  if (!isUuid(savedQueryId)) return null;
+  const result = await appDb.query(
+    "SELECT data_source_id FROM saved_queries WHERE id = $1",
+    [savedQueryId]
+  );
+  return result.rowCount > 0 ? result.rows[0].data_source_id : null;
+}
+
+function emitScheduleAudit(req, action, savedQueryId, details = {}) {
+  auditService
+    .writeEvent({
+      actorUserId: callerId(req),
+      action,
+      details: { saved_query_id: savedQueryId, ...details },
+      ipAddress: requestClientIp(req),
+      userAgent: req.headers["user-agent"] || null
+    })
+    .catch(() => {});
+}
+
+async function handleCreateSchedule(req, res, savedQueryId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) return undefined;
+  const body = await readJsonBody(req);
+  const result = await scheduleService.createSchedule(savedQueryId, body, {
+    callerUserId: callerId(req)
+  });
+  if (result.ok) {
+    emitScheduleAudit(req, "saved_query.schedule.created", savedQueryId, {
+      schedule_id: result.body.id,
+      cron_expression: result.body.cron_expression,
+      timezone: result.body.timezone,
+      delivery_mode: result.body.delivery_mode,
+      format: result.body.format,
+      recipient_count: (result.body.recipients || []).length
+    });
+  }
+  return writeResult(res, result);
+}
+
+async function handleListSchedules(req, res, savedQueryId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) return undefined;
+  const result = await scheduleService.listSchedules(savedQueryId, {
+    callerUserId: callerId(req)
+  });
+  return writeResult(res, result);
+}
+
+async function handleUpdateSchedule(req, res, savedQueryId, scheduleId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) return undefined;
+  const body = await readJsonBody(req);
+  const result = await scheduleService.updateSchedule(savedQueryId, scheduleId, body, {
+    callerUserId: callerId(req)
+  });
+  if (result.ok) {
+    emitScheduleAudit(req, "saved_query.schedule.updated", savedQueryId, {
+      schedule_id: result.body.id,
+      cron_expression: result.body.cron_expression,
+      timezone: result.body.timezone,
+      delivery_mode: result.body.delivery_mode,
+      format: result.body.format,
+      status: result.body.status,
+      recipient_count: (result.body.recipients || []).length
+    });
+  }
+  return writeResult(res, result);
+}
+
+async function handleDeleteSchedule(req, res, savedQueryId, scheduleId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) return undefined;
+  const result = await scheduleService.deleteSchedule(savedQueryId, scheduleId, {
+    callerUserId: callerId(req)
+  });
+  if (result.ok) {
+    emitScheduleAudit(req, "saved_query.schedule.deleted", savedQueryId, {
+      schedule_id: scheduleId
+    });
+  }
+  return writeResult(res, result);
+}
+
+async function handleRetrySchedule(req, res, savedQueryId, scheduleId) {
+  const dsId = await loadSavedQueryDataSourceId(savedQueryId);
+  if (dsId && !(await enforceDataSourceAccess(req, res, dsId))) return undefined;
+  const result = await scheduleService.retryFailedRun(savedQueryId, scheduleId, {
+    callerUserId: callerId(req)
+  });
+  if (result.ok) {
+    emitScheduleAudit(req, "saved_query.schedule.retried", savedQueryId, {
+      schedule_id: scheduleId,
+      run_id: result.body.run_id,
+      delivery_ok: result.body.ok
+    });
+  }
+  return writeResult(res, result);
+}
+
+module.exports = {
+  handleCreateSchedule,
+  handleListSchedules,
+  handleUpdateSchedule,
+  handleDeleteSchedule,
+  handleRetrySchedule
+};

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -58,6 +58,13 @@ const {
   handleRestoreSavedQueryVersion
 } = require("./routes/savedQueries");
 const {
+  handleCreateSchedule,
+  handleListSchedules,
+  handleUpdateSchedule,
+  handleDeleteSchedule,
+  handleRetrySchedule
+} = require("./routes/savedQuerySchedules");
+const {
   handleExportSession,
   handleExportDeliver,
   handleExportStatus
@@ -462,6 +469,32 @@ async function routeRequest(req, res) {
   const savedQueryRestoreMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/versions\/([^/]+)\/restore$/);
   if (req.method === "POST" && savedQueryRestoreMatch) {
     return handleRestoreSavedQueryVersion(req, res, savedQueryRestoreMatch[1], savedQueryRestoreMatch[2]);
+  }
+
+  // QUERY-007: scheduled delivery — matched before the generic /:id catch-all.
+  const savedQueryScheduleRetryMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/schedules\/([^/]+)\/retry$/);
+  if (req.method === "POST" && savedQueryScheduleRetryMatch) {
+    return handleRetrySchedule(req, res, savedQueryScheduleRetryMatch[1], savedQueryScheduleRetryMatch[2]);
+  }
+
+  const savedQueryScheduleIdMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/schedules\/([^/]+)$/);
+  if (savedQueryScheduleIdMatch) {
+    if (req.method === "PUT") {
+      return handleUpdateSchedule(req, res, savedQueryScheduleIdMatch[1], savedQueryScheduleIdMatch[2]);
+    }
+    if (req.method === "DELETE") {
+      return handleDeleteSchedule(req, res, savedQueryScheduleIdMatch[1], savedQueryScheduleIdMatch[2]);
+    }
+  }
+
+  const savedQuerySchedulesMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)\/schedules$/);
+  if (savedQuerySchedulesMatch) {
+    if (req.method === "POST") {
+      return handleCreateSchedule(req, res, savedQuerySchedulesMatch[1]);
+    }
+    if (req.method === "GET") {
+      return handleListSchedules(req, res, savedQuerySchedulesMatch[1]);
+    }
   }
 
   const savedQueryMatch = pathname.match(/^\/v1\/saved-queries\/([^/]+)$/);

--- a/app/src/services/cronExpression.js
+++ b/app/src/services/cronExpression.js
@@ -1,0 +1,247 @@
+// QUERY-007: minimal 5-field cron parser + timezone-aware next-run computation.
+//
+// Why hand-rolled: the repo deliberately keeps backend deps lean (see
+// `package.json` — no chrono/cron lib is already on the tree). A 5-field
+// cron is small enough to parse and step through deterministically. If the
+// scope grows (RRULE, seconds, "@every 5m"), swap in `cron-parser` / `croner`
+// here without touching the dispatcher.
+//
+// Supported syntax:
+//   field 1 — minute (0-59)
+//   field 2 — hour (0-23)
+//   field 3 — day-of-month (1-31)
+//   field 4 — month (1-12)
+//   field 5 — day-of-week (0-6, Sunday=0; 7 also Sunday)
+// Each field accepts:
+//   *          — every value
+//   N          — literal
+//   N-M        — inclusive range
+//   N,M,...    — comma list
+//   * / step   — every `step` units (e.g. "*/15", "0-30/5")
+//
+// Timezone: an IANA TZ name (e.g. "Europe/London"). Calculation walks the
+// schedule's wall-clock minutes forward and converts back to UTC via Intl;
+// DST transitions are handled by the underlying Date math (we keep stepping
+// until a UTC instant is found that matches the local-wall-clock fields).
+
+const MINUTE_RANGE = [0, 59];
+const HOUR_RANGE = [0, 23];
+const DOM_RANGE = [1, 31];
+const MONTH_RANGE = [1, 12];
+const DOW_RANGE = [0, 6];
+
+function parseField(spec, [min, max]) {
+  if (typeof spec !== "string" || !spec.length) {
+    throw new Error(`cron field must be a non-empty string`);
+  }
+  const result = new Set();
+  for (const part of spec.split(",")) {
+    if (!part.length) {
+      throw new Error(`cron field has empty list entry`);
+    }
+    const stepIndex = part.indexOf("/");
+    const base = stepIndex === -1 ? part : part.slice(0, stepIndex);
+    const step = stepIndex === -1 ? 1 : Number(part.slice(stepIndex + 1));
+    if (!Number.isInteger(step) || step <= 0) {
+      throw new Error(`cron step must be a positive integer`);
+    }
+    let rangeStart;
+    let rangeEnd;
+    if (base === "*") {
+      rangeStart = min;
+      rangeEnd = max;
+    } else if (base.includes("-")) {
+      const [a, b] = base.split("-");
+      rangeStart = Number(a);
+      rangeEnd = Number(b);
+    } else {
+      rangeStart = Number(base);
+      rangeEnd = rangeStart;
+    }
+    if (!Number.isInteger(rangeStart) || !Number.isInteger(rangeEnd)) {
+      throw new Error(`cron field has non-integer value: ${part}`);
+    }
+    if (rangeStart < min || rangeEnd > max || rangeStart > rangeEnd) {
+      throw new Error(`cron field out of range (${min}-${max}): ${part}`);
+    }
+    for (let v = rangeStart; v <= rangeEnd; v += step) {
+      result.add(v);
+    }
+  }
+  return result;
+}
+
+function parseCronExpression(expression) {
+  if (typeof expression !== "string") {
+    throw new Error("cron expression must be a string");
+  }
+  const trimmed = expression.trim().replace(/\s+/g, " ");
+  const fields = trimmed.split(" ");
+  if (fields.length !== 5) {
+    throw new Error(`cron expression must have exactly 5 fields (got ${fields.length})`);
+  }
+  const minutes = parseField(fields[0], MINUTE_RANGE);
+  const hours = parseField(fields[1], HOUR_RANGE);
+  const doms = parseField(fields[2], DOM_RANGE);
+  const months = parseField(fields[3], MONTH_RANGE);
+  let dowSpec = fields[4];
+  // Accept "7" as Sunday → normalize to 0 to fit our set semantics.
+  if (dowSpec.includes("7")) {
+    dowSpec = dowSpec.replace(/\b7\b/g, "0");
+  }
+  const dows = parseField(dowSpec, DOW_RANGE);
+
+  return {
+    expression: trimmed,
+    minutes,
+    hours,
+    doms,
+    months,
+    dows,
+    domStarred: fields[2] === "*",
+    dowStarred: fields[4] === "*"
+  };
+}
+
+function isCronExpressionValid(expression) {
+  try {
+    parseCronExpression(expression);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const FORMATTER_CACHE = new Map();
+const DOW_MAP = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+
+function getFormatter(timezone) {
+  let formatter = FORMATTER_CACHE.get(timezone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+      weekday: "short"
+    });
+    FORMATTER_CACHE.set(timezone, formatter);
+  }
+  return formatter;
+}
+
+function getZonedParts(date, timezone) {
+  const formatter = getFormatter(timezone);
+  const parts = {};
+  for (const part of formatter.formatToParts(date)) {
+    if (part.type !== "literal") parts[part.type] = part.value;
+  }
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day),
+    hour: Number(parts.hour === "24" ? "0" : parts.hour),
+    minute: Number(parts.minute),
+    dayOfWeek: DOW_MAP[parts.weekday]
+  };
+}
+
+function isTimezoneValid(timezone) {
+  if (typeof timezone !== "string" || !timezone.length) return false;
+  try {
+    // Will throw RangeError if invalid.
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function matchesCron(parsed, parts) {
+  if (!parsed.minutes.has(parts.minute)) return false;
+  if (!parsed.hours.has(parts.hour)) return false;
+  if (!parsed.months.has(parts.month)) return false;
+  // Vixie-cron rule: when both dom and dow are restricted (neither is "*"),
+  // either match suffices. Otherwise both must match.
+  const domMatch = parsed.doms.has(parts.day);
+  const dowMatch = parsed.dows.has(parts.dayOfWeek);
+  if (!parsed.domStarred && !parsed.dowStarred) {
+    return domMatch || dowMatch;
+  }
+  return domMatch && dowMatch;
+}
+
+/**
+ * Compute the next UTC Date strictly after `fromDate` at which the cron
+ * expression fires in `timezone`. Walks one minute at a time — fine for the
+ * cron grain we support (1-minute resolution) and avoids re-implementing
+ * leap-second / DST math.
+ *
+ * Caps at 366 days of search; anything beyond that is a sign of an impossible
+ * combination (e.g. "0 0 31 2 *").
+ *
+ * @param {string} expression  cron expression in `timezone`
+ * @param {string} timezone    IANA tz name
+ * @param {Date}   [fromDate]  defaults to "now"
+ * @returns {Date}             next fire time as a UTC Date
+ */
+function computeNextRun(expression, timezone, fromDate = new Date()) {
+  const parsed = parseCronExpression(expression);
+  if (!isTimezoneValid(timezone)) {
+    throw new Error(`invalid timezone: ${timezone}`);
+  }
+  // Step from the next whole minute strictly after fromDate.
+  const start = new Date(fromDate.getTime());
+  start.setUTCSeconds(0, 0);
+  start.setUTCMinutes(start.getUTCMinutes() + 1);
+
+  // Walk forward minute-by-minute but skip whole hours / days / months whenever
+  // a coarser field doesn't match. Keeps the impossible-cron diagnostic loop
+  // (e.g. "0 0 31 2 *") cheap rather than walking ~526k minutes one at a time.
+  let cursor = start.getTime();
+  const limit = cursor + 366 * 24 * 60 * 60_000;
+  while (cursor <= limit) {
+    const candidate = new Date(cursor);
+    const parts = getZonedParts(candidate, timezone);
+    if (matchesCron(parsed, parts)) {
+      return candidate;
+    }
+    if (!parsed.months.has(parts.month)) {
+      // Jump to the first minute of the next month in this timezone.
+      cursor += (32 - parts.day) * 24 * 60 * 60_000;
+      const sameTzNext = getZonedParts(new Date(cursor), timezone);
+      cursor -= (sameTzNext.day - 1) * 24 * 60 * 60_000
+        + sameTzNext.hour * 60 * 60_000
+        + sameTzNext.minute * 60_000;
+      continue;
+    }
+    const domStarred = parsed.domStarred;
+    const dowStarred = parsed.dowStarred;
+    const domOk = parsed.doms.has(parts.day);
+    const dowOk = parsed.dows.has(parts.dayOfWeek);
+    const dayMatches = (!domStarred && !dowStarred)
+      ? (domOk || dowOk)
+      : (domOk && dowOk);
+    if (!dayMatches) {
+      cursor += (24 - parts.hour) * 60 * 60_000 - parts.minute * 60_000;
+      continue;
+    }
+    if (!parsed.hours.has(parts.hour)) {
+      cursor += (60 - parts.minute) * 60_000;
+      continue;
+    }
+    cursor += 60_000;
+  }
+  throw new Error(`no cron match within 366 days for expression "${expression}"`);
+}
+
+module.exports = {
+  parseCronExpression,
+  isCronExpressionValid,
+  isTimezoneValid,
+  computeNextRun
+};

--- a/app/src/services/savedQueryScheduleService.js
+++ b/app/src/services/savedQueryScheduleService.js
@@ -1,0 +1,802 @@
+// QUERY-007: scheduled report delivery for saved queries.
+//
+// CRUD service for `saved_query_schedules` + dispatch helpers for the in-process
+// worker. The dispatcher itself lives in `scheduleDispatcher.js` and calls into
+// `dispatchSchedule()` here.
+//
+// Permissions: the route layer applies `saved_queries.schedule` first (admin +
+// analyst by default). On top of that, the service requires the caller to be
+// the owner of the saved query — schedules write to the owner's recipients and
+// are the owner's responsibility. Shared/granted recipients cannot schedule
+// other people's queries, matching the QUERY-006 share semantics.
+
+const appDb = require("../lib/appDb");
+const { isUuid } = require("../lib/validation");
+const { isCronExpressionValid, isTimezoneValid, computeNextRun } = require("./cronExpression");
+const { SUPPORTED_FORMATS } = require("./exportService");
+const { sendExportEmail } = require("./emailService");
+const { createDatabaseAdapter, isSupportedDbType } = require("../adapters/dbAdapterFactory");
+const { ensureLimit, sanitizeGeneratedSql, validateAndNormalizeSql } = require("./sqlSafety");
+const {
+  validateParameterValues,
+  substitutePlaceholdersForValidation
+} = require("./queryParameterService");
+
+const SCHEDULE_COLUMNS = `
+  id,
+  saved_query_id,
+  owner_user_id,
+  name,
+  cron_expression,
+  timezone,
+  recipients,
+  delivery_mode,
+  format,
+  parameter_overrides,
+  status,
+  next_run_at,
+  last_run_at,
+  last_status,
+  created_at,
+  updated_at
+`;
+
+const RUN_COLUMNS = `
+  id,
+  schedule_id,
+  saved_query_id,
+  scheduled_for,
+  started_at,
+  completed_at,
+  status,
+  attempt,
+  recipients,
+  delivery_mode,
+  format,
+  file_name,
+  file_size_bytes,
+  row_count,
+  error_message
+`;
+
+const ALLOWED_DELIVERY_MODES = new Set(["email", "download_artifact"]);
+const ALLOWED_FORMATS = new Set(["json", "csv", "tsv", "xlsx", "parquet"]);
+const ALLOWED_STATUSES = new Set(["active", "paused"]);
+const MAX_RECIPIENTS = 25;
+const MAX_NAME_LENGTH = 200;
+const MAX_ATTEMPTS = 3;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function success(body, statusCode = 200) {
+  return { ok: true, statusCode, body };
+}
+function failure(statusCode, body) {
+  return { ok: false, statusCode, body };
+}
+
+async function loadSavedQuery(savedQueryId) {
+  const result = await appDb.query(
+    `SELECT id, owner_id, sql, data_source_id, default_run_params, parameter_schema
+       FROM saved_queries WHERE id = $1`,
+    [savedQueryId]
+  );
+  return result.rows[0] || null;
+}
+
+async function loadSchedule(scheduleId) {
+  const result = await appDb.query(
+    `SELECT ${SCHEDULE_COLUMNS} FROM saved_query_schedules WHERE id = $1`,
+    [scheduleId]
+  );
+  return result.rows[0] || null;
+}
+
+function normalizeRecipients(value, deliveryMode) {
+  if (value === undefined || value === null) {
+    if (deliveryMode === "email") {
+      return { ok: false, message: "recipients are required for email delivery" };
+    }
+    return { ok: true, value: [] };
+  }
+  if (!Array.isArray(value)) {
+    return { ok: false, message: "recipients must be an array of email strings" };
+  }
+  const cleaned = [];
+  const seen = new Set();
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      return { ok: false, message: "recipients must be an array of email strings" };
+    }
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    if (!EMAIL_REGEX.test(trimmed)) {
+      return { ok: false, message: `invalid recipient email: ${trimmed}` };
+    }
+    const lower = trimmed.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    cleaned.push(trimmed);
+  }
+  if (deliveryMode === "email" && cleaned.length === 0) {
+    return { ok: false, message: "recipients are required for email delivery" };
+  }
+  if (cleaned.length > MAX_RECIPIENTS) {
+    return { ok: false, message: `cannot exceed ${MAX_RECIPIENTS} recipients per schedule` };
+  }
+  return { ok: true, value: cleaned };
+}
+
+function normalizeParameterOverrides(value) {
+  if (value === undefined || value === null) {
+    return { ok: true, value: {} };
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, message: "parameter_overrides must be an object" };
+  }
+  // The values themselves are validated against the saved query's parameter
+  // schema at dispatch time (`validateParameterValues`). At persist time we
+  // only ensure it's JSON-safe.
+  try {
+    JSON.stringify(value);
+  } catch {
+    return { ok: false, message: "parameter_overrides is not JSON-serialisable" };
+  }
+  return { ok: true, value };
+}
+
+function validateSchedulePayload(payload, { isUpdate = false } = {}) {
+  const out = {};
+  if (!isUpdate || payload.name !== undefined) {
+    if (typeof payload.name !== "string" || !payload.name.trim()) {
+      return { ok: false, message: "name is required" };
+    }
+    if (payload.name.length > MAX_NAME_LENGTH) {
+      return { ok: false, message: `name cannot exceed ${MAX_NAME_LENGTH} characters` };
+    }
+    out.name = payload.name.trim();
+  }
+  if (!isUpdate || payload.cron_expression !== undefined) {
+    if (!isCronExpressionValid(payload.cron_expression)) {
+      return { ok: false, message: "cron_expression is not a valid 5-field cron" };
+    }
+    out.cron_expression = String(payload.cron_expression).trim().replace(/\s+/g, " ");
+  }
+  if (!isUpdate || payload.timezone !== undefined) {
+    const tz = payload.timezone === undefined ? "UTC" : payload.timezone;
+    if (!isTimezoneValid(tz)) {
+      return { ok: false, message: `timezone is not a valid IANA name: ${tz}` };
+    }
+    out.timezone = tz;
+  }
+  if (!isUpdate || payload.delivery_mode !== undefined) {
+    const mode = payload.delivery_mode === undefined ? "email" : payload.delivery_mode;
+    if (!ALLOWED_DELIVERY_MODES.has(mode)) {
+      return {
+        ok: false,
+        message: `delivery_mode must be one of: ${[...ALLOWED_DELIVERY_MODES].join(", ")}`
+      };
+    }
+    out.delivery_mode = mode;
+  }
+  if (!isUpdate || payload.format !== undefined) {
+    const fmt = payload.format === undefined ? "csv" : payload.format;
+    if (!ALLOWED_FORMATS.has(fmt) || !SUPPORTED_FORMATS.has(fmt)) {
+      return { ok: false, message: `format must be one of: ${[...ALLOWED_FORMATS].join(", ")}` };
+    }
+    out.format = fmt;
+  }
+  if (!isUpdate || payload.recipients !== undefined) {
+    const deliveryMode = out.delivery_mode || payload.delivery_mode || "email";
+    const recipients = normalizeRecipients(payload.recipients, deliveryMode);
+    if (!recipients.ok) return recipients;
+    out.recipients = recipients.value;
+  }
+  if (!isUpdate || payload.parameter_overrides !== undefined) {
+    const overrides = normalizeParameterOverrides(payload.parameter_overrides);
+    if (!overrides.ok) return overrides;
+    out.parameter_overrides = overrides.value;
+  }
+  if (!isUpdate || payload.status !== undefined) {
+    const status = payload.status === undefined ? "active" : payload.status;
+    if (!ALLOWED_STATUSES.has(status)) {
+      return { ok: false, message: `status must be one of: ${[...ALLOWED_STATUSES].join(", ")}` };
+    }
+    out.status = status;
+  }
+  return { ok: true, value: out };
+}
+
+async function createSchedule(savedQueryId, payload, { callerUserId }) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (!callerUserId) {
+    return failure(401, { error: "unauthenticated" });
+  }
+  if (savedQuery.owner_id !== callerUserId) {
+    return failure(403, {
+      error: "forbidden",
+      message: "Only the owner can schedule deliveries for this saved query"
+    });
+  }
+  const validation = validateSchedulePayload(payload, { isUpdate: false });
+  if (!validation.ok) {
+    return failure(400, { error: "bad_request", message: validation.message });
+  }
+  const v = validation.value;
+  // Compute the next run from "now" so a freshly created schedule fires on the
+  // next matching minute and not retroactively for past minutes.
+  const nextRunAt = v.status === "paused"
+    ? null
+    : computeNextRun(v.cron_expression, v.timezone, new Date());
+
+  const result = await appDb.query(
+    `
+      INSERT INTO saved_query_schedules (
+        saved_query_id, owner_user_id, name, cron_expression, timezone,
+        recipients, delivery_mode, format, parameter_overrides, status, next_run_at
+      ) VALUES (
+        $1, $2, $3, $4, $5, $6::text[], $7, $8, $9::jsonb, $10, $11
+      )
+      RETURNING ${SCHEDULE_COLUMNS}
+    `,
+    [
+      savedQueryId,
+      callerUserId,
+      v.name,
+      v.cron_expression,
+      v.timezone,
+      v.recipients,
+      v.delivery_mode,
+      v.format,
+      JSON.stringify(v.parameter_overrides),
+      v.status,
+      nextRunAt
+    ]
+  );
+  return success(result.rows[0], 201);
+}
+
+async function listSchedules(savedQueryId, { callerUserId }) {
+  if (!isUuid(savedQueryId)) {
+    return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
+  }
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  // Read access: owner only. Recipients of shared queries cannot see who else
+  // is on the schedule.
+  if (callerUserId && savedQuery.owner_id !== callerUserId) {
+    return failure(403, {
+      error: "forbidden",
+      message: "Only the owner can view schedules for this saved query"
+    });
+  }
+  const result = await appDb.query(
+    `SELECT ${SCHEDULE_COLUMNS} FROM saved_query_schedules
+      WHERE saved_query_id = $1
+      ORDER BY created_at ASC`,
+    [savedQueryId]
+  );
+  // Attach recent run history per schedule (up to last 10) so the UI can render
+  // "last delivered" / retry context without a second round trip.
+  if (result.rows.length === 0) return success({ items: [] });
+  const scheduleIds = result.rows.map((row) => row.id);
+  const runsResult = await appDb.query(
+    `
+      SELECT ${RUN_COLUMNS}
+        FROM saved_query_schedule_runs
+       WHERE schedule_id = ANY($1::uuid[])
+       ORDER BY scheduled_for DESC, attempt DESC, started_at DESC NULLS LAST
+       LIMIT 200
+    `,
+    [scheduleIds]
+  );
+  const runsBySchedule = new Map();
+  for (const run of runsResult.rows) {
+    if (!runsBySchedule.has(run.schedule_id)) runsBySchedule.set(run.schedule_id, []);
+    const list = runsBySchedule.get(run.schedule_id);
+    if (list.length < 10) list.push(run);
+  }
+  const items = result.rows.map((row) => ({
+    ...row,
+    recent_runs: runsBySchedule.get(row.id) || []
+  }));
+  return success({ items });
+}
+
+async function updateSchedule(savedQueryId, scheduleId, payload, { callerUserId }) {
+  if (!isUuid(savedQueryId) || !isUuid(scheduleId)) {
+    return failure(400, { error: "bad_request", message: "Both ids must be valid UUIDs" });
+  }
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (callerUserId && savedQuery.owner_id !== callerUserId) {
+    return failure(403, {
+      error: "forbidden",
+      message: "Only the owner can update schedules for this saved query"
+    });
+  }
+  const existing = await loadSchedule(scheduleId);
+  if (!existing || existing.saved_query_id !== savedQueryId) {
+    return failure(404, { error: "not_found", message: "Schedule not found" });
+  }
+  const merged = {
+    name: existing.name,
+    cron_expression: existing.cron_expression,
+    timezone: existing.timezone,
+    recipients: existing.recipients,
+    delivery_mode: existing.delivery_mode,
+    format: existing.format,
+    parameter_overrides: existing.parameter_overrides,
+    status: existing.status,
+    ...payload
+  };
+  const validation = validateSchedulePayload(merged, { isUpdate: false });
+  if (!validation.ok) {
+    return failure(400, { error: "bad_request", message: validation.message });
+  }
+  const v = validation.value;
+  // Recompute next_run_at whenever cron / timezone / status changes, or when
+  // resuming from paused. Always recompute on edit to keep semantics simple.
+  let nextRunAt = existing.next_run_at;
+  if (v.status === "paused") {
+    nextRunAt = null;
+  } else if (
+    v.cron_expression !== existing.cron_expression
+    || v.timezone !== existing.timezone
+    || existing.status === "paused"
+    || nextRunAt === null
+  ) {
+    nextRunAt = computeNextRun(v.cron_expression, v.timezone, new Date());
+  }
+
+  const result = await appDb.query(
+    `
+      UPDATE saved_query_schedules
+         SET name = $2,
+             cron_expression = $3,
+             timezone = $4,
+             recipients = $5::text[],
+             delivery_mode = $6,
+             format = $7,
+             parameter_overrides = $8::jsonb,
+             status = $9,
+             next_run_at = $10,
+             updated_at = NOW()
+       WHERE id = $1
+       RETURNING ${SCHEDULE_COLUMNS}
+    `,
+    [
+      scheduleId,
+      v.name,
+      v.cron_expression,
+      v.timezone,
+      v.recipients,
+      v.delivery_mode,
+      v.format,
+      JSON.stringify(v.parameter_overrides),
+      v.status,
+      nextRunAt
+    ]
+  );
+  return success(result.rows[0]);
+}
+
+async function deleteSchedule(savedQueryId, scheduleId, { callerUserId }) {
+  if (!isUuid(savedQueryId) || !isUuid(scheduleId)) {
+    return failure(400, { error: "bad_request", message: "Both ids must be valid UUIDs" });
+  }
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (callerUserId && savedQuery.owner_id !== callerUserId) {
+    return failure(403, {
+      error: "forbidden",
+      message: "Only the owner can delete schedules for this saved query"
+    });
+  }
+  const existing = await loadSchedule(scheduleId);
+  if (!existing || existing.saved_query_id !== savedQueryId) {
+    return failure(404, { error: "not_found", message: "Schedule not found" });
+  }
+  const result = await appDb.query(
+    `DELETE FROM saved_query_schedules WHERE id = $1 RETURNING id`,
+    [scheduleId]
+  );
+  if (result.rowCount === 0) {
+    return failure(404, { error: "not_found", message: "Schedule not found" });
+  }
+  return success({ ok: true, id: result.rows[0].id });
+}
+
+async function loadSavedQueryForExecution(savedQueryId) {
+  const result = await appDb.query(
+    `
+      SELECT
+        sq.id,
+        sq.owner_id,
+        sq.name,
+        sq.description,
+        sq.data_source_id,
+        sq.sql,
+        sq.default_run_params,
+        sq.parameter_schema,
+        sq.tags,
+        sq.visibility,
+        sq.created_at,
+        sq.updated_at,
+        ds.connection_ref,
+        ds.db_type
+      FROM saved_queries sq
+      JOIN data_sources ds ON ds.id = sq.data_source_id
+      WHERE sq.id = $1
+    `,
+    [savedQueryId]
+  );
+  return result.rows[0] || null;
+}
+
+async function loadSchemaObjects(dataSourceId) {
+  const result = await appDb.query(
+    `
+      SELECT schema_name, object_name
+      FROM schema_objects
+      WHERE data_source_id = $1
+        AND is_ignored = FALSE
+        AND object_type IN ('table', 'view', 'materialized_view')
+    `,
+    [dataSourceId]
+  );
+  return result.rows;
+}
+
+// Execute the saved query with the schedule's parameter overrides, render the
+// chosen format, and return a buffer+filename. Mirrors the manual /run + /export
+// path but is self-contained so manual flows stay untouched.
+async function runScheduledQuery(savedQueryId, parameterOverrides, format) {
+  const savedQuery = await loadSavedQueryForExecution(savedQueryId);
+  if (!savedQuery) {
+    throw new Error(`Saved query not found: ${savedQueryId}`);
+  }
+  if (!isSupportedDbType(savedQuery.db_type)) {
+    throw new Error(`Unsupported db_type for execution: ${savedQuery.db_type}`);
+  }
+  const parameterValidation = validateParameterValues(
+    savedQuery.parameter_schema,
+    parameterOverrides || {}
+  );
+  if (!parameterValidation.ok) {
+    throw new Error(
+      `Invalid scheduled parameters: ${parameterValidation.errors.map((e) => e.message || e).join("; ")}`
+    );
+  }
+  const dialect = savedQuery.db_type === "mssql" ? "mssql" : "postgres";
+  const maxRows = Math.min(
+    Number(savedQuery.default_run_params?.max_rows) > 0
+      ? Number(savedQuery.default_run_params.max_rows)
+      : 10000,
+    100000
+  );
+  const timeoutMs = Math.min(
+    Number(savedQuery.default_run_params?.timeout_ms) > 0
+      ? Number(savedQuery.default_run_params.timeout_ms)
+      : 60000,
+    120000
+  );
+  const executableSql = ensureLimit(sanitizeGeneratedSql(savedQuery.sql), maxRows, dialect);
+  const schemaObjects = await loadSchemaObjects(savedQuery.data_source_id);
+  const validationSql = substitutePlaceholdersForValidation(executableSql, savedQuery.parameter_schema);
+  const normalized = validateAndNormalizeSql(validationSql, {
+    maxRows,
+    schemaObjects,
+    dialect
+  });
+  if (!normalized.ok) {
+    throw new Error(`SQL safety check failed: ${normalized.errors.join("; ")}`);
+  }
+  let adapter = null;
+  let rows;
+  let columns;
+  try {
+    adapter = createDatabaseAdapter(savedQuery.db_type, savedQuery.connection_ref);
+    const adapterValidation = await adapter.validateSql(normalized.sql);
+    if (!adapterValidation.ok) {
+      throw new Error(`Adapter validation failed: ${adapterValidation.errors.join("; ")}`);
+    }
+    const execution = await adapter.executeParameterizedReadOnly(
+      executableSql,
+      parameterValidation.resolvedValues,
+      savedQuery.parameter_schema,
+      { maxRows, timeoutMs }
+    );
+    rows = execution.rows;
+    columns = execution.columns;
+  } finally {
+    if (adapter) await adapter.close();
+  }
+  return renderExportInline(rows, columns, savedQuery.name, format);
+}
+
+// Inline renderer. We mirror exportService's format branches rather than going
+// through exportService.exportQueryResult, because that helper rehydrates from
+// a query_session that scheduled runs do not have. Same dependencies, same
+// supported formats.
+async function renderExportInline(rows, columns, queryName, format) {
+  const { stringify } = require("csv-stringify/sync");
+  const xlsx = require("xlsx");
+  const safeName = String(queryName || "scheduled_report").replace(/[^a-z0-9]/gi, "_").slice(0, 50);
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const columnOrder = Array.isArray(columns) && columns.length > 0
+    ? columns
+    : (rows[0] ? Object.keys(rows[0]) : []);
+
+  const filename = `${safeName}_${stamp}.${format}`;
+
+  if (format === "csv") {
+    return {
+      buffer: Buffer.from(stringify(rows, { header: true, columns: columnOrder.length ? columnOrder : undefined }), "utf8"),
+      contentType: "text/csv; charset=utf-8",
+      filename,
+      rowCount: rows.length
+    };
+  }
+  if (format === "tsv") {
+    return {
+      buffer: Buffer.from(stringify(rows, {
+        header: true,
+        columns: columnOrder.length ? columnOrder : undefined,
+        delimiter: "\t"
+      }), "utf8"),
+      contentType: "text/tab-separated-values; charset=utf-8",
+      filename,
+      rowCount: rows.length
+    };
+  }
+  if (format === "xlsx") {
+    const wb = xlsx.utils.book_new();
+    const ws = xlsx.utils.json_to_sheet(rows, { header: columnOrder.length ? columnOrder : undefined });
+    xlsx.utils.book_append_sheet(wb, ws, "Results");
+    return {
+      buffer: xlsx.write(wb, { type: "buffer", bookType: "xlsx" }),
+      contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      filename,
+      rowCount: rows.length
+    };
+  }
+  if (format === "parquet") {
+    if (rows.length === 0) {
+      return {
+        buffer: Buffer.from("[]", "utf8"),
+        contentType: "application/json; charset=utf-8",
+        filename: `${safeName}_${stamp}.json`,
+        rowCount: 0
+      };
+    }
+    const parquet = require("parquetjs-lite");
+    const fs = require("fs/promises");
+    const os = require("os");
+    const path = require("path");
+    const schemaDefinition = {};
+    for (const column of columnOrder) {
+      schemaDefinition[column] = { type: "UTF8", optional: true };
+    }
+    const schema = new parquet.ParquetSchema(schemaDefinition);
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "report-pilot-schedule-"));
+    const filePath = path.join(tempDir, `export-${Date.now()}.parquet`);
+    let writer;
+    try {
+      writer = await parquet.ParquetWriter.openFile(schema, filePath);
+      for (const row of rows) {
+        const normalizedRow = {};
+        for (const column of columnOrder) {
+          const v = row[column];
+          normalizedRow[column] = v === null || v === undefined ? null : String(v);
+        }
+        await writer.appendRow(normalizedRow);
+      }
+      await writer.close();
+      writer = null;
+      const buffer = await fs.readFile(filePath);
+      return {
+        buffer,
+        contentType: "application/vnd.apache.parquet",
+        filename,
+        rowCount: rows.length
+      };
+    } finally {
+      if (writer) await writer.close().catch(() => {});
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+  return {
+    buffer: Buffer.from(JSON.stringify(rows, null, 2), "utf8"),
+    contentType: "application/json; charset=utf-8",
+    filename,
+    rowCount: rows.length
+  };
+}
+
+// One full dispatch: insert a run row, attempt delivery, update both the run +
+// the schedule's next_run_at. Used by the dispatcher and by the retry endpoint.
+async function dispatchSchedule(schedule, { scheduledFor = null, attempt = 1 } = {}) {
+  const now = new Date();
+  const runScheduledFor = scheduledFor || schedule.next_run_at || now;
+  const runResult = await appDb.query(
+    `
+      INSERT INTO saved_query_schedule_runs (
+        schedule_id, saved_query_id, scheduled_for, started_at, status, attempt,
+        recipients, delivery_mode, format
+      ) VALUES ($1, $2, $3, $4, 'running', $5, $6::text[], $7, $8)
+      RETURNING ${RUN_COLUMNS}
+    `,
+    [
+      schedule.id,
+      schedule.saved_query_id,
+      runScheduledFor,
+      now,
+      attempt,
+      schedule.recipients || [],
+      schedule.delivery_mode,
+      schedule.format
+    ]
+  );
+  const run = runResult.rows[0];
+  await appDb.query(
+    `UPDATE saved_query_schedules SET last_status = 'running', updated_at = NOW() WHERE id = $1`,
+    [schedule.id]
+  );
+  try {
+    const rendered = await runScheduledQuery(
+      schedule.saved_query_id,
+      schedule.parameter_overrides || {},
+      schedule.format
+    );
+    if (schedule.delivery_mode === "email") {
+      await sendExportEmail({
+        recipients: schedule.recipients,
+        subject: `Report Pilot Scheduled Report: ${schedule.name}`,
+        textBody:
+          `Your scheduled report "${schedule.name}" is attached.\n\n`
+          + `Format: ${schedule.format.toUpperCase()}\n`
+          + `Rows: ${rendered.rowCount}\n`
+          + `File: ${rendered.filename}\n`
+          + `Scheduled for: ${new Date(runScheduledFor).toISOString()}\n`,
+        fileBuffer: rendered.buffer,
+        fileName: rendered.filename,
+        contentType: rendered.contentType
+      });
+    }
+    // For download_artifact mode we record the file metadata only; the bytes
+    // themselves are not persisted (matches the existing export_deliveries
+    // pattern which is also stateless on file content).
+    const nextRunAt = schedule.status === "paused"
+      ? null
+      : computeNextRun(schedule.cron_expression, schedule.timezone, new Date());
+    await appDb.query(
+      `
+        UPDATE saved_query_schedule_runs
+           SET status = 'succeeded',
+               completed_at = NOW(),
+               file_name = $2,
+               file_size_bytes = $3,
+               row_count = $4
+         WHERE id = $1
+      `,
+      [run.id, rendered.filename, rendered.buffer.length, rendered.rowCount]
+    );
+    await appDb.query(
+      `
+        UPDATE saved_query_schedules
+           SET last_run_at = NOW(),
+               last_status = 'succeeded',
+               next_run_at = $2,
+               updated_at = NOW()
+         WHERE id = $1
+      `,
+      [schedule.id, nextRunAt]
+    );
+    return { ok: true, runId: run.id, filename: rendered.filename, rowCount: rendered.rowCount };
+  } catch (err) {
+    const errMessage = err && err.message ? String(err.message).slice(0, 2000) : "unknown error";
+    await appDb.query(
+      `
+        UPDATE saved_query_schedule_runs
+           SET status = 'failed', completed_at = NOW(), error_message = $2
+         WHERE id = $1
+      `,
+      [run.id, errMessage]
+    );
+    // Bump next_run_at to the next cron tick even on failure — the schedule
+    // keeps running. Per-attempt retries are surfaced via the runs history,
+    // and an explicit POST /retry endpoint can re-attempt before then.
+    const nextRunAt = schedule.status === "paused"
+      ? null
+      : computeNextRun(schedule.cron_expression, schedule.timezone, new Date());
+    await appDb.query(
+      `
+        UPDATE saved_query_schedules
+           SET last_run_at = NOW(),
+               last_status = 'failed',
+               next_run_at = $2,
+               updated_at = NOW()
+         WHERE id = $1
+      `,
+      [schedule.id, nextRunAt]
+    );
+    return { ok: false, runId: run.id, error: errMessage };
+  }
+}
+
+async function listDueSchedules(now = new Date(), limit = 50) {
+  const result = await appDb.query(
+    `
+      SELECT ${SCHEDULE_COLUMNS}
+        FROM saved_query_schedules
+       WHERE status = 'active'
+         AND next_run_at IS NOT NULL
+         AND next_run_at <= $1
+       ORDER BY next_run_at ASC
+       LIMIT $2
+    `,
+    [now, limit]
+  );
+  return result.rows;
+}
+
+// Manual retry: re-dispatch the latest run for this schedule. Bumps the
+// `attempt` counter so the runs table reflects the retry chain. Capped at
+// MAX_ATTEMPTS attempts to keep an owner from looping indefinitely on a
+// permanently-broken target — they can edit the schedule (recipients, SQL,
+// etc.) to reset the chain.
+async function retryFailedRun(savedQueryId, scheduleId, { callerUserId }) {
+  if (!isUuid(savedQueryId) || !isUuid(scheduleId)) {
+    return failure(400, { error: "bad_request", message: "Both ids must be valid UUIDs" });
+  }
+  const savedQuery = await loadSavedQuery(savedQueryId);
+  if (!savedQuery) {
+    return failure(404, { error: "not_found", message: "Saved query not found" });
+  }
+  if (callerUserId && savedQuery.owner_id !== callerUserId) {
+    return failure(403, { error: "forbidden", message: "Only the owner can retry scheduled deliveries" });
+  }
+  const schedule = await loadSchedule(scheduleId);
+  if (!schedule || schedule.saved_query_id !== savedQueryId) {
+    return failure(404, { error: "not_found", message: "Schedule not found" });
+  }
+  const latest = await appDb.query(
+    `SELECT attempt, status FROM saved_query_schedule_runs
+      WHERE schedule_id = $1 ORDER BY scheduled_for DESC LIMIT 1`,
+    [scheduleId]
+  );
+  const lastAttempt = latest.rows[0]?.attempt ?? 0;
+  if (lastAttempt >= MAX_ATTEMPTS) {
+    return failure(429, {
+      error: "too_many_attempts",
+      message: `Reached the retry cap of ${MAX_ATTEMPTS} attempts. Edit the schedule and try again.`
+    });
+  }
+  const dispatch = await dispatchSchedule(schedule, { attempt: lastAttempt + 1 });
+  return success({ ok: dispatch.ok, run_id: dispatch.runId, error: dispatch.error || null });
+}
+
+module.exports = {
+  createSchedule,
+  listSchedules,
+  updateSchedule,
+  deleteSchedule,
+  dispatchSchedule,
+  listDueSchedules,
+  retryFailedRun,
+  validateSchedulePayload,
+  EMAIL_REGEX,
+  MAX_ATTEMPTS
+};

--- a/app/src/services/scheduleDispatcher.js
+++ b/app/src/services/scheduleDispatcher.js
@@ -1,0 +1,92 @@
+// QUERY-007: in-process dispatcher for scheduled saved-query delivery.
+//
+// Why in-process: we already run a single Node server (see start.js) and adding
+// a second worker process / external queue would be heavy for the current scope.
+// The dispatcher polls `saved_query_schedules` every `tickIntervalMs` (default
+// 60s), picks rows whose `next_run_at <= now` and `status = 'active'`, and
+// invokes `dispatchSchedule()` for each. The dispatch flow updates next_run_at
+// itself, so a re-poll won't double-fire.
+//
+// Concurrency safety: we serialize one tick at a time per Node process. If the
+// app is ever horizontally scaled, swap the polling-loop for a SELECT ... FOR
+// UPDATE SKIP LOCKED claim, or move to a real queue. The runs table is
+// idempotent-ish (a duplicate dispatch creates a separate runs row) so the
+// worst-case is two emails for the same scheduled tick, not silent data loss.
+//
+// Disable in tests by leaving `SCHEDULE_DISPATCHER_ENABLED` unset (default
+// "false"). Enable in prod by setting it to "true" in the environment.
+
+const scheduleService = require("./savedQueryScheduleService");
+const { logEvent } = require("../lib/observability");
+
+let intervalHandle = null;
+let runningTick = false;
+
+async function tickOnce() {
+  if (runningTick) return { skipped: true };
+  runningTick = true;
+  try {
+    const due = await scheduleService.listDueSchedules(new Date(), 50);
+    if (due.length === 0) {
+      return { dispatched: 0 };
+    }
+    let succeeded = 0;
+    let failed = 0;
+    for (const schedule of due) {
+      try {
+        const result = await scheduleService.dispatchSchedule(schedule);
+        if (result.ok) succeeded += 1;
+        else failed += 1;
+      } catch (err) {
+        failed += 1;
+        logEvent("schedule_dispatch_error", {
+          schedule_id: schedule.id,
+          saved_query_id: schedule.saved_query_id,
+          error: err && err.message ? err.message : String(err)
+        }, "error");
+      }
+    }
+    logEvent("schedule_dispatcher_tick", {
+      due_count: due.length,
+      succeeded,
+      failed
+    });
+    return { dispatched: due.length, succeeded, failed };
+  } finally {
+    runningTick = false;
+  }
+}
+
+function startDispatcher({ tickIntervalMs = 60_000 } = {}) {
+  if (intervalHandle) return intervalHandle;
+  intervalHandle = setInterval(() => {
+    tickOnce().catch((err) => {
+      logEvent("schedule_dispatcher_tick_error", {
+        error: err && err.message ? err.message : String(err)
+      }, "error");
+    });
+  }, tickIntervalMs);
+  // Don't keep the process alive solely because of the dispatcher (keeps test
+  // teardown clean).
+  if (typeof intervalHandle.unref === "function") intervalHandle.unref();
+  logEvent("schedule_dispatcher_started", { tick_interval_ms: tickIntervalMs });
+  return intervalHandle;
+}
+
+function stopDispatcher() {
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+}
+
+function isEnabled() {
+  return String(process.env.SCHEDULE_DISPATCHER_ENABLED || "false") === "true";
+}
+
+module.exports = {
+  startDispatcher,
+  stopDispatcher,
+  tickOnce,
+  isEnabled
+};

--- a/app/src/start.js
+++ b/app/src/start.js
@@ -1,5 +1,6 @@
 const { runMigrations } = require("./migrate");
 const { startServer } = require("./server");
+const scheduleDispatcher = require("./services/scheduleDispatcher");
 
 async function start() {
   console.log("[boot] Running migrations...");
@@ -7,6 +8,15 @@ async function start() {
 
   console.log("[boot] Starting HTTP server...");
   await startServer();
+
+  // QUERY-007: in-process scheduled-delivery worker. Off by default so tests
+  // and bare `npm start` runs don't poll the DB; enable in deployment via
+  // SCHEDULE_DISPATCHER_ENABLED=true.
+  if (scheduleDispatcher.isEnabled()) {
+    const intervalMs = Number(process.env.SCHEDULE_DISPATCHER_INTERVAL_MS || 60_000);
+    scheduleDispatcher.startDispatcher({ tickIntervalMs: intervalMs });
+    console.log(`[boot] Schedule dispatcher running every ${intervalMs}ms`);
+  }
 }
 
 start().catch((err) => {

--- a/app/test/cronExpression.test.js
+++ b/app/test/cronExpression.test.js
@@ -1,0 +1,74 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  parseCronExpression,
+  isCronExpressionValid,
+  isTimezoneValid,
+  computeNextRun
+} = require("../src/services/cronExpression");
+
+test("parseCronExpression accepts well-formed 5-field cron", () => {
+  const parsed = parseCronExpression("0 9 * * 1-5");
+  assert.ok(parsed.minutes.has(0));
+  assert.equal(parsed.minutes.size, 1);
+  assert.ok(parsed.hours.has(9));
+  assert.deepEqual([...parsed.dows].sort(), [1, 2, 3, 4, 5]);
+  assert.equal(parsed.domStarred, true);
+  assert.equal(parsed.dowStarred, false);
+});
+
+test("parseCronExpression accepts steps and lists", () => {
+  const parsed = parseCronExpression("*/15 0,12 1,15 * *");
+  assert.deepEqual([...parsed.minutes].sort((a, b) => a - b), [0, 15, 30, 45]);
+  assert.deepEqual([...parsed.hours].sort((a, b) => a - b), [0, 12]);
+  assert.deepEqual([...parsed.doms].sort((a, b) => a - b), [1, 15]);
+});
+
+test("parseCronExpression treats 7 as Sunday", () => {
+  const parsed = parseCronExpression("0 0 * * 7");
+  assert.ok(parsed.dows.has(0));
+});
+
+test("isCronExpressionValid returns false on garbage", () => {
+  assert.equal(isCronExpressionValid("not a cron"), false);
+  assert.equal(isCronExpressionValid("60 0 * * *"), false); // minute out of range
+  assert.equal(isCronExpressionValid("0 0 0 * *"), false);  // day-of-month 0 invalid
+  assert.equal(isCronExpressionValid("0 0 * 13 *"), false); // month 13 invalid
+  assert.equal(isCronExpressionValid("0 0 * *"), false);    // 4 fields
+});
+
+test("isTimezoneValid accepts IANA names and rejects garbage", () => {
+  assert.equal(isTimezoneValid("UTC"), true);
+  assert.equal(isTimezoneValid("Europe/London"), true);
+  assert.equal(isTimezoneValid("America/New_York"), true);
+  assert.equal(isTimezoneValid("Not/A/Real/Zone"), false);
+  assert.equal(isTimezoneValid(""), false);
+  assert.equal(isTimezoneValid(null), false);
+});
+
+test("computeNextRun returns the next minute matching the expression in UTC", () => {
+  // 2026-05-18T12:34:56Z → next 09:00 UTC fires next day at 09:00 UTC because
+  // 12:34 is already past today's 09:00.
+  const from = new Date("2026-05-18T12:34:56Z");
+  const next = computeNextRun("0 9 * * *", "UTC", from);
+  assert.equal(next.toISOString(), "2026-05-19T09:00:00.000Z");
+});
+
+test("computeNextRun honours the schedule timezone", () => {
+  // 09:00 in Europe/London on 2026-05-18 is 08:00 UTC (BST in effect).
+  const from = new Date("2026-05-18T05:00:00Z");
+  const next = computeNextRun("0 9 * * *", "Europe/London", from);
+  assert.equal(next.toISOString(), "2026-05-18T08:00:00.000Z");
+});
+
+test("computeNextRun handles weekday filter (Mon-Fri)", () => {
+  // 2026-05-16 is a Saturday → next 09:00 Mon-Fri UTC is 2026-05-18 09:00.
+  const from = new Date("2026-05-16T12:00:00Z");
+  const next = computeNextRun("0 9 * * 1-5", "UTC", from);
+  assert.equal(next.toISOString(), "2026-05-18T09:00:00.000Z");
+});
+
+test("computeNextRun throws when called on an impossible schedule", () => {
+  assert.throws(() => computeNextRun("0 0 31 2 *", "UTC", new Date("2026-01-01T00:00:00Z")));
+});

--- a/app/test/helpers/authTestStub.js
+++ b/app/test/helpers/authTestStub.js
@@ -38,6 +38,7 @@ const ROLE_PERMISSIONS = {
     "saved_queries.read",
     "saved_queries.write",
     "saved_queries.share",
+    "saved_queries.schedule",
     "observability.read",
     "observability.write",
     ...SELF_PERMS
@@ -51,6 +52,7 @@ const ROLE_PERMISSIONS = {
     "saved_queries.read",
     "saved_queries.write",
     "saved_queries.share",
+    "saved_queries.schedule",
     "observability.read",
     ...SELF_PERMS
   ],

--- a/app/test/savedQuerySchedulesApi.test.js
+++ b/app/test/savedQuerySchedulesApi.test.js
@@ -1,0 +1,667 @@
+const { test, before, after, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+process.env.PORT = "0";
+process.env.AUTH_COOKIE_SECURE = "false";
+
+const appDb = require("../src/lib/appDb");
+const dbAdapterFactory = require("../src/adapters/dbAdapterFactory");
+const emailService = require("../src/services/emailService");
+const { createAuthTestStub } = require("./helpers/authTestStub");
+
+const DATA_SOURCE_ID = "00000000-0000-4000-8000-000000000111";
+
+let server;
+let baseUrl;
+let savedQueries;
+let savedQueryShares;
+let savedQueryVersions;
+let schedules;
+let scheduleRuns;
+let savedQueryCounter;
+let scheduleCounter;
+let scheduleRunCounter;
+let originalQuery;
+let originalCreateDatabaseAdapter;
+let originalIsSupportedDbType;
+let originalSendExportEmail;
+let sentEmails;
+let emailFailureMode;
+let authStub;
+const testUsers = {};
+
+function nextSavedQueryId() {
+  savedQueryCounter += 1;
+  return `00000000-0000-4000-8000-${String(savedQueryCounter).padStart(12, "0")}`;
+}
+
+function nextScheduleId() {
+  scheduleCounter += 1;
+  return `00000000-0000-4000-8000-dddd${String(scheduleCounter).padStart(8, "0")}`;
+}
+
+function nextScheduleRunId() {
+  scheduleRunCounter += 1;
+  return `00000000-0000-4000-8000-eeee${String(scheduleRunCounter).padStart(8, "0")}`;
+}
+
+function normalize(sql) {
+  return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function ensureTestUser(label, role = "analyst") {
+  if (testUsers[label]) return testUsers[label];
+  const user = authStub.seedUser({
+    email: `${label}@example.com`,
+    roles: [role],
+    dataSourceAccess: [DATA_SOURCE_ID]
+  });
+  const cookie = authStub.cookieFor(authStub.seedSession(user.id).token);
+  testUsers[label] = { id: user.id, cookie, role };
+  return testUsers[label];
+}
+
+function userId(label) {
+  return ensureTestUser(label).id;
+}
+
+async function api(method, path, body, label = "owner", { role = "analyst" } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (label !== null) {
+    const fixture = ensureTestUser(label, role);
+    headers.Cookie = fixture.cookie;
+  }
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+  return { status: response.status, payload };
+}
+
+async function seedSavedQuery({ ownerLabel = "owner", name = "Daily report", sql = "SELECT 1 AS value" } = {}) {
+  const ownerId = userId(ownerLabel);
+  const id = nextSavedQueryId();
+  const now = new Date().toISOString();
+  savedQueries.set(id, {
+    id,
+    owner_id: ownerId,
+    name,
+    description: null,
+    data_source_id: DATA_SOURCE_ID,
+    sql,
+    default_run_params: {},
+    parameter_schema: [],
+    tags: [],
+    visibility: "private",
+    created_at: now,
+    updated_at: now
+  });
+  return id;
+}
+
+before(async () => {
+  originalQuery = appDb.query;
+  originalCreateDatabaseAdapter = dbAdapterFactory.createDatabaseAdapter;
+  originalIsSupportedDbType = dbAdapterFactory.isSupportedDbType;
+  originalSendExportEmail = emailService.sendExportEmail;
+
+  savedQueries = new Map();
+  savedQueryShares = new Map();
+  savedQueryVersions = new Map();
+  schedules = new Map();
+  scheduleRuns = new Map();
+  savedQueryCounter = 0;
+  scheduleCounter = 0;
+  scheduleRunCounter = 0;
+  sentEmails = [];
+  emailFailureMode = null;
+  authStub = createAuthTestStub();
+
+  dbAdapterFactory.createDatabaseAdapter = () => ({
+    async validateSql() {
+      return { ok: true, errors: [], refs: [] };
+    },
+    async executeParameterizedReadOnly() {
+      return {
+        columns: ["value"],
+        rows: [{ value: 1 }],
+        rowCount: 1,
+        durationMs: 4
+      };
+    },
+    async close() {}
+  });
+  dbAdapterFactory.isSupportedDbType = (dbType) => dbType === "postgres" || dbType === "mssql";
+
+  // Stub email transport so tests can assert on what would have been sent and
+  // exercise the failure path without touching SMTP.
+  emailService.sendExportEmail = async (opts) => {
+    if (emailFailureMode === "throw") {
+      throw new Error("SMTP unavailable (test stub)");
+    }
+    sentEmails.push({
+      recipients: [...opts.recipients],
+      subject: opts.subject,
+      fileName: opts.fileName,
+      bytes: opts.fileBuffer.length
+    });
+    return { messageId: `stub-${sentEmails.length}` };
+  };
+
+  appDb.query = async (sql, params = []) => {
+    const auth = authStub.handleSql(sql, params);
+    if (auth) return auth;
+    const normalized = normalize(sql);
+
+    if (normalized === "select id from data_sources where id = $1") {
+      const [id] = params;
+      if (id === DATA_SOURCE_ID) {
+        return { rowCount: 1, rows: [{ id }] };
+      }
+      return { rowCount: 0, rows: [] };
+    }
+
+    if (normalized === "select data_source_id from saved_queries where id = $1") {
+      const [id] = params;
+      const row = savedQueries.get(id);
+      return row
+        ? { rowCount: 1, rows: [{ data_source_id: row.data_source_id }] }
+        : { rowCount: 0, rows: [] };
+    }
+
+    if (normalized.startsWith("select id, owner_id, sql, data_source_id, default_run_params, parameter_schema from saved_queries where id = $1")) {
+      const [id] = params;
+      const row = savedQueries.get(id);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    if (normalized.startsWith("select sq.id, sq.owner_id, sq.name, sq.description, sq.data_source_id, sq.sql, sq.default_run_params, sq.parameter_schema, sq.tags, sq.visibility, sq.created_at, sq.updated_at, ds.connection_ref, ds.db_type from saved_queries sq join data_sources ds on ds.id = sq.data_source_id where sq.id = $1")) {
+      const [id] = params;
+      const row = savedQueries.get(id);
+      if (!row) return { rowCount: 0, rows: [] };
+      return {
+        rowCount: 1,
+        rows: [{ ...row, connection_ref: "postgresql://example", db_type: "postgres" }]
+      };
+    }
+
+    if (normalized.startsWith("select schema_name, object_name from schema_objects where data_source_id = $1")) {
+      return { rowCount: 1, rows: [{ schema_name: "public", object_name: "revenue" }] };
+    }
+
+    // CRUD on saved_query_schedules
+    if (normalized.startsWith("insert into saved_query_schedules")) {
+      const [
+        savedQueryId,
+        ownerUserId,
+        name,
+        cronExpression,
+        timezone,
+        recipients,
+        deliveryMode,
+        format,
+        parameterOverridesJson,
+        status,
+        nextRunAt
+      ] = params;
+      const now = new Date().toISOString();
+      const row = {
+        id: nextScheduleId(),
+        saved_query_id: savedQueryId,
+        owner_user_id: ownerUserId,
+        name,
+        cron_expression: cronExpression,
+        timezone,
+        recipients: Array.isArray(recipients) ? recipients : [],
+        delivery_mode: deliveryMode,
+        format,
+        parameter_overrides: JSON.parse(parameterOverridesJson),
+        status,
+        next_run_at: nextRunAt,
+        last_run_at: null,
+        last_status: null,
+        created_at: now,
+        updated_at: now
+      };
+      schedules.set(row.id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (normalized.startsWith("select id, saved_query_id, owner_user_id, name, cron_expression, timezone, recipients, delivery_mode, format, parameter_overrides, status, next_run_at, last_run_at, last_status, created_at, updated_at from saved_query_schedules where saved_query_id = $1")) {
+      const [savedQueryId] = params;
+      const rows = [...schedules.values()]
+        .filter((row) => row.saved_query_id === savedQueryId)
+        .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith("select id, saved_query_id, owner_user_id, name, cron_expression, timezone, recipients, delivery_mode, format, parameter_overrides, status, next_run_at, last_run_at, last_status, created_at, updated_at from saved_query_schedules where id = $1")) {
+      const [id] = params;
+      const row = schedules.get(id);
+      return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
+    }
+
+    if (normalized.startsWith("select id, saved_query_id, owner_user_id, name, cron_expression, timezone, recipients, delivery_mode, format, parameter_overrides, status, next_run_at, last_run_at, last_status, created_at, updated_at from saved_query_schedules where status = 'active'")) {
+      const [now, limit] = params;
+      const rows = [...schedules.values()]
+        .filter((row) => row.status === "active" && row.next_run_at && new Date(row.next_run_at) <= new Date(now))
+        .sort((a, b) => new Date(a.next_run_at) - new Date(b.next_run_at))
+        .slice(0, limit);
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith("update saved_query_schedules set name = $2,")) {
+      const [
+        id,
+        name,
+        cronExpression,
+        timezone,
+        recipients,
+        deliveryMode,
+        format,
+        parameterOverridesJson,
+        status,
+        nextRunAt
+      ] = params;
+      const existing = schedules.get(id);
+      if (!existing) return { rowCount: 0, rows: [] };
+      const updated = {
+        ...existing,
+        name,
+        cron_expression: cronExpression,
+        timezone,
+        recipients: Array.isArray(recipients) ? recipients : [],
+        delivery_mode: deliveryMode,
+        format,
+        parameter_overrides: JSON.parse(parameterOverridesJson),
+        status,
+        next_run_at: nextRunAt,
+        updated_at: new Date().toISOString()
+      };
+      schedules.set(id, updated);
+      return { rowCount: 1, rows: [updated] };
+    }
+
+    if (normalized.startsWith("update saved_query_schedules set last_status = 'running'")) {
+      const [id] = params;
+      const existing = schedules.get(id);
+      if (existing) {
+        schedules.set(id, { ...existing, last_status: "running", updated_at: new Date().toISOString() });
+      }
+      return { rowCount: existing ? 1 : 0, rows: [] };
+    }
+
+    if (normalized.startsWith("update saved_query_schedules set last_run_at = now(), last_status = 'succeeded'")) {
+      const [id, nextRunAt] = params;
+      const existing = schedules.get(id);
+      if (existing) {
+        schedules.set(id, {
+          ...existing,
+          last_run_at: new Date().toISOString(),
+          last_status: "succeeded",
+          next_run_at: nextRunAt,
+          updated_at: new Date().toISOString()
+        });
+      }
+      return { rowCount: existing ? 1 : 0, rows: [] };
+    }
+
+    if (normalized.startsWith("update saved_query_schedules set last_run_at = now(), last_status = 'failed'")) {
+      const [id, nextRunAt] = params;
+      const existing = schedules.get(id);
+      if (existing) {
+        schedules.set(id, {
+          ...existing,
+          last_run_at: new Date().toISOString(),
+          last_status: "failed",
+          next_run_at: nextRunAt,
+          updated_at: new Date().toISOString()
+        });
+      }
+      return { rowCount: existing ? 1 : 0, rows: [] };
+    }
+
+    if (normalized.startsWith("delete from saved_query_schedules where id = $1 returning id")) {
+      const [id] = params;
+      if (!schedules.has(id)) return { rowCount: 0, rows: [] };
+      schedules.delete(id);
+      // CASCADE clean-up of runs.
+      for (const [runId, run] of [...scheduleRuns.entries()]) {
+        if (run.schedule_id === id) scheduleRuns.delete(runId);
+      }
+      return { rowCount: 1, rows: [{ id }] };
+    }
+
+    // Runs
+    if (normalized.startsWith("insert into saved_query_schedule_runs")) {
+      const [
+        scheduleId,
+        savedQueryId,
+        scheduledFor,
+        startedAt,
+        attempt,
+        recipients,
+        deliveryMode,
+        format
+      ] = params;
+      const row = {
+        id: nextScheduleRunId(),
+        schedule_id: scheduleId,
+        saved_query_id: savedQueryId,
+        scheduled_for: scheduledFor,
+        started_at: startedAt,
+        completed_at: null,
+        status: "running",
+        attempt,
+        recipients: Array.isArray(recipients) ? recipients : [],
+        delivery_mode: deliveryMode,
+        format,
+        file_name: null,
+        file_size_bytes: null,
+        row_count: null,
+        error_message: null
+      };
+      scheduleRuns.set(row.id, row);
+      return { rowCount: 1, rows: [row] };
+    }
+
+    if (normalized.startsWith("update saved_query_schedule_runs set status = 'succeeded'")) {
+      const [id, fileName, fileSize, rowCount] = params;
+      const existing = scheduleRuns.get(id);
+      if (existing) {
+        scheduleRuns.set(id, {
+          ...existing,
+          status: "succeeded",
+          completed_at: new Date().toISOString(),
+          file_name: fileName,
+          file_size_bytes: fileSize,
+          row_count: rowCount
+        });
+      }
+      return { rowCount: existing ? 1 : 0, rows: [] };
+    }
+
+    if (normalized.startsWith("update saved_query_schedule_runs set status = 'failed'")) {
+      const [id, errMessage] = params;
+      const existing = scheduleRuns.get(id);
+      if (existing) {
+        scheduleRuns.set(id, {
+          ...existing,
+          status: "failed",
+          completed_at: new Date().toISOString(),
+          error_message: errMessage
+        });
+      }
+      return { rowCount: existing ? 1 : 0, rows: [] };
+    }
+
+    if (normalized.startsWith("select id, schedule_id, saved_query_id, scheduled_for, started_at, completed_at, status, attempt, recipients, delivery_mode, format, file_name, file_size_bytes, row_count, error_message from saved_query_schedule_runs where schedule_id = any")) {
+      const [scheduleIds] = params;
+      const set = new Set(scheduleIds);
+      const rows = [...scheduleRuns.values()]
+        .filter((row) => set.has(row.schedule_id))
+        .sort((a, b) => {
+          const dateDiff = new Date(b.scheduled_for) - new Date(a.scheduled_for);
+          if (dateDiff !== 0) return dateDiff;
+          if (b.attempt !== a.attempt) return b.attempt - a.attempt;
+          const ta = a.started_at ? new Date(a.started_at).getTime() : 0;
+          const tb = b.started_at ? new Date(b.started_at).getTime() : 0;
+          return tb - ta;
+        })
+        .slice(0, 200);
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith("select attempt, status from saved_query_schedule_runs where schedule_id = $1")) {
+      const [scheduleId] = params;
+      const rows = [...scheduleRuns.values()]
+        .filter((row) => row.schedule_id === scheduleId)
+        .sort((a, b) => new Date(b.scheduled_for) - new Date(a.scheduled_for))
+        .slice(0, 1)
+        .map((row) => ({ attempt: row.attempt, status: row.status }));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith("insert into auth_audit_log")) {
+      return { rowCount: 1, rows: [] };
+    }
+
+    throw new Error(`Unexpected SQL in schedule test stub: ${normalized}`);
+  };
+
+  delete require.cache[require.resolve("../src/server")];
+  const { startServer } = require("../src/server");
+  server = await startServer();
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+beforeEach(() => {
+  savedQueries.clear();
+  savedQueryShares.clear();
+  savedQueryVersions.clear();
+  schedules.clear();
+  scheduleRuns.clear();
+  savedQueryCounter = 0;
+  scheduleCounter = 0;
+  scheduleRunCounter = 0;
+  sentEmails = [];
+  emailFailureMode = null;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  appDb.query = originalQuery;
+  dbAdapterFactory.createDatabaseAdapter = originalCreateDatabaseAdapter;
+  dbAdapterFactory.isSupportedDbType = originalIsSupportedDbType;
+  emailService.sendExportEmail = originalSendExportEmail;
+});
+
+test("QUERY-007 create + list + update + delete schedule happy path", async () => {
+  const savedQueryId = await seedSavedQuery({ ownerLabel: "owner" });
+
+  const create = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
+    name: "Weekday 9am",
+    cron_expression: "0 9 * * 1-5",
+    timezone: "UTC",
+    recipients: ["ops@example.com", "lead@example.com"],
+    delivery_mode: "email",
+    format: "csv"
+  }, "owner");
+  assert.equal(create.status, 201);
+  assert.equal(create.payload.name, "Weekday 9am");
+  assert.equal(create.payload.cron_expression, "0 9 * * 1-5");
+  assert.equal(create.payload.format, "csv");
+  assert.deepEqual(create.payload.recipients, ["ops@example.com", "lead@example.com"]);
+  assert.ok(create.payload.next_run_at);
+  assert.equal(create.payload.status, "active");
+
+  const list = await api("GET", `/v1/saved-queries/${savedQueryId}/schedules`, undefined, "owner");
+  assert.equal(list.status, 200);
+  assert.equal(list.payload.items.length, 1);
+  assert.equal(list.payload.items[0].id, create.payload.id);
+  assert.deepEqual(list.payload.items[0].recent_runs, []);
+
+  const update = await api("PUT", `/v1/saved-queries/${savedQueryId}/schedules/${create.payload.id}`, {
+    name: "Weekday 9am (paused)",
+    status: "paused"
+  }, "owner");
+  assert.equal(update.status, 200);
+  assert.equal(update.payload.status, "paused");
+  assert.equal(update.payload.next_run_at, null);
+
+  const del = await api("DELETE", `/v1/saved-queries/${savedQueryId}/schedules/${create.payload.id}`, undefined, "owner");
+  assert.equal(del.status, 200);
+
+  const after = await api("GET", `/v1/saved-queries/${savedQueryId}/schedules`, undefined, "owner");
+  assert.equal(after.status, 200);
+  assert.deepEqual(after.payload.items, []);
+});
+
+test("QUERY-007 rejects invalid cron, timezone, recipients, and format", async () => {
+  const savedQueryId = await seedSavedQuery({ ownerLabel: "owner" });
+
+  const badCron = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
+    name: "bad",
+    cron_expression: "not a cron",
+    recipients: ["x@example.com"]
+  }, "owner");
+  assert.equal(badCron.status, 400);
+  assert.match(badCron.payload.message, /cron_expression/i);
+
+  const badTz = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
+    name: "bad",
+    cron_expression: "0 9 * * *",
+    timezone: "Not/A/Real/Zone",
+    recipients: ["x@example.com"]
+  }, "owner");
+  assert.equal(badTz.status, 400);
+  assert.match(badTz.payload.message, /timezone/i);
+
+  const badRecipients = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
+    name: "bad",
+    cron_expression: "0 9 * * *",
+    recipients: ["not-an-email"]
+  }, "owner");
+  assert.equal(badRecipients.status, 400);
+
+  const noRecipients = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
+    name: "bad",
+    cron_expression: "0 9 * * *",
+    delivery_mode: "email"
+  }, "owner");
+  assert.equal(noRecipients.status, 400);
+  assert.match(noRecipients.payload.message, /recipients/i);
+
+  const badFormat = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
+    name: "bad",
+    cron_expression: "0 9 * * *",
+    recipients: ["x@example.com"],
+    format: "pdf"
+  }, "owner");
+  assert.equal(badFormat.status, 400);
+  assert.match(badFormat.payload.message, /format/i);
+});
+
+test("QUERY-007 schedules are owner-only — non-owners get 403", async () => {
+  const savedQueryId = await seedSavedQuery({ ownerLabel: "owner" });
+
+  // The other user has the schedule permission via their role, but the
+  // service layer should still 403 them because they don't own the query.
+  const create = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
+    name: "trying",
+    cron_expression: "0 9 * * *",
+    recipients: ["x@example.com"]
+  }, "stranger");
+  assert.equal(create.status, 403);
+
+  const list = await api("GET", `/v1/saved-queries/${savedQueryId}/schedules`, undefined, "stranger");
+  assert.equal(list.status, 403);
+});
+
+test("QUERY-007 download_artifact mode skips SMTP and still records the run", async () => {
+  const savedQueryId = await seedSavedQuery({ ownerLabel: "owner" });
+
+  const created = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
+    name: "Artifact only",
+    cron_expression: "0 9 * * *",
+    delivery_mode: "download_artifact",
+    recipients: [],
+    format: "json"
+  }, "owner");
+  assert.equal(created.status, 201);
+
+  // Force a dispatch by calling the service directly. We can't easily exercise
+  // the time-driven path from a unit test, so we drive the dispatcher entry
+  // point. This is the same code path the retry endpoint and the worker call.
+  const scheduleService = require("../src/services/savedQueryScheduleService");
+  const schedule = schedules.get(created.payload.id);
+  const result = await scheduleService.dispatchSchedule(schedule);
+  assert.equal(result.ok, true);
+  assert.equal(sentEmails.length, 0); // no email for download_artifact
+
+  const runs = [...scheduleRuns.values()];
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0].status, "succeeded");
+  assert.equal(runs[0].delivery_mode, "download_artifact");
+  assert.ok(runs[0].file_name && runs[0].file_size_bytes > 0);
+});
+
+test("QUERY-007 dispatch failure records error_message and exposes it via list endpoint", async () => {
+  const savedQueryId = await seedSavedQuery({ ownerLabel: "owner" });
+
+  const created = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
+    name: "will fail",
+    cron_expression: "0 9 * * *",
+    recipients: ["ops@example.com"],
+    format: "csv"
+  }, "owner");
+  assert.equal(created.status, 201);
+
+  emailFailureMode = "throw";
+  const scheduleService = require("../src/services/savedQueryScheduleService");
+  const schedule = schedules.get(created.payload.id);
+  const result = await scheduleService.dispatchSchedule(schedule);
+  assert.equal(result.ok, false);
+  assert.match(result.error, /SMTP unavailable/);
+
+  const list = await api("GET", `/v1/saved-queries/${savedQueryId}/schedules`, undefined, "owner");
+  assert.equal(list.status, 200);
+  assert.equal(list.payload.items[0].last_status, "failed");
+  assert.equal(list.payload.items[0].recent_runs.length, 1);
+  assert.equal(list.payload.items[0].recent_runs[0].status, "failed");
+  assert.match(list.payload.items[0].recent_runs[0].error_message, /SMTP unavailable/);
+
+  // Manual retry via the API exposes a second attempt that succeeds once SMTP
+  // is healthy again.
+  emailFailureMode = null;
+  const retry = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules/${created.payload.id}/retry`, {}, "owner");
+  assert.equal(retry.status, 200);
+  assert.equal(retry.payload.ok, true);
+  assert.ok(retry.payload.run_id);
+
+  const finalList = await api("GET", `/v1/saved-queries/${savedQueryId}/schedules`, undefined, "owner");
+  assert.equal(finalList.payload.items[0].last_status, "succeeded");
+  assert.equal(finalList.payload.items[0].recent_runs.length, 2);
+  // Newest first — retry attempt should be attempt 2.
+  assert.equal(finalList.payload.items[0].recent_runs[0].attempt, 2);
+  assert.equal(finalList.payload.items[0].recent_runs[0].status, "succeeded");
+});
+
+test("QUERY-007 successful email dispatch sends to recipients and records file size", async () => {
+  const savedQueryId = await seedSavedQuery({ ownerLabel: "owner" });
+
+  const created = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
+    name: "Monday digest",
+    cron_expression: "0 9 * * 1",
+    recipients: ["ops@example.com", "lead@example.com"],
+    format: "xlsx"
+  }, "owner");
+  assert.equal(created.status, 201);
+
+  const scheduleService = require("../src/services/savedQueryScheduleService");
+  const schedule = schedules.get(created.payload.id);
+  const result = await scheduleService.dispatchSchedule(schedule);
+  assert.equal(result.ok, true);
+
+  assert.equal(sentEmails.length, 1);
+  assert.deepEqual(sentEmails[0].recipients.sort(), ["lead@example.com", "ops@example.com"]);
+  assert.match(sentEmails[0].subject, /Monday digest/);
+  assert.match(sentEmails[0].fileName, /\.xlsx$/);
+  assert.ok(sentEmails[0].bytes > 0);
+
+  const runs = [...scheduleRuns.values()];
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0].status, "succeeded");
+  assert.equal(runs[0].row_count, 1);
+  assert.match(runs[0].file_name, /\.xlsx$/);
+});

--- a/app/test/savedQuerySchedulesMigration.test.js
+++ b/app/test/savedQuerySchedulesMigration.test.js
@@ -1,0 +1,46 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+test("0027_saved_query_schedules migration creates schedule + run tables and seeds permission", () => {
+  const migrationPath = path.resolve(__dirname, "../../db/migrations/0027_saved_query_schedules.sql");
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  // Schedule table
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS saved_query_schedules/i);
+  assert.match(sql, /saved_query_id UUID NOT NULL REFERENCES saved_queries\(id\) ON DELETE CASCADE/i);
+  assert.match(sql, /cron_expression TEXT NOT NULL/i);
+  assert.match(sql, /timezone TEXT NOT NULL/i);
+  assert.match(sql, /recipients TEXT\[\] NOT NULL/i);
+  assert.match(sql, /delivery_mode TEXT NOT NULL/i);
+  assert.match(sql, /CHECK \(delivery_mode IN \('email', 'download_artifact'\)\)/i);
+  assert.match(sql, /format TEXT NOT NULL/i);
+  assert.match(sql, /CHECK \(format IN \('json', 'csv', 'tsv', 'xlsx', 'parquet'\)\)/i);
+  assert.match(sql, /parameter_overrides JSONB NOT NULL DEFAULT '\{\}'::jsonb/i);
+  assert.match(sql, /status TEXT NOT NULL DEFAULT 'active'/i);
+  assert.match(sql, /CHECK \(status IN \('active', 'paused'\)\)/i);
+  assert.match(sql, /next_run_at TIMESTAMPTZ/i);
+  assert.match(sql, /last_run_at TIMESTAMPTZ/i);
+  assert.match(sql, /last_status TEXT/i);
+
+  // Indexes
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_saved_query_schedules_query/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS idx_saved_query_schedules_due/i);
+
+  // Runs table
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS saved_query_schedule_runs/i);
+  assert.match(sql, /schedule_id UUID NOT NULL REFERENCES saved_query_schedules\(id\) ON DELETE CASCADE/i);
+  assert.match(sql, /scheduled_for TIMESTAMPTZ NOT NULL/i);
+  assert.match(sql, /attempt INT NOT NULL DEFAULT 1/i);
+  assert.match(sql, /file_name TEXT/i);
+  assert.match(sql, /file_size_bytes BIGINT/i);
+  assert.match(sql, /row_count INT/i);
+  assert.match(sql, /error_message TEXT/i);
+
+  // Permission seed
+  assert.match(sql, /INSERT INTO permissions/i);
+  assert.match(sql, /'saved_queries\.schedule'/i);
+  assert.match(sql, /INSERT INTO role_permissions/i);
+  assert.match(sql, /WHERE lower\(r\.name\) IN \('admin', 'analyst'\)/i);
+});

--- a/db/migrations/0027_saved_query_schedules.sql
+++ b/db/migrations/0027_saved_query_schedules.sql
@@ -1,0 +1,95 @@
+-- QUERY-007: scheduled report delivery for saved queries.
+--
+-- Two tables:
+--   * `saved_query_schedules` — one row per schedule attached to a saved query.
+--     Stores cron expression, IANA timezone, recipients, delivery_mode,
+--     output format, per-schedule parameter overrides, the next dispatch time
+--     (precomputed from the cron + tz at create/update), and a `status` flag
+--     so an owner can pause a schedule without deleting it.
+--   * `saved_query_schedule_runs` — append-only delivery history. Every
+--     dispatch attempt writes one row with status pending/running/succeeded/failed,
+--     error_message, recipients, file_name + size, attempt number, and
+--     timestamps. Used by GET /schedules to surface last status + retry visibility.
+--
+-- Recurrence syntax: 5-field cron in the schedule's timezone (e.g. "0 9 * * 1-5").
+-- The service parses it; we do not store next-run-after rules in the DB.
+-- `next_run_at` is recomputed by the service when the schedule is created,
+-- updated, paused/resumed, and after each successful dispatch.
+--
+-- Recipients are stored as TEXT[] (validated by the service). Delivery mode is
+-- 'email' or 'download_artifact' — the latter just retains the file for manual
+-- retrieval and skips the SMTP step.
+--
+-- `parameter_overrides` is a JSONB map that fully overrides the saved query's
+-- `default_run_params` parameter values when this schedule fires. Missing keys
+-- fall back to the saved query's defaults.
+
+CREATE TABLE IF NOT EXISTS saved_query_schedules (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  saved_query_id UUID NOT NULL REFERENCES saved_queries(id) ON DELETE CASCADE,
+  owner_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  name TEXT NOT NULL,
+  cron_expression TEXT NOT NULL,
+  timezone TEXT NOT NULL DEFAULT 'UTC',
+  recipients TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  delivery_mode TEXT NOT NULL DEFAULT 'email'
+    CHECK (delivery_mode IN ('email', 'download_artifact')),
+  format TEXT NOT NULL DEFAULT 'csv'
+    CHECK (format IN ('json', 'csv', 'tsv', 'xlsx', 'parquet')),
+  parameter_overrides JSONB NOT NULL DEFAULT '{}'::jsonb,
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'paused')),
+  next_run_at TIMESTAMPTZ,
+  last_run_at TIMESTAMPTZ,
+  last_status TEXT
+    CHECK (last_status IN ('succeeded', 'failed', 'running', 'pending')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_query_schedules_query
+  ON saved_query_schedules (saved_query_id);
+
+-- Used by the dispatcher to pull due schedules cheaply.
+CREATE INDEX IF NOT EXISTS idx_saved_query_schedules_due
+  ON saved_query_schedules (next_run_at)
+  WHERE status = 'active' AND next_run_at IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS saved_query_schedule_runs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  schedule_id UUID NOT NULL REFERENCES saved_query_schedules(id) ON DELETE CASCADE,
+  saved_query_id UUID NOT NULL REFERENCES saved_queries(id) ON DELETE CASCADE,
+  scheduled_for TIMESTAMPTZ NOT NULL,
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'running', 'succeeded', 'failed')),
+  attempt INT NOT NULL DEFAULT 1,
+  recipients TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  delivery_mode TEXT NOT NULL,
+  format TEXT NOT NULL,
+  file_name TEXT,
+  file_size_bytes BIGINT,
+  row_count INT,
+  error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_query_schedule_runs_schedule_completed_at
+  ON saved_query_schedule_runs (schedule_id, completed_at DESC);
+
+-- Permission seed: 'saved_queries.schedule' guards the CRUD endpoints. Owners
+-- of a saved query can always manage their own schedules; admins and analysts
+-- get the permission by default. Viewers do not — scheduled delivery is a
+-- write-like action because it materialises results to email.
+INSERT INTO permissions (name, description) VALUES
+  ('saved_queries.schedule', 'Schedule saved query delivery to email or download artifacts')
+ON CONFLICT DO NOTHING;
+
+WITH schedule_perm AS (
+  SELECT id FROM permissions WHERE name = 'saved_queries.schedule'
+)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, schedule_perm.id
+  FROM roles r, schedule_perm
+ WHERE lower(r.name) IN ('admin', 'analyst')
+ON CONFLICT DO NOTHING;

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1265,6 +1265,118 @@ paths:
           description: Caller is not the owner
         "404":
           description: Saved query or version not found
+  /v1/saved-queries/{savedQueryId}/schedules:
+    post:
+      tags: [Query]
+      summary: Create a scheduled delivery for a saved query (owner-only)
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SavedQueryScheduleRequest"
+      responses:
+        "201":
+          description: Schedule created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQuerySchedule"
+        "400":
+          description: Invalid schedule payload (cron, timezone, recipients, etc.)
+        "403":
+          description: Caller is not the owner of this saved query
+        "404":
+          description: Saved query not found
+    get:
+      tags: [Query]
+      summary: List scheduled deliveries for a saved query (owner-only)
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+      responses:
+        "200":
+          description: Schedule list with recent run history per row
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQueryScheduleListResponse"
+        "403":
+          description: Caller is not the owner of this saved query
+        "404":
+          description: Saved query not found
+  /v1/saved-queries/{savedQueryId}/schedules/{scheduleId}:
+    put:
+      tags: [Query]
+      summary: Update a scheduled delivery (owner-only)
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+        - in: path
+          name: scheduleId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SavedQueryScheduleRequest"
+      responses:
+        "200":
+          description: Schedule updated. `next_run_at` is recomputed when cron, timezone, or status changes.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQuerySchedule"
+        "400":
+          description: Invalid schedule payload
+        "403":
+          description: Caller is not the owner of this saved query
+        "404":
+          description: Saved query or schedule not found
+    delete:
+      tags: [Query]
+      summary: Delete a scheduled delivery (owner-only)
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+        - in: path
+          name: scheduleId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Schedule deleted
+        "403":
+          description: Caller is not the owner of this saved query
+        "404":
+          description: Saved query or schedule not found
+  /v1/saved-queries/{savedQueryId}/schedules/{scheduleId}/retry:
+    post:
+      tags: [Query]
+      summary: Manually re-attempt the most recent run of a schedule (owner-only)
+      parameters:
+        - $ref: "#/components/parameters/SavedQueryId"
+        - in: path
+          name: scheduleId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Retry attempt completed. Body reports whether delivery succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavedQueryScheduleRetryResponse"
+        "403":
+          description: Caller is not the owner of this saved query
+        "404":
+          description: Saved query or schedule not found
+        "429":
+          description: Retry attempt cap reached for this schedule
   /v1/query/sessions:
     post:
       tags: [Query]
@@ -2946,6 +3058,168 @@ components:
         new_version:
           $ref: "#/components/schemas/SavedQueryVersion"
       required: [saved_query, restored_from_version_number, new_version]
+    SavedQueryScheduleRequest:
+      type: object
+      description: |
+        Request body for POST/PUT /v1/saved-queries/{id}/schedules. On PUT,
+        omitted fields fall back to the current schedule values.
+      properties:
+        name:
+          type: string
+          description: Human-friendly schedule name (max 200 chars).
+        cron_expression:
+          type: string
+          description: |
+            5-field cron expression evaluated in `timezone`. Example
+            `0 9 * * 1-5` for 09:00 Monday-Friday.
+        timezone:
+          type: string
+          description: IANA timezone name. Default `UTC`.
+          default: UTC
+        recipients:
+          type: array
+          items:
+            type: string
+            format: email
+          description: Email recipients. Required when `delivery_mode` is `email`.
+        delivery_mode:
+          type: string
+          enum: [email, download_artifact]
+          default: email
+        format:
+          type: string
+          enum: [json, csv, tsv, xlsx, parquet]
+          default: csv
+        parameter_overrides:
+          type: object
+          additionalProperties: true
+          description: Per-schedule overrides for the saved query's parameters.
+        status:
+          type: string
+          enum: [active, paused]
+          default: active
+      required: [name, cron_expression]
+    SavedQuerySchedule:
+      type: object
+      properties:
+        id:
+          type: string
+        saved_query_id:
+          type: string
+        owner_user_id:
+          type: string
+          nullable: true
+        name:
+          type: string
+        cron_expression:
+          type: string
+        timezone:
+          type: string
+        recipients:
+          type: array
+          items:
+            type: string
+        delivery_mode:
+          type: string
+          enum: [email, download_artifact]
+        format:
+          type: string
+          enum: [json, csv, tsv, xlsx, parquet]
+        parameter_overrides:
+          type: object
+          additionalProperties: true
+        status:
+          type: string
+          enum: [active, paused]
+        next_run_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_run_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_status:
+          type: string
+          enum: [succeeded, failed, running, pending]
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        recent_runs:
+          type: array
+          description: Up to 10 most recent runs, newest first. Only populated by the list endpoint.
+          items:
+            $ref: "#/components/schemas/SavedQueryScheduleRun"
+      required: [id, saved_query_id, name, cron_expression, timezone, recipients, delivery_mode, format, parameter_overrides, status, created_at, updated_at]
+    SavedQueryScheduleRun:
+      type: object
+      properties:
+        id:
+          type: string
+        schedule_id:
+          type: string
+        saved_query_id:
+          type: string
+        scheduled_for:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        status:
+          type: string
+          enum: [pending, running, succeeded, failed]
+        attempt:
+          type: integer
+        recipients:
+          type: array
+          items:
+            type: string
+        delivery_mode:
+          type: string
+        format:
+          type: string
+        file_name:
+          type: string
+          nullable: true
+        file_size_bytes:
+          type: integer
+          nullable: true
+        row_count:
+          type: integer
+          nullable: true
+        error_message:
+          type: string
+          nullable: true
+      required: [id, schedule_id, saved_query_id, scheduled_for, status, attempt, recipients, delivery_mode, format]
+    SavedQueryScheduleListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SavedQuerySchedule"
+      required: [items]
+    SavedQueryScheduleRetryResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        run_id:
+          type: string
+        error:
+          type: string
+          nullable: true
+      required: [ok, run_id]
     SavedQueryShareResponse:
       type: object
       properties:


### PR DESCRIPTION
Closes #42.

## Endpoints
- `POST   /v1/saved-queries/{id}/schedules` — create a schedule for the owner's saved query.
- `GET    /v1/saved-queries/{id}/schedules` — list schedules (owner-only) with up to the last 10 runs per row.
- `PUT    /v1/saved-queries/{id}/schedules/{scheduleId}` — update name / cron / timezone / recipients / format / status / parameter_overrides; recomputes `next_run_at`.
- `DELETE /v1/saved-queries/{id}/schedules/{scheduleId}` — delete a schedule (cascades runs).
- `POST   /v1/saved-queries/{id}/schedules/{scheduleId}/retry` — manually re-dispatch the latest run with a bumped attempt counter (capped at 3).

## Storage
- Migration `0027_saved_query_schedules.sql`:
  - `saved_query_schedules` (id, saved_query_id FK, owner_user_id, name, cron_expression, timezone, recipients TEXT[], delivery_mode `email`/`download_artifact`, format `json`/`csv`/`tsv`/`xlsx`/`parquet`, parameter_overrides JSONB, status `active`/`paused`, next_run_at, last_run_at, last_status).
  - `saved_query_schedule_runs` (append-only delivery history: schedule_id FK, scheduled_for, started_at, completed_at, status `pending`/`running`/`succeeded`/`failed`, attempt, recipients, delivery_mode, format, file_name, file_size_bytes, row_count, error_message).
  - Seeds permission `saved_queries.schedule` and grants it to `admin` + `analyst`.

## Design decisions worth flagging

- **Scheduler topology — in-process polling worker.** `app/src/services/scheduleDispatcher.js` is a `setInterval` poller that ticks every `SCHEDULE_DISPATCHER_INTERVAL_MS` (default 60s), pulls active rows with `next_run_at <= now`, and dispatches them sequentially. Off by default (`SCHEDULE_DISPATCHER_ENABLED=false`) so `npm test` and bare `npm start` don't touch the DB on a timer. Trade-off documented inline: a single-node assumption. For horizontal scaling, swap to `SELECT … FOR UPDATE SKIP LOCKED` or a real queue without touching the service layer.
- **Recurrence syntax — 5-field cron, IANA timezones, hand-rolled parser.** `app/src/services/cronExpression.js`. Rationale: the repo deliberately keeps backend deps lean (no `cron-parser` / `croner` / `rrule` already present). `*`, `N`, `N-M`, `N,M,…`, `*/step`, and `7=Sun` are supported. `computeNextRun` walks forward with month-/day-/hour-level fast-paths, capped at 366 days; impossible expressions like `0 0 31 2 *` reject in <1 s. Drop-in replaceable if scope ever needs RRULE.
- **Email transport — reuses the existing nodemailer `emailService.sendExportEmail`.** The same SMTP env vars (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`) wired up for the existing on-demand exports (`/v1/query/sessions/{id}/export/deliver`) are reused. To swap providers (SES, SendGrid, etc.), replace `emailService.js` — no scheduler-side changes. Tests stub it out and assert on captured outbound mail.
- **Manual run path untouched.** Scheduled execution runs through a dedicated `runScheduledQuery` helper that mirrors but does not call the existing `executeSavedQuery` / `exportQueryResult` (those bind to interactive query sessions which scheduled runs don't have). Same `sqlSafety` / `parameterSchema` / adapter pipeline, so safety invariants apply equally.
- **Retry semantics.** Every dispatch — scheduled or manual — writes a `saved_query_schedule_runs` row with `attempt` ≥ 1 and a final `status` of `succeeded` or `failed`. Failures bump `next_run_at` to the next cron tick so the schedule keeps running. `POST …/retry` (owner-only) re-attempts the latest run with `attempt + 1`, capped at 3 to prevent thrashing on permanently-broken targets; editing the schedule resets the chain.
- **Owner-only enforcement.** The route policy gate is `saved_queries.schedule` (admin + analyst) but the service layer additionally rejects non-owners with 403, matching the QUERY-006 share semantics — recipients of shared queries can't schedule deliveries to other people's mailboxes.
- **Frontend scope.** Backend-only PR. The matching dialog/UI is left as a follow-up so this PR stays focused and doesn't collide with the parallel QUERY-008 foldering work.

## Test plan
- [x] `npm test` (205/205 passing; +16 new tests: 9 cron, 1 migration, 6 API covering create/list/update/delete, owner-only enforcement, validation rejection, download-artifact mode, failure path with error_message + manual retry, and a successful email dispatch).
- [x] `npm --prefix frontend run lint` (clean).
- [ ] Manual SMTP test deferred — please verify with a real SMTP target: (1) create a schedule with `cron_expression: "*/2 * * * *"` and `SCHEDULE_DISPATCHER_ENABLED=true SCHEDULE_DISPATCHER_INTERVAL_MS=30000`, confirm email arrives every other minute with the chosen format; (2) point SMTP at an unreachable host, confirm `last_status=failed` + `error_message` populated + `POST …/retry` flips it back to `succeeded` once SMTP is reachable.