### PR TITLE
ci: run only on pull-request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Drops the `push: branches: [main]` trigger from `.github/workflows/ci.yml`. The workflow now runs only on pull-request events: `opened`, `synchronize`, `reopened`, `ready_for_review`.

Tests already run inside the existing **Backend (typecheck, test, build)** job — they were never in a separate workflow — so this change only narrows *when* CI fires, not *what* it does.

## What this changes

| Event | Before | After |
|---|---|---|
| Push to main (after merge) | runs full CI | **does not run** |
| PR opened / synchronize / reopened / ready_for_review | runs full CI | runs full CI |
| Manual workflow_dispatch | not configured | not configured |

`cancel-in-progress` was previously gated on `github.event_name == 'pull_request'`; now that PR is the only event, it's set to `true` outright.

## Why

The post-merge run on main was redundant — PRs are validated by the same jobs before merge, so the merged commit has already been through CI in its pre-merge form. Skipping it cuts roughly one full run per merge.

## Caveats

- If anyone bypasses the PR flow (force-push or direct commit to main), CI won't run. If you want a safety net for that, add a `workflow_dispatch:` trigger or restore `push: branches: [main]`.
- This only affects `.github/workflows/ci.yml`. If you add new workflows later, they'll have their own trigger config.

## Test plan

- [ ] This PR runs CI on the `opened` event (you should see the jobs go green below)
- [ ] After merge, no run is queued on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)