### PR TITLE
ci: add GitHub Actions for typecheck, lint, test, and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend (typecheck, test, build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build:be
+
+  frontend:
+    name: Frontend (lint, build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Lint
+        run: npm run lint
+        working-directory: frontend
+
+      - name: Build
+        run: npm run build
+        working-directory: frontend


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` to validate every push to `main` and every pull request.

Two parallel jobs, both pinned to the Node version in `.nvmrc` (currently 22):

**backend** (`Backend (typecheck, test, build)`)
- `npm ci`
- `npm run typecheck` — `tsc --noEmit` over `app/src` + `app/test`
- `npm test` — the 219-test `node --test` suite
- `npm run build:be` — `tsc` emit, verifies the build artifact path

**frontend** (`Frontend (lint, build)`)
- `npm ci` (in `frontend/`)
- `npm run lint` — `eslint .`
- `npm run build` — `tsc -b && vite build`

Other workflow choices:
- `concurrency` cancels in-progress PR runs on new pushes so a busy PR doesn't queue up duplicates; pushes to `main` are not cancelled.
- `permissions: contents: read` — minimum needed; no write access.
- npm cache via `actions/setup-node`, with `cache-dependency-path: frontend/package-lock.json` for the frontend job so each cache key reflects the right lockfile.

## Notes

- All commands verified to pass locally on this branch before opening the PR.
- Backend tests don't need a real Postgres — they stub `appDb.query`, so no service container is required.
- The frontend build emits a chunk-size advisory (`> 500 kB`); it's a warning, not an error, and isn't fatal in CI. Splitting the bundle is out of scope here.

## Test plan

- [ ] CI runs and both jobs are green on this PR
- [ ] Subsequent PRs trigger the workflow
- [ ] Pushes to `main` trigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)