### PR TITLE
TS-007 Define LlmAdapter interface and migrate LLM provider adapters

### DIFF
--- a/app/src/adapters/llm/customAdapter.ts
+++ b/app/src/adapters/llm/customAdapter.ts
@@ -1,7 +1,27 @@
+import type {
+  LlmAdapter,
+  LlmAdapterOptions,
+  LlmEmbedResult,
+  LlmGenerateInput,
+  LlmGenerateResult
+} from "./types";
+
 const { postJson, extractJsonObject } = require("./httpClient");
 
-class CustomAdapter {
-  constructor(opts = {}) {
+/**
+ * Adapter for self-hosted / OpenAI-compatible providers (e.g. Ollama running
+ * with the OpenAI-compatible frontend). The caller supplies `baseUrl` and
+ * `provider` so this adapter can stand in for any OpenAI-shaped REST endpoint.
+ * Embeddings are not assumed to be supported and `embed()` throws.
+ */
+class CustomAdapter implements LlmAdapter {
+  provider: string;
+  apiKey: string;
+  defaultModel: string;
+  timeoutMs: number;
+  baseUrl: string;
+
+  constructor(opts: LlmAdapterOptions = {}) {
     this.provider = opts.provider || "custom";
     this.apiKey = opts.apiKey || "";
     this.defaultModel = opts.defaultModel || "";
@@ -9,7 +29,7 @@ class CustomAdapter {
     this.baseUrl = String(opts.baseUrl || "").replace(/\/+$/, "");
   }
 
-  async healthCheck() {
+  async healthCheck(): Promise<void> {
     if (!this.baseUrl) {
       throw new Error("Custom provider base_url is not configured");
     }
@@ -18,7 +38,7 @@ class CustomAdapter {
     }
   }
 
-  async generate(input) {
+  async generate(input: LlmGenerateInput): Promise<LlmGenerateResult> {
     await this.healthCheck();
 
     const model = input.model || this.defaultModel;
@@ -57,12 +77,12 @@ class CustomAdapter {
     };
   }
 
-  async generateStructured(input) {
+  async generateStructured(input: LlmGenerateInput): Promise<unknown> {
     const output = await this.generate(input);
     return extractJsonObject(output.text);
   }
 
-  async embed() {
+  async embed(): Promise<LlmEmbedResult> {
     throw new Error("embed() is not supported for the custom adapter");
   }
 }

--- a/app/src/adapters/llm/deepSeekAdapter.ts
+++ b/app/src/adapters/llm/deepSeekAdapter.ts
@@ -1,7 +1,25 @@
+import type {
+  LlmAdapter,
+  LlmAdapterOptions,
+  LlmEmbedResult,
+  LlmGenerateInput,
+  LlmGenerateResult
+} from "./types";
+
 const { postJson, extractJsonObject } = require("./httpClient");
 
-class DeepSeekAdapter {
-  constructor(opts = {}) {
+/**
+ * Adapter for DeepSeek's OpenAI-compatible chat-completions endpoint.
+ * Embeddings are not yet implemented upstream, so `embed()` throws.
+ */
+class DeepSeekAdapter implements LlmAdapter {
+  readonly provider: string;
+  apiKey: string;
+  defaultModel: string;
+  timeoutMs: number;
+  baseUrl: string;
+
+  constructor(opts: LlmAdapterOptions = {}) {
     this.provider = "deepseek";
     this.apiKey = opts.apiKey || "";
     this.defaultModel = opts.defaultModel || "deepseek-chat";
@@ -9,13 +27,13 @@ class DeepSeekAdapter {
     this.baseUrl = opts.baseUrl || "https://api.deepseek.com";
   }
 
-  async healthCheck() {
+  async healthCheck(): Promise<void> {
     if (!this.apiKey) {
       throw new Error("DeepSeek API key is not configured");
     }
   }
 
-  async generate(input) {
+  async generate(input: LlmGenerateInput): Promise<LlmGenerateResult> {
     await this.healthCheck();
 
     const model = input.model || this.defaultModel;
@@ -54,12 +72,12 @@ class DeepSeekAdapter {
     };
   }
 
-  async generateStructured(input) {
+  async generateStructured(input: LlmGenerateInput): Promise<unknown> {
     const output = await this.generate(input);
     return extractJsonObject(output.text);
   }
 
-  async embed() {
+  async embed(): Promise<LlmEmbedResult> {
     throw new Error("embed() is not implemented yet for DeepSeek adapter");
   }
 }

--- a/app/src/adapters/llm/geminiAdapter.ts
+++ b/app/src/adapters/llm/geminiAdapter.ts
@@ -1,26 +1,46 @@
+import type {
+  LlmAdapter,
+  LlmAdapterOptions,
+  LlmEmbedInput,
+  LlmEmbedResult,
+  LlmGenerateInput,
+  LlmGenerateResult,
+  LlmTokenUsage
+} from "./types";
+
 const { postJson, extractJsonObject } = require("./httpClient");
 
-class GeminiAdapter {
-  constructor(opts = {}) {
+/**
+ * Adapter for Google's Gemini generative-language REST API. Note that
+ * embeddings use a separate `:embedContent` endpoint and must be requested
+ * per-text (unlike OpenAI which batches).
+ */
+class GeminiAdapter implements LlmAdapter {
+  readonly provider: string;
+  apiKey: string;
+  defaultModel: string;
+  timeoutMs: number;
+
+  constructor(opts: LlmAdapterOptions = {}) {
     this.provider = "gemini";
     this.apiKey = opts.apiKey || "";
     this.defaultModel = opts.defaultModel || "gemini-2.0-flash";
     this.timeoutMs = Number(opts.timeoutMs || 15000);
   }
 
-  async healthCheck() {
+  async healthCheck(): Promise<void> {
     if (!this.apiKey) {
       throw new Error("Gemini API key is not configured");
     }
   }
 
-  async generate(input) {
+  async generate(input: LlmGenerateInput): Promise<LlmGenerateResult> {
     await this.healthCheck();
 
     const model = input.model || this.defaultModel;
     const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(this.apiKey)}`;
 
-    const payload = {
+    const payload: Record<string, unknown> = {
       contents: [
         {
           role: "user",
@@ -50,13 +70,13 @@ class GeminiAdapter {
 
     const response = await postJson(endpoint, payload, { timeoutMs: this.timeoutMs });
     const parts = response?.candidates?.[0]?.content?.parts || [];
-    const text = parts.map((p) => p.text || "").join("\n").trim();
+    const text = parts.map((p: any) => p.text || "").join("\n").trim();
 
     if (!text) {
       throw new Error("Gemini returned an empty completion");
     }
 
-    const usage = response?.usageMetadata
+    const usage: LlmTokenUsage | null = response?.usageMetadata
       ? {
           prompt_tokens: Number(response.usageMetadata.promptTokenCount || 0),
           completion_tokens: Number(response.usageMetadata.candidatesTokenCount || 0),
@@ -71,22 +91,22 @@ class GeminiAdapter {
     };
   }
 
-  async generateStructured(input) {
+  async generateStructured(input: LlmGenerateInput): Promise<unknown> {
     const output = await this.generate(input);
     return extractJsonObject(output.text);
   }
 
-  async embed(input) {
+  async embed(input?: LlmEmbedInput): Promise<LlmEmbedResult> {
     await this.healthCheck();
 
-    const model = input.model || "text-embedding-004";
-    const texts = Array.isArray(input.texts) ? input.texts : [];
+    const model = (input && input.model) || "text-embedding-004";
+    const texts = Array.isArray(input?.texts) ? input!.texts : [];
     if (texts.length === 0) {
       throw new Error("embed input texts are required");
     }
 
     const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:embedContent?key=${encodeURIComponent(this.apiKey)}`;
-    const vectors = [];
+    const vectors: number[][] = [];
 
     for (const text of texts) {
       const payload = {

--- a/app/src/adapters/llm/httpClient.ts
+++ b/app/src/adapters/llm/httpClient.ts
@@ -1,6 +1,28 @@
-async function postJson(url, body, opts = {}) {
+import type { LlmAdapterError } from "./types";
+
+export interface PostJsonOptions {
+  /** Request timeout in milliseconds (defaults to 15000). */
+  timeoutMs?: number;
+  /** Extra headers merged on top of `Content-Type: application/json`. */
+  headers?: Record<string, string>;
+}
+
+/** Provider response payloads are unknown JSON; callers downcast as needed. */
+export type ProviderResponse = any;
+
+/**
+ * POST a JSON body to `url` and return the parsed JSON response.
+ *
+ * On non-2xx status codes throws an `Error` with a `statusCode` field attached,
+ * matching the `LlmAdapterError` shape so callers can react to HTTP errors.
+ */
+async function postJson(
+  url: string,
+  body: unknown,
+  opts: PostJsonOptions = {}
+): Promise<ProviderResponse> {
   const timeoutMs = Number(opts.timeoutMs || 15000);
-  const headers = Object.assign(
+  const headers: Record<string, string> = Object.assign(
     {
       "Content-Type": "application/json"
     },
@@ -18,7 +40,7 @@ async function postJson(url, body, opts = {}) {
     });
 
     const text = await response.text();
-    let parsed = null;
+    let parsed: ProviderResponse = null;
     try {
       parsed = text ? JSON.parse(text) : null;
     } catch {
@@ -26,7 +48,7 @@ async function postJson(url, body, opts = {}) {
     }
 
     if (!response.ok) {
-      const error = new Error(
+      const error: LlmAdapterError = new Error(
         `HTTP ${response.status} from provider: ${parsed?.error?.message || text || "unknown error"}`
       );
       error.statusCode = response.status;
@@ -39,7 +61,12 @@ async function postJson(url, body, opts = {}) {
   }
 }
 
-function extractJsonObject(text) {
+/**
+ * Parse a JSON object out of a model's free-form text response. Handles
+ * fenced code blocks (```json ... ```) and trims to the first/last brace as a
+ * last resort. Throws when nothing parseable is found.
+ */
+function extractJsonObject(text: unknown): unknown {
   const raw = String(text || "").trim();
   if (!raw) {
     throw new Error("Model response is empty");
@@ -62,8 +89,18 @@ function extractJsonObject(text) {
   }
 }
 
-function resolveApiKey(ref, defaultEnvKey) {
-  const candidates = [];
+/**
+ * Resolve an API key from a provider configuration reference.
+ *
+ * Supported reference forms:
+ * - `env:NAME` — read from `process.env.NAME`
+ * - `plain:value` — use `value` literally
+ * - `NAME` — look up `process.env.NAME`, otherwise treat as a literal value
+ *
+ * If `ref` is empty/missing, falls back to `process.env[defaultEnvKey]`.
+ */
+function resolveApiKey(ref?: string | null, defaultEnvKey?: string | null): string {
+  const candidates: string[] = [];
   if (ref) {
     candidates.push(ref);
   }
@@ -78,7 +115,7 @@ function resolveApiKey(ref, defaultEnvKey) {
     if (candidate.startsWith("env:")) {
       const envName = candidate.slice(4).trim();
       if (envName && process.env[envName]) {
-        return process.env[envName];
+        return process.env[envName] as string;
       }
       continue;
     }
@@ -86,7 +123,7 @@ function resolveApiKey(ref, defaultEnvKey) {
       return candidate.slice(6);
     }
     if (process.env[candidate]) {
-      return process.env[candidate];
+      return process.env[candidate] as string;
     }
     return candidate;
   }

--- a/app/src/adapters/llm/openAiAdapter.ts
+++ b/app/src/adapters/llm/openAiAdapter.ts
@@ -1,25 +1,40 @@
+import type {
+  LlmAdapter,
+  LlmAdapterOptions,
+  LlmEmbedInput,
+  LlmEmbedResult,
+  LlmGenerateInput,
+  LlmGenerateResult
+} from "./types";
+
 const { postJson, extractJsonObject } = require("./httpClient");
 
-class OpenAiAdapter {
-  constructor(opts = {}) {
+/** Adapter for OpenAI's REST API (chat completions + embeddings). */
+class OpenAiAdapter implements LlmAdapter {
+  readonly provider: string;
+  apiKey: string;
+  defaultModel: string;
+  timeoutMs: number;
+
+  constructor(opts: LlmAdapterOptions = {}) {
     this.provider = "openai";
     this.apiKey = opts.apiKey || "";
     this.defaultModel = opts.defaultModel || "gpt-5.2-mini";
     this.timeoutMs = Number(opts.timeoutMs || 15000);
   }
 
-  async healthCheck() {
+  async healthCheck(): Promise<void> {
     if (!this.apiKey) {
       throw new Error("OpenAI API key is not configured");
     }
   }
 
-  async generate(input) {
+  async generate(input: LlmGenerateInput): Promise<LlmGenerateResult> {
     await this.healthCheck();
 
     const model = input.model || this.defaultModel;
     const maxTokens = input.maxTokens ?? 800;
-    const payload = {
+    const payload: Record<string, unknown> = {
       model,
       temperature: input.temperature ?? 0,
       messages: [
@@ -58,16 +73,16 @@ class OpenAiAdapter {
     };
   }
 
-  async generateStructured(input) {
+  async generateStructured(input: LlmGenerateInput): Promise<unknown> {
     const output = await this.generate(input);
     return extractJsonObject(output.text);
   }
 
-  async embed(input) {
+  async embed(input?: LlmEmbedInput): Promise<LlmEmbedResult> {
     await this.healthCheck();
 
-    const model = input.model || "text-embedding-3-small";
-    const texts = Array.isArray(input.texts) ? input.texts : [];
+    const model = (input && input.model) || "text-embedding-3-small";
+    const texts = Array.isArray(input?.texts) ? input!.texts : [];
     if (texts.length === 0) {
       throw new Error("embed input texts are required");
     }
@@ -84,10 +99,10 @@ class OpenAiAdapter {
       }
     });
 
-    const vectors = Array.isArray(response?.data)
+    const vectors: number[][] = Array.isArray(response?.data)
       ? response.data
-        .sort((a, b) => a.index - b.index)
-        .map((item) => item.embedding)
+        .sort((a: any, b: any) => a.index - b.index)
+        .map((item: any) => item.embedding)
       : [];
 
     if (vectors.length !== texts.length) {
@@ -101,7 +116,7 @@ class OpenAiAdapter {
   }
 }
 
-function usesCompletionTokenParam(model) {
+function usesCompletionTokenParam(model: string): boolean {
   return /^gpt-5(?:[.-]|$)/i.test(String(model || ""));
 }
 

--- a/app/src/adapters/llm/openRouterAdapter.ts
+++ b/app/src/adapters/llm/openRouterAdapter.ts
@@ -1,7 +1,27 @@
+import type {
+  LlmAdapter,
+  LlmAdapterOptions,
+  LlmEmbedResult,
+  LlmGenerateInput,
+  LlmGenerateResult
+} from "./types";
+
 const { postJson, extractJsonObject } = require("./httpClient");
 
-class OpenRouterAdapter {
-  constructor(opts = {}) {
+/**
+ * Adapter for OpenRouter's OpenAI-compatible chat completions endpoint.
+ * Optional `HTTP-Referer` / `X-Title` headers are forwarded from environment
+ * variables to satisfy OpenRouter's attribution guidelines. Embeddings are not
+ * exposed by this provider, so `embed()` throws.
+ */
+class OpenRouterAdapter implements LlmAdapter {
+  readonly provider: string;
+  apiKey: string;
+  defaultModel: string;
+  timeoutMs: number;
+  baseUrl: string;
+
+  constructor(opts: LlmAdapterOptions = {}) {
     this.provider = "openrouter";
     this.apiKey = opts.apiKey || "";
     this.defaultModel = opts.defaultModel || "google/gemma-4-31b-it";
@@ -9,13 +29,13 @@ class OpenRouterAdapter {
     this.baseUrl = "https://openrouter.ai/api/v1";
   }
 
-  async healthCheck() {
+  async healthCheck(): Promise<void> {
     if (!this.apiKey) {
       throw new Error("OpenRouter API key is not configured");
     }
   }
 
-  async generate(input) {
+  async generate(input: LlmGenerateInput): Promise<LlmGenerateResult> {
     await this.healthCheck();
 
     const model = input.model || this.defaultModel;
@@ -35,7 +55,7 @@ class OpenRouterAdapter {
       ]
     };
 
-    const headers = {
+    const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`
     };
     if (process.env.OPENROUTER_SITE_URL) {
@@ -62,12 +82,12 @@ class OpenRouterAdapter {
     };
   }
 
-  async generateStructured(input) {
+  async generateStructured(input: LlmGenerateInput): Promise<unknown> {
     const output = await this.generate(input);
     return extractJsonObject(output.text);
   }
 
-  async embed() {
+  async embed(): Promise<LlmEmbedResult> {
     throw new Error("embed() is not supported for the OpenRouter adapter");
   }
 }

--- a/app/src/adapters/llm/types.ts
+++ b/app/src/adapters/llm/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared types and interface for LLM provider adapters.
+ *
+ * Every provider adapter (OpenAI, Gemini, DeepSeek, OpenRouter, custom) must
+ * implement `LlmAdapter` so the routing layer in
+ * `app/src/services/llmProviderRouting.js` and `app/src/services/embeddingRouter.js`
+ * can treat them uniformly.
+ */
+
+/** Provider identifier surfaced on each adapter instance. */
+export type LlmProvider = "openai" | "gemini" | "deepseek" | "openrouter" | string;
+
+/** Options accepted by every adapter constructor. */
+export interface LlmAdapterOptions {
+  /** API key, already resolved (not an `env:` reference). */
+  apiKey?: string;
+  /** Default model used when the caller does not pass one. */
+  defaultModel?: string;
+  /** Request timeout in milliseconds (defaults to 15000). */
+  timeoutMs?: number;
+  /** Base URL for providers that allow overriding the host (custom, deepseek). */
+  baseUrl?: string;
+  /** Provider id override (used by the custom adapter to expose a stable name). */
+  provider?: string;
+}
+
+/** Input for chat/completion-style generation. */
+export interface LlmGenerateInput {
+  /** Primary user message. */
+  prompt: string;
+  /** System prompt injected as the system role; providers map this appropriately. */
+  systemPrompt?: string;
+  /** Optional model override; falls back to the adapter's `defaultModel`. */
+  model?: string;
+  /** Sampling temperature; defaults to 0 in each provider implementation. */
+  temperature?: number;
+  /** Maximum tokens for the completion; defaults to 800. */
+  maxTokens?: number;
+}
+
+/**
+ * Normalized token usage shape. Provider-specific keys are preserved when the
+ * upstream payload uses them (OpenAI / DeepSeek / OpenRouter), but Gemini is
+ * mapped explicitly to these three keys.
+ */
+export interface LlmTokenUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  /** Allow additional provider-specific usage keys without losing them. */
+  [key: string]: unknown;
+}
+
+/** Result of `generate()`. */
+export interface LlmGenerateResult {
+  /** Decoded completion text. */
+  text: string;
+  /** Model id reported by the provider (falls back to the requested model). */
+  model: string;
+  /** Normalized token usage; null when the provider does not report it. */
+  usage: LlmTokenUsage | null;
+}
+
+/** Input for embedding requests. */
+export interface LlmEmbedInput {
+  /** Texts to embed, in order. */
+  texts: string[];
+  /** Optional embedding model override. */
+  model?: string;
+}
+
+/** Result of `embed()`. */
+export interface LlmEmbedResult {
+  /** One embedding vector per input text, in the same order. */
+  vectors: number[][];
+  /** Embedding model id (reported by provider or echoed from the request). */
+  model: string;
+}
+
+/**
+ * Shape of an HTTP-style error thrown by the adapters. Provider responses with
+ * non-2xx status codes surface as `Error` instances with `statusCode` attached
+ * by `httpClient.postJson`.
+ */
+export interface LlmAdapterError extends Error {
+  statusCode?: number;
+}
+
+/**
+ * Common interface implemented by every LLM provider adapter. Embedding
+ * support is optional at runtime — providers that do not implement embeddings
+ * throw from `embed()` rather than omitting the method, so the type signature
+ * is uniform across providers.
+ */
+export interface LlmAdapter {
+  /** Stable provider identifier (e.g. "openai"). */
+  readonly provider: string;
+  /** Throws when the adapter is missing required configuration. */
+  healthCheck(): Promise<void>;
+  /** Run a chat/completion request and return the normalized response. */
+  generate(input: LlmGenerateInput): Promise<LlmGenerateResult>;
+  /** Run `generate` and parse the returned text as JSON. */
+  generateStructured(input: LlmGenerateInput): Promise<unknown>;
+  /** Embed the input texts; throws if the provider does not support embeddings. */
+  embed(input?: LlmEmbedInput): Promise<LlmEmbedResult>;
+}


### PR DESCRIPTION
## Summary

Migrates `app/src/adapters/llm/*` from CommonJS `.js` to TypeScript and introduces a shared `LlmAdapter` interface that every provider (OpenAI, Gemini, DeepSeek, OpenRouter, custom) implements. The routing layer can now treat every provider through the same typed surface.

Closes #138.

## Interface

`app/src/adapters/llm/types.ts` exports:

```ts
export interface LlmAdapter {
  readonly provider: string;
  healthCheck(): Promise<void>;
  generate(input: LlmGenerateInput): Promise<LlmGenerateResult>;
  generateStructured(input: LlmGenerateInput): Promise<unknown>;
  embed(input?: LlmEmbedInput): Promise<LlmEmbedResult>;
}

export interface LlmAdapterOptions {
  apiKey?: string;
  defaultModel?: string;
  timeoutMs?: number;
  baseUrl?: string;   // used by deepseek + custom
  provider?: string;  // used by custom to override the id
}

export interface LlmGenerateInput {
  prompt: string;
  systemPrompt?: string;
  model?: string;
  temperature?: number;
  maxTokens?: number;
}

export interface LlmGenerateResult {
  text: string;
  model: string;
  usage: LlmTokenUsage | null;
}

export interface LlmEmbedInput { texts: string[]; model?: string; }
export interface LlmEmbedResult { vectors: number[][]; model: string; }

export interface LlmTokenUsage {
  prompt_tokens?: number;
  completion_tokens?: number;
  total_tokens?: number;
  [key: string]: unknown;
}

export interface LlmAdapterError extends Error {
  statusCode?: number;
}
```

## Per-adapter migration notes

- **httpClient.ts** — typed `postJson` (with `PostJsonOptions`), `extractJsonObject`, and `resolveApiKey`. `postJson` attaches `statusCode` to non-2xx errors matching `LlmAdapterError`. Provider response payloads stay `any` because each provider has its own JSON shape and callers downcast on the call site.
- **openAiAdapter.ts** — implements `LlmAdapter`. Keeps the existing GPT-5 detection (`usesCompletionTokenParam`) so `max_completion_tokens` is sent for `gpt-5*` and `max_tokens` for everything else. Embeddings batch via `POST /v1/embeddings` and assert size matches the input.
- **geminiAdapter.ts** — implements `LlmAdapter`. Provider-specific: Gemini uses `:generateContent`/`:embedContent` REST endpoints, threads the API key via the query string (not bearer auth), and exposes embeddings as a per-text loop because `:embedContent` does not batch. Token usage is mapped from `usageMetadata.{promptTokenCount, candidatesTokenCount, totalTokenCount}` into the normalized `LlmTokenUsage` shape.
- **deepSeekAdapter.ts** — implements `LlmAdapter`. Uses the OpenAI-compatible chat-completions shape; `baseUrl` defaults to `https://api.deepseek.com`. `embed()` throws (upstream support not implemented yet).
- **openRouterAdapter.ts** — implements `LlmAdapter`. Forwards optional `HTTP-Referer` / `X-Title` headers from `OPENROUTER_SITE_URL`/`OPENROUTER_SITE_NAME` env vars. `embed()` throws (provider does not expose embeddings).
- **customAdapter.ts** — implements `LlmAdapter` and accepts a caller-supplied `provider` + `baseUrl` (so it can stand in for any OpenAI-shaped endpoint, e.g. Ollama). `embed()` throws because no specific embedding contract is assumed.

All adapters preserve their CommonJS `module.exports = { XAdapter }` shape so the existing `.js` callers in `services/llmProviderRouting.js`, `services/embeddingRouter.js`, and `routes/providers.js` continue to work without changes. No runtime behavior changes.

## Verification

- `npm run typecheck` — clean
- `npm run build:be` — emits `dist/src/adapters/llm/*.js` for all six modules + `types.js`
- `npm test` — 219 tests passing, 0 failures
  - `app/test/customAdapter.test.js` — 6/6 passing
  - `app/test/llmHelpers.test.js` — 4/4 passing

## Test plan

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build:be`
- [x] `npx node --import tsx --test app/test/customAdapter.test.js app/test/llmHelpers.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)