### PR TITLE
QUERY-009 saved query sidebar integration

### DIFF
--- a/frontend/src/components/Query/FolderEditDialog.tsx
+++ b/frontend/src/components/Query/FolderEditDialog.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { SAVED_QUERY_FOLDER_NAME_MAX_LENGTH } from '../../hooks/useSavedQueryFolders';
+
+interface FolderEditDialogProps {
+    mode: 'create' | 'rename';
+    initialName?: string;
+    parentLabel?: string | null;
+    isSubmitting: boolean;
+    onSubmit: (name: string) => Promise<void> | void;
+    onCancel: () => void;
+}
+
+export function FolderEditDialog({
+    mode,
+    initialName = '',
+    parentLabel,
+    isSubmitting,
+    onSubmit,
+    onCancel,
+}: FolderEditDialogProps) {
+    const [name, setName] = useState(initialName);
+    const [error, setError] = useState<string | null>(null);
+
+    const trimmed = name.trim();
+    const canSubmit = trimmed.length > 0 && trimmed.length <= SAVED_QUERY_FOLDER_NAME_MAX_LENGTH && !isSubmitting;
+
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+        if (!canSubmit) {
+            setError('Enter a name between 1 and 200 characters.');
+            return;
+        }
+        setError(null);
+        await onSubmit(trimmed);
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4">
+            <form
+                onSubmit={handleSubmit}
+                className="w-full max-w-sm rounded-md border border-outline-variant bg-white p-5 shadow-xl"
+            >
+                <h2 className="text-base font-semibold text-on-surface">
+                    {mode === 'create' ? 'New folder' : 'Rename folder'}
+                </h2>
+                {parentLabel && mode === 'create' && (
+                    <p className="mt-1 text-xs text-slate-500">Will be created under <strong>{parentLabel}</strong>.</p>
+                )}
+                <label className="mt-4 block text-xs font-medium text-on-surface">
+                    Name
+                    <input
+                        autoFocus
+                        type="text"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                        maxLength={SAVED_QUERY_FOLDER_NAME_MAX_LENGTH}
+                        className="mt-1 w-full rounded border border-outline-variant bg-white px-3 py-2 text-sm text-on-surface focus:border-oxblood focus:outline-none focus:ring-1 focus:ring-oxblood"
+                    />
+                </label>
+                {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+                <div className="mt-5 flex justify-end gap-2">
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        disabled={isSubmitting}
+                        className="rounded border border-outline-variant bg-white px-3 py-1.5 text-xs font-medium text-on-surface hover:bg-surface-container-low disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={!canSubmit}
+                        className="inline-flex items-center gap-1.5 rounded bg-oxblood px-3 py-1.5 text-xs font-medium text-white hover:bg-oxblood-soft disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        {isSubmitting && <Loader2 size={12} className="animate-spin" />}
+                        {mode === 'create' ? 'Create' : 'Save'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/components/Query/MoveToFolderDialog.tsx
+++ b/frontend/src/components/Query/MoveToFolderDialog.tsx
@@ -1,0 +1,108 @@
+import { useMemo, useState } from 'react';
+import { FolderClosed, Inbox, Loader2 } from 'lucide-react';
+import type { SavedQuery } from './types';
+import type { SavedQueryFolderTreeNode } from '../../hooks/useSavedQueryFolders';
+
+interface MoveToFolderDialogProps {
+    savedQuery: SavedQuery;
+    tree: SavedQueryFolderTreeNode[];
+    isSubmitting: boolean;
+    onSubmit: (folderId: string | null) => Promise<void> | void;
+    onCancel: () => void;
+}
+
+type FlatOption = { id: string | null; label: string; depth: number };
+
+function flattenTree(nodes: SavedQueryFolderTreeNode[], depth = 0): FlatOption[] {
+    const out: FlatOption[] = [];
+    for (const node of nodes) {
+        out.push({ id: node.id, label: node.name, depth });
+        out.push(...flattenTree(node.children, depth + 1));
+    }
+    return out;
+}
+
+export function MoveToFolderDialog({
+    savedQuery,
+    tree,
+    isSubmitting,
+    onSubmit,
+    onCancel,
+}: MoveToFolderDialogProps) {
+    const flat = useMemo(() => flattenTree(tree), [tree]);
+    const initial = savedQuery.folder_id ?? null;
+    const [selectedId, setSelectedId] = useState<string | null>(initial);
+
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+        await onSubmit(selectedId);
+    };
+
+    const unchanged = selectedId === initial;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4">
+            <form
+                onSubmit={handleSubmit}
+                className="flex max-h-[80vh] w-full max-w-sm flex-col rounded-md border border-outline-variant bg-white p-5 shadow-xl"
+            >
+                <h2 className="text-base font-semibold text-on-surface">Move to folder</h2>
+                <p className="mt-1 truncate text-xs text-slate-500" title={savedQuery.name}>{savedQuery.name}</p>
+                <div className="mt-4 flex-1 overflow-y-auto rounded border border-outline-variant bg-surface-container-low p-1 text-xs">
+                    <button
+                        type="button"
+                        onClick={() => setSelectedId(null)}
+                        className={[
+                            'flex w-full items-center gap-2 rounded px-2 py-1 text-left',
+                            selectedId === null
+                                ? 'bg-oxblood/10 text-oxblood'
+                                : 'text-on-surface hover:bg-white',
+                        ].join(' ')}
+                    >
+                        <Inbox size={12} />
+                        <span className="truncate">Unfiled (root)</span>
+                    </button>
+                    {flat.length === 0 ? (
+                        <p className="px-2 py-4 text-center text-[11px] text-slate-400">No folders yet — create one from the library tree first.</p>
+                    ) : (
+                        flat.map((option) => (
+                            <button
+                                key={option.id}
+                                type="button"
+                                onClick={() => setSelectedId(option.id)}
+                                className={[
+                                    'flex w-full items-center gap-2 rounded px-2 py-1 text-left',
+                                    selectedId === option.id
+                                        ? 'bg-oxblood/10 text-oxblood'
+                                        : 'text-on-surface hover:bg-white',
+                                ].join(' ')}
+                                style={{ paddingLeft: `${option.depth * 12 + 8}px` }}
+                            >
+                                <FolderClosed size={12} className="text-amber-accent" />
+                                <span className="truncate">{option.label}</span>
+                            </button>
+                        ))
+                    )}
+                </div>
+                <div className="mt-5 flex justify-end gap-2">
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        disabled={isSubmitting}
+                        className="rounded border border-outline-variant bg-white px-3 py-1.5 text-xs font-medium text-on-surface hover:bg-surface-container-low disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={isSubmitting || unchanged}
+                        className="inline-flex items-center gap-1.5 rounded bg-oxblood px-3 py-1.5 text-xs font-medium text-white hover:bg-oxblood-soft disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        {isSubmitting && <Loader2 size={12} className="animate-spin" />}
+                        Move
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/components/Query/SavedQueryTree.tsx
+++ b/frontend/src/components/Query/SavedQueryTree.tsx
@@ -1,0 +1,481 @@
+import { useMemo, useState } from 'react';
+import {
+    ChevronDown,
+    ChevronRight,
+    FileText,
+    FolderClosed,
+    FolderOpen,
+    FolderPlus,
+    Globe,
+    Inbox,
+    Lock,
+    MoreVertical,
+    Pencil,
+    RefreshCw,
+    Search,
+    Trash2,
+    Library,
+} from 'lucide-react';
+import type { SavedQuery } from './types';
+import type { SavedQueryFolder, SavedQueryFolderTreeNode } from '../../hooks/useSavedQueryFolders';
+
+export type FolderSelection =
+    | { kind: 'all' }
+    | { kind: 'unfiled' }
+    | { kind: 'folder'; folderId: string };
+
+interface SavedQueryTreeProps {
+    tree: SavedQueryFolderTreeNode[];
+    folders: SavedQueryFolder[];
+    savedQueries: SavedQuery[];
+    selection: FolderSelection;
+    onSelect: (selection: FolderSelection) => void;
+    onOpenSavedQuery: (savedQueryId: string) => void;
+    onCreateFolder: (parentId: string | null) => void;
+    onRenameFolder: (folder: SavedQueryFolder) => void;
+    onDeleteFolder: (folder: SavedQueryFolder) => void;
+    onMoveSavedQuery: (savedQuery: SavedQuery) => void;
+    onRefresh: () => void;
+    isLoading?: boolean;
+    canWrite: boolean;
+}
+
+function countQueriesInSubtree(
+    node: SavedQueryFolderTreeNode,
+    queriesByFolder: Record<string, SavedQuery[]>,
+): number {
+    const direct = queriesByFolder[node.id]?.length ?? 0;
+    return node.children.reduce((sum, child) => sum + countQueriesInSubtree(child, queriesByFolder), direct);
+}
+
+function matchesSearch(saved: SavedQuery, needle: string) {
+    if (!needle) return true;
+    const haystack = [saved.name, saved.description ?? '', ...(saved.tags ?? [])].join(' ').toLowerCase();
+    return haystack.includes(needle);
+}
+
+function folderMatchesSearch(folder: SavedQueryFolder, needle: string) {
+    if (!needle) return true;
+    return folder.name.toLowerCase().includes(needle);
+}
+
+function visibleFolderIds(
+    tree: SavedQueryFolderTreeNode[],
+    queriesByFolder: Record<string, SavedQuery[]>,
+    needle: string,
+): Set<string> {
+    if (!needle) {
+        return new Set();
+    }
+    const visible = new Set<string>();
+    const walk = (node: SavedQueryFolderTreeNode): boolean => {
+        const childMatches = node.children.map(walk).some(Boolean);
+        const hasMatchingQuery = (queriesByFolder[node.id] ?? []).some((entry) => matchesSearch(entry, needle));
+        const selfMatch = folderMatchesSearch(node, needle);
+        const matched = childMatches || hasMatchingQuery || selfMatch;
+        if (matched) {
+            visible.add(node.id);
+        }
+        return matched;
+    };
+    tree.forEach(walk);
+    return visible;
+}
+
+interface FolderNodeProps extends SavedQueryTreeProps {
+    node: SavedQueryFolderTreeNode;
+    depth: number;
+    expanded: Set<string>;
+    toggleExpanded: (folderId: string) => void;
+    queriesByFolder: Record<string, SavedQuery[]>;
+    searchNeedle: string;
+    matchedFolderIds: Set<string>;
+}
+
+function FolderNode(props: FolderNodeProps) {
+    const {
+        node,
+        depth,
+        expanded,
+        toggleExpanded,
+        queriesByFolder,
+        selection,
+        onSelect,
+        onOpenSavedQuery,
+        onCreateFolder,
+        onRenameFolder,
+        onDeleteFolder,
+        onMoveSavedQuery,
+        searchNeedle,
+        matchedFolderIds,
+        canWrite,
+    } = props;
+
+    const [menuOpen, setMenuOpen] = useState(false);
+    const isExpanded = expanded.has(node.id) || (searchNeedle.length > 0 && matchedFolderIds.has(node.id));
+    const isSelected = selection.kind === 'folder' && selection.folderId === node.id;
+    const directQueries = (queriesByFolder[node.id] ?? []).filter((entry) => matchesSearch(entry, searchNeedle));
+    const totalCount = countQueriesInSubtree(node, queriesByFolder);
+
+    const childrenToRender = node.children.filter((child) =>
+        searchNeedle ? matchedFolderIds.has(child.id) : true,
+    );
+
+    return (
+        <div>
+            <div
+                className={[
+                    'group flex items-center gap-1 rounded px-1 py-1 text-xs',
+                    isSelected ? 'bg-oxblood/10 text-oxblood' : 'text-on-surface hover:bg-surface-container-low',
+                ].join(' ')}
+                style={{ paddingLeft: `${depth * 12 + 4}px` }}
+            >
+                <button
+                    type="button"
+                    onClick={() => toggleExpanded(node.id)}
+                    className="flex h-4 w-4 shrink-0 items-center justify-center text-slate-400 hover:text-slate-700"
+                    aria-label={isExpanded ? 'Collapse folder' : 'Expand folder'}
+                >
+                    {node.children.length > 0 ? (
+                        isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />
+                    ) : <span className="inline-block h-3 w-3" />}
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onSelect({ kind: 'folder', folderId: node.id })}
+                    className="flex min-w-0 flex-1 items-center gap-1.5 truncate text-left"
+                >
+                    {isExpanded ? (
+                        <FolderOpen size={13} className={isSelected ? 'text-oxblood' : 'text-amber-accent'} />
+                    ) : (
+                        <FolderClosed size={13} className={isSelected ? 'text-oxblood' : 'text-amber-accent'} />
+                    )}
+                    <span className="truncate font-medium">{node.name}</span>
+                    {totalCount > 0 && (
+                        <span className="text-[10px] text-slate-400">{totalCount}</span>
+                    )}
+                </button>
+                {canWrite && (
+                    <div className="relative">
+                        <button
+                            type="button"
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                setMenuOpen((current) => !current);
+                            }}
+                            className="rounded p-0.5 text-slate-400 opacity-0 hover:bg-surface-container hover:text-slate-700 group-hover:opacity-100"
+                            title="Folder actions"
+                            aria-label="Folder actions"
+                        >
+                            <MoreVertical size={12} />
+                        </button>
+                        {menuOpen && (
+                            <>
+                                <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
+                                <div className="absolute right-0 top-5 z-20 w-44 rounded border border-outline-variant bg-white py-1 text-xs shadow-lg">
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setMenuOpen(false);
+                                            onCreateFolder(node.id);
+                                        }}
+                                        className="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-surface-container-low"
+                                    >
+                                        <FolderPlus size={12} />
+                                        New subfolder
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setMenuOpen(false);
+                                            onRenameFolder(node);
+                                        }}
+                                        className="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-surface-container-low"
+                                    >
+                                        <Pencil size={12} />
+                                        Rename
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setMenuOpen(false);
+                                            onDeleteFolder(node);
+                                        }}
+                                        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-red-600 hover:bg-red-50"
+                                    >
+                                        <Trash2 size={12} />
+                                        Delete
+                                    </button>
+                                </div>
+                            </>
+                        )}
+                    </div>
+                )}
+            </div>
+            {isExpanded && (
+                <div>
+                    {childrenToRender.map((child) => (
+                        <FolderNode
+                            {...props}
+                            key={child.id}
+                            node={child}
+                            depth={depth + 1}
+                        />
+                    ))}
+                    {directQueries.map((entry) => (
+                        <SavedQueryLeaf
+                            key={entry.id}
+                            entry={entry}
+                            depth={depth + 1}
+                            onOpen={() => onOpenSavedQuery(entry.id)}
+                            onMove={() => onMoveSavedQuery(entry)}
+                            canWrite={canWrite}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+interface SavedQueryLeafProps {
+    entry: SavedQuery;
+    depth: number;
+    onOpen: () => void;
+    onMove: () => void;
+    canWrite: boolean;
+}
+
+function SavedQueryLeaf({ entry, depth, onOpen, onMove, canWrite }: SavedQueryLeafProps) {
+    const [menuOpen, setMenuOpen] = useState(false);
+    return (
+        <div
+            className="group flex items-center gap-1 rounded px-1 py-1 text-xs text-on-surface hover:bg-surface-container-low"
+            style={{ paddingLeft: `${depth * 12 + 20}px` }}
+        >
+            <button
+                type="button"
+                onClick={onOpen}
+                className="flex min-w-0 flex-1 items-center gap-1.5 truncate text-left"
+                title={entry.description || entry.name}
+            >
+                <FileText size={12} className="shrink-0 text-slate-400" />
+                <span className="truncate">{entry.name}</span>
+                {entry.visibility === 'shared' ? (
+                    <Globe size={9} className="shrink-0 text-emerald-600" />
+                ) : (
+                    <Lock size={9} className="shrink-0 text-slate-400" />
+                )}
+            </button>
+            {canWrite && (
+                <div className="relative">
+                    <button
+                        type="button"
+                        onClick={(event) => {
+                            event.stopPropagation();
+                            setMenuOpen((current) => !current);
+                        }}
+                        className="rounded p-0.5 text-slate-400 opacity-0 hover:bg-surface-container hover:text-slate-700 group-hover:opacity-100"
+                        title="Query actions"
+                        aria-label="Query actions"
+                    >
+                        <MoreVertical size={12} />
+                    </button>
+                    {menuOpen && (
+                        <>
+                            <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
+                            <div className="absolute right-0 top-5 z-20 w-44 rounded border border-outline-variant bg-white py-1 text-xs shadow-lg">
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setMenuOpen(false);
+                                        onMove();
+                                    }}
+                                    className="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-surface-container-low"
+                                >
+                                    <FolderClosed size={12} />
+                                    Move to folder…
+                                </button>
+                            </div>
+                        </>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function SavedQueryTree(props: SavedQueryTreeProps) {
+    const {
+        tree,
+        savedQueries,
+        selection,
+        onSelect,
+        onOpenSavedQuery,
+        onCreateFolder,
+        onMoveSavedQuery,
+        onRefresh,
+        isLoading,
+        canWrite,
+    } = props;
+
+    const [expanded, setExpanded] = useState<Set<string>>(new Set());
+    const [searchText, setSearchText] = useState('');
+
+    const queriesByFolder = useMemo(() => {
+        const grouped: Record<string, SavedQuery[]> = {};
+        for (const entry of savedQueries) {
+            const key = entry.folder_id ?? '__unfiled__';
+            (grouped[key] ||= []).push(entry);
+        }
+        for (const key of Object.keys(grouped)) {
+            grouped[key].sort((a, b) => a.name.localeCompare(b.name));
+        }
+        return grouped;
+    }, [savedQueries]);
+
+    const needle = searchText.trim().toLowerCase();
+    const matchedFolderIds = useMemo(
+        () => visibleFolderIds(tree, queriesByFolder, needle),
+        [tree, queriesByFolder, needle],
+    );
+
+    const unfiled = (queriesByFolder['__unfiled__'] ?? []).filter((entry) => matchesSearch(entry, needle));
+    const totalQueries = savedQueries.length;
+
+    function toggleExpanded(folderId: string) {
+        setExpanded((current) => {
+            const next = new Set(current);
+            if (next.has(folderId)) {
+                next.delete(folderId);
+            } else {
+                next.add(folderId);
+            }
+            return next;
+        });
+    }
+
+    const visibleTree = needle
+        ? tree.filter((node) => matchedFolderIds.has(node.id))
+        : tree;
+
+    return (
+        <div className="flex h-full flex-col bg-white">
+            <div className="shrink-0 border-b border-outline-variant px-3 py-3">
+                <div className="mb-2 flex items-center justify-between">
+                    <h2 className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">Library</h2>
+                    <div className="flex items-center gap-1">
+                        {canWrite && (
+                            <button
+                                type="button"
+                                onClick={() => onCreateFolder(null)}
+                                className="rounded p-1 text-slate-500 hover:bg-surface-container-low hover:text-on-surface"
+                                title="New folder"
+                                aria-label="New folder"
+                            >
+                                <FolderPlus size={14} />
+                            </button>
+                        )}
+                        <button
+                            type="button"
+                            onClick={onRefresh}
+                            className="rounded p-1 text-slate-500 hover:bg-surface-container-low hover:text-on-surface"
+                            title="Refresh"
+                            aria-label="Refresh folders"
+                        >
+                            <RefreshCw size={14} className={isLoading ? 'animate-spin' : undefined} />
+                        </button>
+                    </div>
+                </div>
+                <div className="relative">
+                    <Search size={12} className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-slate-400" />
+                    <input
+                        type="text"
+                        value={searchText}
+                        onChange={(event) => setSearchText(event.target.value)}
+                        placeholder="Search folders & queries"
+                        className="w-full rounded border border-outline-variant bg-surface-container-low py-1 pl-6 pr-2 text-xs text-on-surface placeholder-slate-400 focus:border-oxblood focus:outline-none focus:ring-1 focus:ring-oxblood"
+                    />
+                </div>
+            </div>
+            <div className="flex-1 overflow-y-auto px-2 py-2 text-xs">
+                <button
+                    type="button"
+                    onClick={() => onSelect({ kind: 'all' })}
+                    className={[
+                        'mb-0.5 flex w-full items-center gap-2 rounded px-2 py-1 text-left',
+                        selection.kind === 'all'
+                            ? 'bg-oxblood/10 text-oxblood'
+                            : 'text-on-surface hover:bg-surface-container-low',
+                    ].join(' ')}
+                >
+                    <Library size={13} />
+                    <span className="flex-1 truncate font-medium">All queries</span>
+                    <span className="text-[10px] text-slate-400">{totalQueries}</span>
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onSelect({ kind: 'unfiled' })}
+                    className={[
+                        'mb-1 flex w-full items-center gap-2 rounded px-2 py-1 text-left',
+                        selection.kind === 'unfiled'
+                            ? 'bg-oxblood/10 text-oxblood'
+                            : 'text-on-surface hover:bg-surface-container-low',
+                    ].join(' ')}
+                >
+                    <Inbox size={13} />
+                    <span className="flex-1 truncate font-medium">Unfiled</span>
+                    <span className="text-[10px] text-slate-400">{queriesByFolder['__unfiled__']?.length ?? 0}</span>
+                </button>
+
+                {selection.kind === 'unfiled' && unfiled.length > 0 && (
+                    <div className="mb-2">
+                        {unfiled.map((entry) => (
+                            <SavedQueryLeaf
+                                key={entry.id}
+                                entry={entry}
+                                depth={1}
+                                onOpen={() => onOpenSavedQuery(entry.id)}
+                                onMove={() => onMoveSavedQuery(entry)}
+                                canWrite={canWrite}
+                            />
+                        ))}
+                    </div>
+                )}
+
+                {visibleTree.length === 0 && tree.length === 0 && !isLoading && (
+                    <div className="px-2 py-6 text-center text-[11px] text-slate-400">
+                        No folders yet.
+                        {canWrite && (
+                            <>
+                                <br />
+                                <button
+                                    type="button"
+                                    onClick={() => onCreateFolder(null)}
+                                    className="mt-2 inline-flex items-center gap-1 text-oxblood hover:underline"
+                                >
+                                    <FolderPlus size={11} />
+                                    Create one
+                                </button>
+                            </>
+                        )}
+                    </div>
+                )}
+
+                {visibleTree.map((node) => (
+                    <FolderNode
+                        {...props}
+                        key={node.id}
+                        node={node}
+                        depth={0}
+                        expanded={expanded}
+                        toggleExpanded={toggleExpanded}
+                        queriesByFolder={queriesByFolder}
+                        searchNeedle={needle}
+                        matchedFolderIds={matchedFolderIds}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/hooks/useSavedQueryFolders.ts
+++ b/frontend/src/hooks/useSavedQueryFolders.ts
@@ -1,0 +1,185 @@
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { client } from '../lib/api/client';
+import type { components } from '../lib/api/types';
+
+export type SavedQueryFolder = components['schemas']['SavedQueryFolder'];
+export type SavedQueryFolderTreeNode = components['schemas']['SavedQueryFolderTreeNode'];
+
+export const SAVED_QUERY_FOLDER_NAME_MAX_LENGTH = 200;
+
+export interface UseSavedQueryFoldersResult {
+    folders: SavedQueryFolder[];
+    tree: SavedQueryFolderTreeNode[];
+    foldersById: Record<string, SavedQueryFolder>;
+    isLoading: boolean;
+    errorMessage: string | null;
+    refresh: () => Promise<void>;
+    createFolder: (input: { name: string; parentId?: string | null }) => Promise<SavedQueryFolder | null>;
+    renameFolder: (folderId: string, name: string) => Promise<SavedQueryFolder | null>;
+    moveFolder: (folderId: string, parentId: string | null) => Promise<SavedQueryFolder | null>;
+    deleteFolder: (folderId: string) => Promise<boolean>;
+    moveSavedQuery: (
+        savedQueryId: string,
+        folderId: string | null,
+    ) => Promise<components['schemas']['MoveSavedQueryResponse'] | null>;
+}
+
+function sortFolders(items: SavedQueryFolder[]) {
+    return [...items].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+// Folder endpoints don't declare error response schemas in the OpenAPI spec, so
+// openapi-fetch types `error` as `never`. The server still returns a JSON error
+// payload — read it defensively at runtime.
+function extractErrorMessage(error: unknown, fallback: string): string {
+    if (error && typeof error === 'object' && 'message' in error) {
+        const message = (error as { message?: unknown }).message;
+        if (typeof message === 'string' && message.length > 0) {
+            return message;
+        }
+    }
+    return fallback;
+}
+
+export function useSavedQueryFolders(): UseSavedQueryFoldersResult {
+    const [folders, setFolders] = useState<SavedQueryFolder[]>([]);
+    const [tree, setTree] = useState<SavedQueryFolderTreeNode[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    const refresh = useCallback(async () => {
+        setIsLoading(true);
+        setErrorMessage(null);
+        try {
+            const { data, error } = await client.GET('/v1/saved-query-folders');
+            if (error || !data) {
+                setErrorMessage('Failed to load folders.');
+                return;
+            }
+            setFolders(sortFolders(data.items ?? []));
+            setTree(data.tree ?? []);
+        } catch (error) {
+            console.error('Failed to fetch folders', error);
+            setErrorMessage('Failed to load folders.');
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void refresh();
+    }, [refresh]);
+
+    const createFolder = useCallback<UseSavedQueryFoldersResult['createFolder']>(async ({ name, parentId = null }) => {
+        try {
+            const { data, error } = await client.POST('/v1/saved-query-folders', {
+                body: { name, parent_id: parentId },
+            });
+            if (error || !data) {
+                toast.error(extractErrorMessage(error, 'Failed to create folder.'));
+                return null;
+            }
+            await refresh();
+            return data;
+        } catch (error) {
+            console.error('Failed to create folder', error);
+            toast.error('Failed to create folder.');
+            return null;
+        }
+    }, [refresh]);
+
+    const renameFolder = useCallback<UseSavedQueryFoldersResult['renameFolder']>(async (folderId, name) => {
+        try {
+            const { data, error } = await client.PUT('/v1/saved-query-folders/{folderId}', {
+                params: { path: { folderId } },
+                body: { name },
+            });
+            if (error || !data) {
+                toast.error(extractErrorMessage(error, 'Failed to rename folder.'));
+                return null;
+            }
+            setFolders((current) => sortFolders(current.map((item) => (item.id === data.id ? data : item))));
+            await refresh();
+            return data;
+        } catch (error) {
+            console.error('Failed to rename folder', error);
+            toast.error('Failed to rename folder.');
+            return null;
+        }
+    }, [refresh]);
+
+    const moveFolder = useCallback<UseSavedQueryFoldersResult['moveFolder']>(async (folderId, parentId) => {
+        try {
+            const { data, error } = await client.PUT('/v1/saved-query-folders/{folderId}', {
+                params: { path: { folderId } },
+                body: { parent_id: parentId },
+            });
+            if (error || !data) {
+                toast.error(extractErrorMessage(error, 'Failed to move folder.'));
+                return null;
+            }
+            await refresh();
+            return data;
+        } catch (error) {
+            console.error('Failed to move folder', error);
+            toast.error('Failed to move folder.');
+            return null;
+        }
+    }, [refresh]);
+
+    const deleteFolder = useCallback<UseSavedQueryFoldersResult['deleteFolder']>(async (folderId) => {
+        try {
+            const { data, error } = await client.DELETE('/v1/saved-query-folders/{folderId}', {
+                params: { path: { folderId } },
+            });
+            if (error || !data?.ok) {
+                toast.error(extractErrorMessage(error, 'Failed to delete folder.'));
+                return false;
+            }
+            await refresh();
+            return true;
+        } catch (error) {
+            console.error('Failed to delete folder', error);
+            toast.error('Failed to delete folder.');
+            return false;
+        }
+    }, [refresh]);
+
+    const moveSavedQuery = useCallback<UseSavedQueryFoldersResult['moveSavedQuery']>(async (savedQueryId, folderId) => {
+        try {
+            const { data, error } = await client.POST('/v1/saved-queries/{savedQueryId}/move', {
+                params: { path: { savedQueryId } },
+                body: { folder_id: folderId },
+            });
+            if (error || !data) {
+                toast.error(extractErrorMessage(error, 'Failed to move saved query.'));
+                return null;
+            }
+            return data;
+        } catch (error) {
+            console.error('Failed to move saved query', error);
+            toast.error('Failed to move saved query.');
+            return null;
+        }
+    }, []);
+
+    const foldersById = folders.reduce<Record<string, SavedQueryFolder>>((acc, folder) => {
+        acc[folder.id] = folder;
+        return acc;
+    }, {});
+
+    return {
+        folders,
+        tree,
+        foldersById,
+        isLoading,
+        errorMessage,
+        refresh,
+        createFolder,
+        renameFolder,
+        moveFolder,
+        deleteFolder,
+        moveSavedQuery,
+    };
+}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -2557,6 +2557,521 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/saved-query-folders": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the caller's folders, flat plus pre-built tree */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Folder list and tree */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQueryFolderListResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a saved-query folder (per-owner) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateSavedQueryFolderRequest"];
+                };
+            };
+            responses: {
+                /** @description Folder created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQueryFolder"];
+                    };
+                };
+                /** @description Invalid name or parent_id shape */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description parent_id belongs to another owner */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description parent_id folder not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description A sibling folder with that name already exists */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/saved-query-folders/{folderId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Rename or move a folder (owner-only) */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    folderId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateSavedQueryFolderRequest"];
+                };
+            };
+            responses: {
+                /** @description Updated folder */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQueryFolder"];
+                    };
+                };
+                /** @description Invalid name or self/descendant parent move */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Caller is not the folder owner, or parent_id belongs to another owner */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Folder not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sibling-name collision under the target parent */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        /** Delete a folder; direct children are reparented to its parent (REASSIGN policy) */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    folderId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Folder deleted; response lists what was reparented and the new parent (null for root). */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["DeleteSavedQueryFolderResponse"];
+                    };
+                };
+                /** @description Caller is not the folder owner */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Folder not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/saved-queries/{savedQueryId}/move": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Move a saved query into a folder (owner-only). `folder_id: null` moves to root. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["MoveSavedQueryRequest"];
+                };
+            };
+            responses: {
+                /** @description Updated saved query plus the resolved folder context */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MoveSavedQueryResponse"];
+                    };
+                };
+                /** @description folder_id is not a UUID */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Caller is not the owner, or folder_id belongs to another owner */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Saved query or folder_id not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/saved-queries/{savedQueryId}/schedules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List scheduled deliveries for a saved query (owner-only) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Schedule list with recent run history per row */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQueryScheduleListResponse"];
+                    };
+                };
+                /** @description Caller is not the owner of this saved query */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Saved query not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /** Create a scheduled delivery for a saved query (owner-only) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["SavedQueryScheduleRequest"];
+                };
+            };
+            responses: {
+                /** @description Schedule created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQuerySchedule"];
+                    };
+                };
+                /** @description Invalid schedule payload (cron, timezone, recipients, etc.) */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Caller is not the owner of this saved query */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Saved query not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/saved-queries/{savedQueryId}/schedules/{scheduleId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update a scheduled delivery (owner-only) */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                    scheduleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["SavedQueryScheduleRequest"];
+                };
+            };
+            responses: {
+                /** @description Schedule updated. `next_run_at` is recomputed when cron, timezone, or status changes. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQuerySchedule"];
+                    };
+                };
+                /** @description Invalid schedule payload */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Caller is not the owner of this saved query */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Saved query or schedule not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        /** Delete a scheduled delivery (owner-only) */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                    scheduleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Schedule deleted */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Caller is not the owner of this saved query */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Saved query or schedule not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/saved-queries/{savedQueryId}/schedules/{scheduleId}/retry": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Manually re-attempt the most recent run of a schedule (owner-only) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    savedQueryId: components["parameters"]["SavedQueryId"];
+                    scheduleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Retry attempt completed. Body reports whether delivery succeeded. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SavedQueryScheduleRetryResponse"];
+                    };
+                };
+                /** @description Caller is not the owner of this saved query */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Saved query or schedule not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Retry attempt cap reached for this schedule */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/query/sessions": {
         parameters: {
             query?: never;
@@ -4252,46 +4767,6 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
-        SavedQueryFolder: {
-            id: string;
-            owner_id: string;
-            parent_id?: string | null;
-            name: string;
-            /** Format: date-time */
-            created_at: string;
-            /** Format: date-time */
-            updated_at: string;
-        };
-        SavedQueryFolderTreeNode: components["schemas"]["SavedQueryFolder"] & {
-            children: components["schemas"]["SavedQueryFolderTreeNode"][];
-        };
-        SavedQueryFolderListResponse: {
-            items: components["schemas"]["SavedQueryFolder"][];
-            tree: components["schemas"]["SavedQueryFolderTreeNode"][];
-        };
-        CreateSavedQueryFolderRequest: {
-            name: string;
-            parent_id?: string | null;
-        };
-        UpdateSavedQueryFolderRequest: {
-            name?: string;
-            parent_id?: string | null;
-        };
-        DeleteSavedQueryFolderResponse: {
-            ok: boolean;
-            id: string;
-            reassigned_to: string | null;
-            reassigned_folder_ids: string[];
-            reassigned_saved_query_ids: string[];
-        };
-        MoveSavedQueryRequest: {
-            folder_id: string | null;
-        };
-        MoveSavedQueryResponse: {
-            saved_query: components["schemas"]["SavedQuery"];
-            previous_folder_id?: string | null;
-            folder_id: string | null;
-        };
         SavedQueryListResponse: {
             items: components["schemas"]["SavedQuery"][];
         };
@@ -4387,6 +4862,104 @@ export interface components {
             restored_from_version_number: number;
             new_version: components["schemas"]["SavedQueryVersion"];
         };
+        /**
+         * @description Request body for POST/PUT /v1/saved-queries/{id}/schedules. On PUT,
+         *     omitted fields fall back to the current schedule values.
+         */
+        SavedQueryScheduleRequest: {
+            /** @description Human-friendly schedule name (max 200 chars). */
+            name: string;
+            /**
+             * @description 5-field cron expression evaluated in `timezone`. Example
+             *     `0 9 * * 1-5` for 09:00 Monday-Friday.
+             */
+            cron_expression: string;
+            /**
+             * @description IANA timezone name. Default `UTC`.
+             * @default UTC
+             */
+            timezone: string;
+            /** @description Email recipients. Required when `delivery_mode` is `email`. */
+            recipients?: string[];
+            /**
+             * @default email
+             * @enum {string}
+             */
+            delivery_mode: "email" | "download_artifact";
+            /**
+             * @default csv
+             * @enum {string}
+             */
+            format: "json" | "csv" | "tsv" | "xlsx" | "parquet";
+            /** @description Per-schedule overrides for the saved query's parameters. */
+            parameter_overrides?: {
+                [key: string]: unknown;
+            };
+            /**
+             * @default active
+             * @enum {string}
+             */
+            status: "active" | "paused";
+        };
+        SavedQuerySchedule: {
+            id: string;
+            saved_query_id: string;
+            owner_user_id?: string | null;
+            name: string;
+            cron_expression: string;
+            timezone: string;
+            recipients: string[];
+            /** @enum {string} */
+            delivery_mode: "email" | "download_artifact";
+            /** @enum {string} */
+            format: "json" | "csv" | "tsv" | "xlsx" | "parquet";
+            parameter_overrides: {
+                [key: string]: unknown;
+            };
+            /** @enum {string} */
+            status: "active" | "paused";
+            /** Format: date-time */
+            next_run_at?: string | null;
+            /** Format: date-time */
+            last_run_at?: string | null;
+            /** @enum {string|null} */
+            last_status?: "succeeded" | "failed" | "running" | "pending" | null;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            /** @description Up to 10 most recent runs, newest first. Only populated by the list endpoint. */
+            recent_runs?: components["schemas"]["SavedQueryScheduleRun"][];
+        };
+        SavedQueryScheduleRun: {
+            id: string;
+            schedule_id: string;
+            saved_query_id: string;
+            /** Format: date-time */
+            scheduled_for: string;
+            /** Format: date-time */
+            started_at?: string | null;
+            /** Format: date-time */
+            completed_at?: string | null;
+            /** @enum {string} */
+            status: "pending" | "running" | "succeeded" | "failed";
+            attempt: number;
+            recipients: string[];
+            delivery_mode: string;
+            format: string;
+            file_name?: string | null;
+            file_size_bytes?: number | null;
+            row_count?: number | null;
+            error_message?: string | null;
+        };
+        SavedQueryScheduleListResponse: {
+            items: components["schemas"]["SavedQuerySchedule"][];
+        };
+        SavedQueryScheduleRetryResponse: {
+            ok: boolean;
+            run_id: string;
+            error?: string | null;
+        };
         SavedQueryShareResponse: {
             /** @enum {string} */
             visibility: "private" | "shared";
@@ -4412,6 +4985,48 @@ export interface components {
                     permission: "view" | "run";
                 }[];
             };
+        };
+        SavedQueryFolder: {
+            id: string;
+            owner_id: string;
+            parent_id?: string | null;
+            name: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        SavedQueryFolderTreeNode: components["schemas"]["SavedQueryFolder"] & {
+            children: components["schemas"]["SavedQueryFolderTreeNode"][];
+        };
+        SavedQueryFolderListResponse: {
+            items: components["schemas"]["SavedQueryFolder"][];
+            tree: components["schemas"]["SavedQueryFolderTreeNode"][];
+        };
+        CreateSavedQueryFolderRequest: {
+            name: string;
+            parent_id?: string | null;
+        };
+        /** @description Patch-style: any field omitted is left as-is. `parent_id: null` moves the folder back to the user's root. */
+        UpdateSavedQueryFolderRequest: {
+            name?: string;
+            parent_id?: string | null;
+        };
+        DeleteSavedQueryFolderResponse: {
+            ok: boolean;
+            id: string;
+            /** @description New parent for the deleted folder's direct children (NULL = root). */
+            reassigned_to: string | null;
+            reassigned_folder_ids: string[];
+            reassigned_saved_query_ids: string[];
+        };
+        MoveSavedQueryRequest: {
+            folder_id: string | null;
+        };
+        MoveSavedQueryResponse: {
+            saved_query: components["schemas"]["SavedQuery"];
+            previous_folder_id?: string | null;
+            folder_id: string | null;
         };
         ValidateParamsRequest: {
             params: {

--- a/frontend/src/pages/SavedQueries.tsx
+++ b/frontend/src/pages/SavedQueries.tsx
@@ -23,12 +23,20 @@ import { toast } from 'sonner';
 import { useAuth } from '../hooks/useAuth';
 import { useDataSource } from '../hooks/useDataSource';
 import { useSavedQueries } from '../hooks/useSavedQueries';
+import { useSavedQueryFolders, type SavedQueryFolder } from '../hooks/useSavedQueryFolders';
 import { SaveQueryDialog, type SaveQueryDialogValues } from '../components/Query/SaveQueryDialog';
 import { ShareSavedQueryDialog } from '../components/Query/ShareSavedQueryDialog';
 import { VersionHistoryDialog } from '../components/Query/VersionHistoryDialog';
+import { SavedQueryTree, type FolderSelection } from '../components/Query/SavedQueryTree';
+import { FolderEditDialog } from '../components/Query/FolderEditDialog';
+import { MoveToFolderDialog } from '../components/Query/MoveToFolderDialog';
 import type { SavedQuery } from '../components/Query/types';
 
 type FilterMode = 'current' | 'all';
+
+type FolderEditState =
+    | { mode: 'create'; parentId: string | null }
+    | { mode: 'rename'; folder: SavedQueryFolder };
 
 function formatDate(value: string) {
     try {
@@ -55,17 +63,36 @@ export const SavedQueries = () => {
         deleteSavedQuery,
     } = useSavedQueries();
 
+    const {
+        folders,
+        tree,
+        foldersById,
+        isLoading: isFoldersLoading,
+        refresh: refreshFolders,
+        createFolder,
+        renameFolder,
+        deleteFolder,
+        moveSavedQuery,
+    } = useSavedQueryFolders();
+
     const [sharingQuery, setSharingQuery] = useState<SavedQuery | null>(null);
     const [historyQuery, setHistoryQuery] = useState<SavedQuery | null>(null);
 
     const [searchText, setSearchText] = useState('');
     const [filterMode, setFilterMode] = useState<FilterMode>('all');
+    const [folderSelection, setFolderSelection] = useState<FolderSelection>({ kind: 'all' });
     const [activeTagFilter, setActiveTagFilter] = useState<string | null>(null);
     const [selectedId, setSelectedId] = useState<string | null>(null);
     const [editing, setEditing] = useState<SavedQuery | null>(null);
     const [isSubmittingEdit, setIsSubmittingEdit] = useState(false);
     const [pendingId, setPendingId] = useState<string | null>(null);
     const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+    const [folderEdit, setFolderEdit] = useState<FolderEditState | null>(null);
+    const [isFolderEditSubmitting, setIsFolderEditSubmitting] = useState(false);
+    const [confirmDeleteFolder, setConfirmDeleteFolder] = useState<SavedQueryFolder | null>(null);
+    const [isDeletingFolder, setIsDeletingFolder] = useState(false);
+    const [movingQuery, setMovingQuery] = useState<SavedQuery | null>(null);
+    const [isMoveSubmitting, setIsMoveSubmitting] = useState(false);
 
     const dataSourceNameById = useMemo(
         () => Object.fromEntries(dataSources.map((ds) => [ds.id, ds.name])),
@@ -83,6 +110,12 @@ export const SavedQueries = () => {
             if (filterMode === 'current' && selectedDataSourceId && entry.data_source_id !== selectedDataSourceId) {
                 return false;
             }
+            if (folderSelection.kind === 'folder' && entry.folder_id !== folderSelection.folderId) {
+                return false;
+            }
+            if (folderSelection.kind === 'unfiled' && entry.folder_id) {
+                return false;
+            }
             if (activeTagFilter && !(entry.tags || []).includes(activeTagFilter)) {
                 return false;
             }
@@ -96,7 +129,17 @@ export const SavedQueries = () => {
             ].join(' ').toLowerCase();
             return haystack.includes(search);
         });
-    }, [savedQueries, searchText, filterMode, selectedDataSourceId, activeTagFilter]);
+    }, [savedQueries, searchText, filterMode, selectedDataSourceId, folderSelection, activeTagFilter]);
+
+    const selectedFolderName = useMemo(() => {
+        if (folderSelection.kind === 'folder') {
+            return foldersById[folderSelection.folderId]?.name ?? null;
+        }
+        if (folderSelection.kind === 'unfiled') {
+            return 'Unfiled';
+        }
+        return null;
+    }, [folderSelection, foldersById]);
 
     useEffect(() => {
         if (selectedId && !filtered.some((entry) => entry.id === selectedId)) {
@@ -169,14 +212,100 @@ export const SavedQueries = () => {
         }
     };
 
+    const handleFolderEditSubmit = async (name: string) => {
+        if (!folderEdit) return;
+        setIsFolderEditSubmitting(true);
+        try {
+            if (folderEdit.mode === 'create') {
+                const result = await createFolder({ name, parentId: folderEdit.parentId });
+                if (result) {
+                    setFolderEdit(null);
+                    toast.success(`Folder "${result.name}" created.`);
+                }
+            } else {
+                const result = await renameFolder(folderEdit.folder.id, name);
+                if (result) {
+                    setFolderEdit(null);
+                    toast.success('Folder renamed.');
+                }
+            }
+        } finally {
+            setIsFolderEditSubmitting(false);
+        }
+    };
+
+    const handleFolderDelete = async () => {
+        if (!confirmDeleteFolder) return;
+        setIsDeletingFolder(true);
+        try {
+            const ok = await deleteFolder(confirmDeleteFolder.id);
+            if (ok) {
+                toast.success(
+                    `Folder "${confirmDeleteFolder.name}" deleted. Its contents were moved to the parent folder.`,
+                );
+                if (folderSelection.kind === 'folder' && folderSelection.folderId === confirmDeleteFolder.id) {
+                    setFolderSelection({ kind: 'all' });
+                }
+                setConfirmDeleteFolder(null);
+                // refresh saved queries so folder_id changes from REASSIGN are reflected
+                await refresh();
+            }
+        } finally {
+            setIsDeletingFolder(false);
+        }
+    };
+
+    const handleMoveSubmit = async (folderId: string | null) => {
+        if (!movingQuery) return;
+        setIsMoveSubmitting(true);
+        try {
+            const result = await moveSavedQuery(movingQuery.id, folderId);
+            if (result) {
+                toast.success(
+                    folderId
+                        ? `Moved to "${foldersById[folderId]?.name ?? 'folder'}".`
+                        : 'Moved to root.',
+                );
+                setMovingQuery(null);
+                await refresh();
+            }
+        } finally {
+            setIsMoveSubmitting(false);
+        }
+    };
+
     return (
         <main className="flex h-full overflow-hidden">
+            <aside className="flex w-64 shrink-0 flex-col overflow-hidden border-r border-outline-variant bg-white">
+                <SavedQueryTree
+                    tree={tree}
+                    folders={folders}
+                    savedQueries={savedQueries}
+                    selection={folderSelection}
+                    onSelect={setFolderSelection}
+                    onOpenSavedQuery={openInWorkspace}
+                    onCreateFolder={(parentId) => setFolderEdit({ mode: 'create', parentId })}
+                    onRenameFolder={(folder) => setFolderEdit({ mode: 'rename', folder })}
+                    onDeleteFolder={(folder) => setConfirmDeleteFolder(folder)}
+                    onMoveSavedQuery={(savedQuery) => setMovingQuery(savedQuery)}
+                    onRefresh={() => {
+                        void refreshFolders();
+                        void refresh();
+                    }}
+                    isLoading={isFoldersLoading}
+                    canWrite={canWriteSavedQueries}
+                />
+            </aside>
             <div className="flex flex-1 flex-col overflow-hidden border-r border-outline-variant bg-white">
                 <div className="shrink-0 border-b border-outline-variant bg-white px-6 pb-4 pt-6">
                     <div className="mb-6 flex items-end justify-between">
                         <div>
                             <h1 className="text-2xl font-semibold tracking-tight text-on-surface">Saved Queries</h1>
-                            <p className="mt-1 text-xs text-slate-500">Manage and execute your analytical library.</p>
+                            <p className="mt-1 text-xs text-slate-500">
+                                {selectedFolderName
+                                    ? `Showing queries in "${selectedFolderName}".`
+                                    : 'Manage and execute your analytical library.'}
+                            </p>
                         </div>
                         <div className="flex gap-2">
                             <button
@@ -603,6 +732,66 @@ export const SavedQueries = () => {
                         </div>
                     </div>
                 </div>
+            )}
+
+            {folderEdit && (
+                <FolderEditDialog
+                    key={folderEdit.mode === 'rename' ? `rename-${folderEdit.folder.id}` : `create-${folderEdit.parentId ?? 'root'}`}
+                    mode={folderEdit.mode}
+                    initialName={folderEdit.mode === 'rename' ? folderEdit.folder.name : ''}
+                    parentLabel={
+                        folderEdit.mode === 'create' && folderEdit.parentId
+                            ? foldersById[folderEdit.parentId]?.name ?? null
+                            : null
+                    }
+                    isSubmitting={isFolderEditSubmitting}
+                    onSubmit={handleFolderEditSubmit}
+                    onCancel={() => setFolderEdit(null)}
+                />
+            )}
+
+            {confirmDeleteFolder && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+                    <div className="w-full max-w-sm rounded-lg bg-white shadow-xl">
+                        <div className="border-b border-outline-variant px-4 py-3">
+                            <h3 className="text-sm font-semibold text-on-surface">Delete folder?</h3>
+                        </div>
+                        <div className="px-4 py-3 text-xs text-slate-600">
+                            <p className="font-medium text-on-surface">{confirmDeleteFolder.name}</p>
+                            <p className="mt-2">
+                                Sub-folders and saved queries inside this folder will be moved up to its parent folder. Saved queries themselves are not deleted.
+                            </p>
+                        </div>
+                        <div className="flex justify-end gap-2 border-t border-outline-variant px-4 py-3">
+                            <button
+                                type="button"
+                                onClick={() => setConfirmDeleteFolder(null)}
+                                disabled={isDeletingFolder}
+                                className="rounded-md border border-outline-variant bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => void handleFolderDelete()}
+                                disabled={isDeletingFolder}
+                                className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                {isDeletingFolder ? 'Deleting…' : 'Delete folder'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {movingQuery && (
+                <MoveToFolderDialog
+                    savedQuery={movingQuery}
+                    tree={tree}
+                    isSubmitting={isMoveSubmitting}
+                    onSubmit={handleMoveSubmit}
+                    onCancel={() => setMovingQuery(null)}
+                />
             )}
         </main>
     );


### PR DESCRIPTION
Closes #44.

## Summary
Adds a folder tree to the Saved Queries page so users can navigate, filter, organize, and open saved queries from a left-hand sidebar that consumes the QUERY-008 folder APIs.

## What's new
- **Library tree** in a new 256px left panel on `/queries`. Renders the server-provided folder tree with saved queries as leaves under their owning folder, plus pinned **All queries** and **Unfiled** roots with counts.
- **Folder CRUD**: create root or sub-folder, rename, delete. Delete dialog explains the REASSIGN policy (children reparent to the deleted folder's parent — saved queries themselves are not deleted).
- **Move saved query** via the per-row menu in the tree → opens a folder-picker dialog (initial selection = current folder; root option = Unfiled). Refreshes saved-query state after move so `folder_id` updates everywhere.
- **Search/filter** input scoped to the tree (folder names + query names/descriptions/tags), auto-expands matching folders.
- **Click a query → workspace**: leaf click navigates to `/query?savedQueryId=<id>` (existing deep-link path).
- **Center table filter** now also respects the folder selection in addition to the existing data-source filter.

## Files
- `frontend/src/hooks/useSavedQueryFolders.ts` — list/create/rename/move/delete folders + move saved query, using the QUERY-008 endpoints.
- `frontend/src/components/Query/SavedQueryTree.tsx` — recursive tree with All/Unfiled roots, per-folder and per-query action menus, search.
- `frontend/src/components/Query/FolderEditDialog.tsx` — shared create/rename dialog.
- `frontend/src/components/Query/MoveToFolderDialog.tsx` — flat-tree folder picker with a root option.
- `frontend/src/pages/SavedQueries.tsx` — new left panel wiring + folder selection state + REASSIGN-aware delete confirmation.
- `frontend/src/lib/api/types.ts` — regenerated from the OpenAPI spec; brings in the QUERY-007 and QUERY-008 path entries that weren't generated previously.

## Decisions worth flagging
- **DnD deferred**, kept menu-based move per the ticket's "drag-and-drop (optional)" wording. Move-to-folder is reachable from the per-query row menu in the tree.
- **Tree lives in the page**, not the global app shell. The existing `/folders` stub in `AppShell` is left untouched; the tree belongs to the saved-queries surface and shouldn't bloat the global nav (which also wouldn't fit a deep hierarchy at 256px alongside the rest of the chrome).
- **Folder error responses aren't in the OpenAPI spec** (only descriptions, no schemas), so `openapi-fetch` types the hook's `error` as `never`. Hook reads `error.message` defensively at runtime via a small `extractErrorMessage` helper rather than expanding the spec — happy to add response schemas if reviewers prefer.

## Test plan
- [ ] `npm --prefix frontend run lint` — clean
- [ ] `npm --prefix frontend run build` — clean (also covers tsc -b)
- [ ] `npm test` — 219/219 passing (backend, unchanged)
- [ ] Manual: create folder → create sub-folder → rename → move query in/out via menu → delete folder (children reparent) → filter by folder → search → click a query → opens workspace with that saved query loaded