### PR TITLE
TS-002 Configure test runner for TypeScript test files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@ Report Pilot is a local-first NL-to-SQL reporting runtime. This file is canonica
 
 - `npm run setup`
 - `npm run dev`
-- `npm test`
+- `npm test` — runs `node --test` with the `tsx` loader against `app/test/**/*.test.{js,ts}`, so `.js` and `.ts` test files are both picked up
+- `npm run typecheck`
 - `npm run migrate`
 - `npm --prefix frontend run lint`
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start": "node app/src/start.js",
     "migrate": "node app/src/migrate.js",
     "benchmark:mvp": "node app/src/benchmark/runMvpBenchmark.js",
-    "test": "node --test app/test/**/*.test.js",
+    "test": "node --import tsx --test app/test/**/*.test.{js,ts}",
     "typecheck": "tsc --noEmit"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Switches the root `test` script to load tests through `tsx` and to match both `.js` and `.ts` files under `app/test/**`, so new tests can land in TypeScript and existing JavaScript tests keep running unchanged. This is the prerequisite for migrating tests under TS-016.

## Changes

- `package.json`: `test` is now `node --import tsx --test app/test/**/*.test.{js,ts}`.
- `AGENTS.md`: documents the new behavior under **Commands**, and also adds `npm run typecheck` to the list (it shipped in TS-001 but wasn't listed there).

## Verification

- All **219** existing `.js` tests still pass under the new command (same count as before, no regression).
- A temporary `app/test/_tsRunner.test.ts` was picked up by the runner — count went to 220 with it in place, the test was listed by name in the output, and the count returned to 219 after removal.
- `npm run typecheck` still exits 0.

## Out of scope

- Migrating any real test file (TS-016).

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)