### PR TITLE
chore: unify LLM adapter provider type with canonical domain.LlmProviderName

### DIFF
--- a/app/src/adapters/llm/types.ts
+++ b/app/src/adapters/llm/types.ts
@@ -7,8 +7,14 @@
  * can treat them uniformly.
  */
 
-/** Provider identifier surfaced on each adapter instance. */
-export type LlmProvider = "openai" | "gemini" | "deepseek" | "openrouter" | string;
+import type { LlmProviderName } from "../../types/domain";
+
+/**
+ * Provider identifier surfaced on each adapter instance. Built-in providers
+ * use `LlmProviderName`; custom providers carry any non-empty string (matching
+ * the storage-layer contract on `LlmProviderConfig.provider`).
+ */
+export type LlmProvider = LlmProviderName | string;
 
 /** Options accepted by every adapter constructor. */
 export interface LlmAdapterOptions {


### PR DESCRIPTION
## Summary

Follow-up cleanup after the TS-005/TS-006/TS-007 parallel merges (#154, #155, #156).

The TS-007 agent defined its provider identifier as a verbatim duplicate of `domain.LlmProviderName`:

```ts
// before
export type LlmProvider = "openai" | "gemini" | "deepseek" | "openrouter" | string;
```

This happened because its worktree was based on a pre-TS-004 commit and didn't see `app/src/types/domain.ts`. The duplication drifts the moment a built-in provider is renamed or added.

Switching to import `LlmProviderName` from the canonical types module:

```ts
// after
import type { LlmProviderName } from "../../types/domain";
export type LlmProvider = LlmProviderName | string;
```

One source of truth, zero runtime change.

## Why only this one change

I inventoried the other apparent overlaps after the three migrations landed and they are intentionally distinct types at different layers, not duplicates:

| Apparent overlap | Why they should stay separate |
|---|---|
| `authGate.AuthUser` vs `domain.User` | sanitized auth-context shape vs full DB row (no `password_hash` etc.) |
| `authGate.ActiveSession` vs `domain.Session` | runtime composite (`{ sessionId, expiresAt, user }`) vs persisted row |
| `adapters/types.SchemaObject` vs `domain.SchemaObject` | freshly-introspected structural identity vs persisted row with id/hash/timestamps |
| `adapters/types.DbDialect` vs `domain.DataSourceDbType` | same literal union; both names are appropriate in their respective contexts |

These will naturally consolidate later in TS-009–TS-014 if it ever becomes valuable — but the layering is sound and forcing unification now would muddy the contracts.

## Verification

- `npm run typecheck` clean
- `npm test` 219/219 pass

## Test plan

- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)