### PR TITLE
TS-013 Migrate export, delivery, audit, observability services

### DIFF
--- a/app/src/services/auditService.ts
+++ b/app/src/services/auditService.ts
@@ -8,41 +8,91 @@
 // source access grants). For standalone events (login, auth provider CRUD)
 // the function falls back to `appDb`.
 
-const appDb = require("../lib/appDb");
+import type { PoolClient } from "pg";
+import appDb = require("../lib/appDb");
 
-const ALLOWED_OUTCOMES = new Set(["success", "failure", "info"]);
+export type AuditOutcome = "success" | "failure" | "info";
 
-const DEFAULT_LIMIT = 50;
-const MAX_LIMIT = 200;
+export interface WriteEventInput {
+  actorUserId?: string | null;
+  actorEmail?: string | null;
+  targetUserId?: string | null;
+  action: string;
+  outcome?: AuditOutcome | string;
+  details?: Record<string, unknown>;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+}
 
-function trimString(value, max) {
+export interface ListEventsInput {
+  action?: string | null;
+  actorUserId?: string | null;
+  targetUserId?: string | null;
+  outcome?: string | null;
+  since?: string | null;
+  until?: string | null;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AuditEventItem {
+  id: string;
+  actor_user_id: string | null;
+  actor_email: string | null;
+  actor: { id: string; email: string | null; display_name: string | null } | null;
+  target_user_id: string | null;
+  target: { id: string; email: string | null; display_name: string | null } | null;
+  action: string;
+  outcome: AuditOutcome | string | null;
+  details: Record<string, unknown>;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: Date | string;
+}
+
+export interface ListEventsResult {
+  items: AuditEventItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+const ALLOWED_OUTCOMES: ReadonlySet<string> = new Set(["success", "failure", "info"]);
+
+export const DEFAULT_LIMIT = 50;
+export const MAX_LIMIT = 200;
+
+function trimString(value: unknown, max: number): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   if (!trimmed) return null;
   return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
 }
 
-function normalizeOutcome(value) {
+function normalizeOutcome(value: unknown): string | null {
   if (value === undefined || value === null) return null;
   if (typeof value !== "string") return null;
   const lower = value.trim().toLowerCase();
   return ALLOWED_OUTCOMES.has(lower) ? lower : null;
 }
 
-async function writeEvent({
-  actorUserId = null,
-  actorEmail = null,
-  targetUserId = null,
-  action,
-  outcome = "success",
-  details = {},
-  ipAddress = null,
-  userAgent = null
-}, client = null) {
+export async function writeEvent(
+  {
+    actorUserId = null,
+    actorEmail = null,
+    targetUserId = null,
+    action,
+    outcome = "success",
+    details = {},
+    ipAddress = null,
+    userAgent = null
+  }: WriteEventInput,
+  client: PoolClient | null = null
+): Promise<void> {
   if (typeof action !== "string" || !action) {
     throw new Error("audit action is required");
   }
-  const exec = client || appDb;
+  const exec = (client || appDb) as typeof appDb;
   await exec.query(
     `
       INSERT INTO auth_audit_log
@@ -63,19 +113,19 @@ async function writeEvent({
   );
 }
 
-function clampLimit(value) {
+function clampLimit(value: unknown): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
   return Math.min(Math.floor(parsed), MAX_LIMIT);
 }
 
-function clampOffset(value) {
+function clampOffset(value: unknown): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed < 0) return 0;
   return Math.floor(parsed);
 }
 
-function parseTimestamp(value) {
+function parseTimestamp(value: unknown): string | null {
   if (!value) return null;
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
@@ -85,7 +135,24 @@ function parseTimestamp(value) {
   return date.toISOString();
 }
 
-async function listEvents({
+interface AuditEventRow {
+  id: string;
+  actor_user_id: string | null;
+  actor_email: string | null;
+  target_user_id: string | null;
+  action: string;
+  outcome: string | null;
+  details: Record<string, unknown> | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: Date | string;
+  actor_user_email: string | null;
+  actor_user_display_name: string | null;
+  target_user_email: string | null;
+  target_user_display_name: string | null;
+}
+
+export async function listEvents({
   action = null,
   actorUserId = null,
   targetUserId = null,
@@ -94,9 +161,9 @@ async function listEvents({
   until = null,
   limit = DEFAULT_LIMIT,
   offset = 0
-} = {}) {
-  const conditions = [];
-  const params = [];
+}: ListEventsInput = {}): Promise<ListEventsResult> {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
 
   if (typeof action === "string" && action.trim()) {
     params.push(action.trim());
@@ -130,7 +197,7 @@ async function listEvents({
   const effectiveLimit = clampLimit(limit);
   const effectiveOffset = clampOffset(offset);
 
-  const countResult = await appDb.query(
+  const countResult = await appDb.query<{ total: string | number }>(
     `SELECT COUNT(*)::bigint AS total FROM auth_audit_log a ${where}`,
     params
   );
@@ -138,7 +205,7 @@ async function listEvents({
 
   params.push(effectiveLimit);
   params.push(effectiveOffset);
-  const listResult = await appDb.query(
+  const listResult = await appDb.query<AuditEventRow>(
     `
       SELECT
         a.id,
@@ -165,7 +232,7 @@ async function listEvents({
     params
   );
 
-  const items = listResult.rows.map((row) => ({
+  const items: AuditEventItem[] = listResult.rows.map((row) => ({
     id: row.id,
     actor_user_id: row.actor_user_id,
     actor_email: row.actor_email,
@@ -191,10 +258,3 @@ async function listEvents({
     offset: effectiveOffset
   };
 }
-
-module.exports = {
-  DEFAULT_LIMIT,
-  MAX_LIMIT,
-  writeEvent,
-  listEvents
-};

--- a/app/src/services/dataSourceAccessService.ts
+++ b/app/src/services/dataSourceAccessService.ts
@@ -1,7 +1,24 @@
-const appDb = require("../lib/appDb");
-const roleService = require("./roleService");
+import type { PoolClient } from "pg";
+import appDb = require("../lib/appDb");
+import roleService = require("./roleService");
 
-async function hasAccess(userId, dataSourceId) {
+export interface UserWithAccess {
+  id: string;
+  email: string;
+  display_name: string | null;
+  is_active: boolean;
+  granted_at: Date | string;
+  granted_by_user_id: string | null;
+  roles: string[];
+}
+
+export interface GrantRevokeArgs {
+  userId: string;
+  dataSourceId: string;
+  actorUserId?: string | null;
+}
+
+export async function hasAccess(userId: string | null | undefined, dataSourceId: string | null | undefined): Promise<boolean> {
   if (!userId || !dataSourceId) {
     return false;
   }
@@ -9,20 +26,20 @@ async function hasAccess(userId, dataSourceId) {
     "SELECT 1 FROM user_data_source_access WHERE user_id = $1 AND data_source_id = $2",
     [userId, dataSourceId]
   );
-  return result.rowCount > 0;
+  return (result.rowCount ?? 0) > 0;
 }
 
-async function listAccessibleDataSourceIds(userId) {
+export async function listAccessibleDataSourceIds(userId: string | null | undefined): Promise<string[]> {
   if (!userId) return [];
-  const result = await appDb.query(
+  const result = await appDb.query<{ data_source_id: string }>(
     "SELECT data_source_id FROM user_data_source_access WHERE user_id = $1",
     [userId]
   );
   return result.rows.map((row) => row.data_source_id);
 }
 
-async function listUsersWithAccess(dataSourceId) {
-  const result = await appDb.query(
+export async function listUsersWithAccess(dataSourceId: string): Promise<UserWithAccess[]> {
+  const result = await appDb.query<UserWithAccess>(
     `
       SELECT
         u.id,
@@ -58,7 +75,7 @@ async function listUsersWithAccess(dataSourceId) {
   }));
 }
 
-async function grantAccess(client, { userId, dataSourceId, actorUserId }) {
+export async function grantAccess(client: PoolClient, { userId, dataSourceId, actorUserId }: GrantRevokeArgs): Promise<boolean> {
   const insert = await client.query(
     `
       INSERT INTO user_data_source_access (user_id, data_source_id, granted_by_user_id)
@@ -68,7 +85,7 @@ async function grantAccess(client, { userId, dataSourceId, actorUserId }) {
     `,
     [userId, dataSourceId, actorUserId || null]
   );
-  const changed = insert.rowCount > 0;
+  const changed = (insert.rowCount ?? 0) > 0;
   if (changed) {
     await roleService.writeAuditEntry(client, {
       actorUserId,
@@ -80,12 +97,12 @@ async function grantAccess(client, { userId, dataSourceId, actorUserId }) {
   return changed;
 }
 
-async function revokeAccess(client, { userId, dataSourceId, actorUserId }) {
+export async function revokeAccess(client: PoolClient, { userId, dataSourceId, actorUserId }: GrantRevokeArgs): Promise<boolean> {
   const del = await client.query(
     "DELETE FROM user_data_source_access WHERE user_id = $1 AND data_source_id = $2 RETURNING user_id",
     [userId, dataSourceId]
   );
-  const changed = del.rowCount > 0;
+  const changed = (del.rowCount ?? 0) > 0;
   if (changed) {
     await roleService.writeAuditEntry(client, {
       actorUserId,
@@ -96,11 +113,3 @@ async function revokeAccess(client, { userId, dataSourceId, actorUserId }) {
   }
   return changed;
 }
-
-module.exports = {
-  hasAccess,
-  listAccessibleDataSourceIds,
-  listUsersWithAccess,
-  grantAccess,
-  revokeAccess
-};

--- a/app/src/services/deliveryService.ts
+++ b/app/src/services/deliveryService.ts
@@ -1,31 +1,64 @@
-const appDb = require("../lib/appDb");
-const { exportQueryResult, SUPPORTED_FORMATS } = require("./exportService");
-const { sendExportEmail } = require("./emailService");
+import appDb = require("../lib/appDb");
+import { exportQueryResult, SUPPORTED_FORMATS } from "./exportService";
+import emailService = require("./emailService");
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+export type DeliveryMode = "download" | "email";
+export type DeliveryFormat = "json" | "csv" | "xlsx" | "tsv" | "parquet";
+
+export interface CreateDeliveryInput {
+  sessionId: string;
+  deliveryMode: DeliveryMode;
+  format: DeliveryFormat;
+  recipients?: string[];
+  requestedBy: string;
+}
+
+export interface DownloadDeliveryResult {
+  id: string;
+  status: "completed";
+  delivery_mode: "download";
+  buffer: Buffer;
+  contentType: string;
+  filename: string;
+}
+
+export interface EmailDeliveryAck {
+  id: string;
+  status: "processing";
+  delivery_mode: "email";
+}
+
+export type CreateDeliveryResult = DownloadDeliveryResult | EmailDeliveryAck;
+
+export interface DeliveryRecord {
+  id: string;
+  session_id: string;
+  delivery_mode: DeliveryMode;
+  format: DeliveryFormat;
+  recipients: string[] | null;
+  status: string;
+  error_message: string | null;
+  file_name: string | null;
+  file_size_bytes: number | null;
+  requested_by: string;
+  created_at: Date | string;
+  completed_at: Date | string | null;
+}
+
 /**
  * Validate an array of email addresses.
- * @param {string[]} emails
- * @returns {{ok: boolean, invalid: string[]}}
  */
-function validateRecipients(emails) {
+function validateRecipients(emails: string[]): { ok: boolean; invalid: string[] } {
   const invalid = emails.filter((e) => !EMAIL_REGEX.test(e));
   return { ok: invalid.length === 0, invalid };
 }
 
 /**
  * Create a delivery record and, for email mode, kick off async delivery.
- *
- * @param {Object} opts
- * @param {string} opts.sessionId
- * @param {string} opts.deliveryMode  'download' | 'email'
- * @param {string} opts.format        'json' | 'csv' | 'xlsx' | 'tsv' | 'parquet'
- * @param {string[]} [opts.recipients]
- * @param {string} opts.requestedBy
- * @returns {Promise<Object>} delivery record (for download mode includes buffer)
  */
-async function createDelivery({ sessionId, deliveryMode, format, recipients, requestedBy }) {
+export async function createDelivery({ sessionId, deliveryMode, format, recipients, requestedBy }: CreateDeliveryInput): Promise<CreateDeliveryResult> {
   if (!SUPPORTED_FORMATS.has(format)) {
     throw Object.assign(new Error(`Unsupported format: ${format}`), { statusCode: 400 });
   }
@@ -44,7 +77,7 @@ async function createDelivery({ sessionId, deliveryMode, format, recipients, req
   }
 
   // Insert delivery record
-  const insertResult = await appDb.query(
+  const insertResult = await appDb.query<{ id: string; status: string; created_at: Date | string }>(
     `
       INSERT INTO export_deliveries (session_id, delivery_mode, format, recipients, status, requested_by)
       VALUES ($1, $2, $3, $4, 'pending', $5)
@@ -84,14 +117,14 @@ async function createDelivery({ sessionId, deliveryMode, format, recipients, req
           SET status = 'failed', error_message = $2, completed_at = NOW()
           WHERE id = $1
         `,
-        [delivery.id, err.message]
+        [delivery.id, (err as Error).message]
       );
       throw err;
     }
   }
 
   // Email mode: run async
-  processEmailDelivery(delivery.id, sessionId, format, recipients).catch((err) => {
+  processEmailDelivery(delivery.id, sessionId, format, recipients!).catch((err: Error) => {
     console.error(`[delivery] Email delivery ${delivery.id} failed: ${err.message}`);
   });
 
@@ -105,7 +138,7 @@ async function createDelivery({ sessionId, deliveryMode, format, recipients, req
 /**
  * Process email delivery asynchronously.
  */
-async function processEmailDelivery(deliveryId, sessionId, format, recipients) {
+async function processEmailDelivery(deliveryId: string, sessionId: string, format: DeliveryFormat, recipients: string[]): Promise<void> {
   await appDb.query(
     "UPDATE export_deliveries SET status = 'processing' WHERE id = $1",
     [deliveryId]
@@ -115,13 +148,13 @@ async function processEmailDelivery(deliveryId, sessionId, format, recipients) {
     const { buffer, contentType, filename } = await exportQueryResult(sessionId, format);
 
     // Fetch session question for email subject
-    const sessionResult = await appDb.query(
+    const sessionResult = await appDb.query<{ question: string | null }>(
       "SELECT question FROM query_sessions WHERE id = $1",
       [sessionId]
     );
     const question = sessionResult.rows[0]?.question || "Query Export";
 
-    await sendExportEmail({
+    await emailService.sendExportEmail({
       recipients,
       subject: `Report Pilot Export: ${question.substring(0, 80)}`,
       textBody: `Your requested export for the query "${question}" is attached.\n\nFormat: ${format.toUpperCase()}\nFile: ${filename}`,
@@ -145,7 +178,7 @@ async function processEmailDelivery(deliveryId, sessionId, format, recipients) {
         SET status = 'failed', error_message = $2, completed_at = NOW()
         WHERE id = $1
       `,
-      [deliveryId, err.message]
+      [deliveryId, (err as Error).message]
     );
     throw err;
   }
@@ -153,11 +186,9 @@ async function processEmailDelivery(deliveryId, sessionId, format, recipients) {
 
 /**
  * Fetch a delivery record by ID.
- * @param {string} exportId
- * @returns {Promise<Object|null>}
  */
-async function getDeliveryStatus(exportId) {
-  const result = await appDb.query(
+export async function getDeliveryStatus(exportId: string): Promise<DeliveryRecord | null> {
+  const result = await appDb.query<DeliveryRecord>(
     `
       SELECT id, session_id, delivery_mode, format, recipients, status, error_message,
              file_name, file_size_bytes, requested_by, created_at, completed_at
@@ -169,5 +200,3 @@ async function getDeliveryStatus(exportId) {
 
   return result.rows[0] || null;
 }
-
-module.exports = { createDelivery, getDeliveryStatus };

--- a/app/src/services/emailService.ts
+++ b/app/src/services/emailService.ts
@@ -1,4 +1,4 @@
-const nodemailer = require("nodemailer");
+import nodemailer, { type Transporter } from "nodemailer";
 
 const SMTP_HOST = process.env.SMTP_HOST || "localhost";
 const SMTP_PORT = Number(process.env.SMTP_PORT || 587);
@@ -7,9 +7,22 @@ const SMTP_USER = process.env.SMTP_USER || "";
 const SMTP_PASS = process.env.SMTP_PASS || "";
 const SMTP_FROM = process.env.SMTP_FROM || "Report Pilot Reports <noreply@report-pilot.local>";
 
-let transporter = null;
+interface SendExportEmailOptions {
+  recipients: string[];
+  subject: string;
+  textBody: string;
+  fileBuffer: Buffer;
+  fileName: string;
+  contentType: string;
+}
 
-function getTransporter() {
+interface SendExportEmailResult {
+  messageId: string;
+}
+
+let transporter: Transporter | null = null;
+
+function getTransporter(): Transporter {
   if (!transporter) {
     transporter = nodemailer.createTransport({
       host: SMTP_HOST,
@@ -23,17 +36,8 @@ function getTransporter() {
 
 /**
  * Send an email with an export file attached.
- *
- * @param {Object} opts
- * @param {string[]} opts.recipients
- * @param {string} opts.subject
- * @param {string} opts.textBody
- * @param {Buffer} opts.fileBuffer
- * @param {string} opts.fileName
- * @param {string} opts.contentType
- * @returns {Promise<{messageId: string}>}
  */
-async function sendExportEmail({ recipients, subject, textBody, fileBuffer, fileName, contentType }) {
+async function sendExportEmail({ recipients, subject, textBody, fileBuffer, fileName, contentType }: SendExportEmailOptions): Promise<SendExportEmailResult> {
   const transport = getTransporter();
 
   const info = await transport.sendMail({
@@ -53,4 +57,9 @@ async function sendExportEmail({ recipients, subject, textBody, fileBuffer, file
   return { messageId: info.messageId };
 }
 
-module.exports = { sendExportEmail };
+// Use CommonJS `module.exports` so tests can monkey-patch
+// `emailService.sendExportEmail`. Named `export` statements compile to
+// immutable getters under tsx, breaking the patch (see lib/appDb.ts).
+export = {
+  sendExportEmail
+};

--- a/app/src/services/exportService.ts
+++ b/app/src/services/exportService.ts
@@ -1,34 +1,43 @@
-const appDb = require("../lib/appDb");
-const { createDatabaseAdapter } = require("../adapters/dbAdapterFactory");
-const { stringify } = require("csv-stringify/sync"); // Synchronous for simplicity in MVP, or stream
-const xlsx = require("xlsx");
-const parquet = require("parquetjs-lite");
-const fs = require("fs/promises");
-const os = require("os");
-const path = require("path");
+import appDb = require("../lib/appDb");
+import { createDatabaseAdapter } from "../adapters/dbAdapterFactory";
+import { stringify } from "csv-stringify/sync";
+import * as xlsx from "xlsx";
+import * as parquet from "parquetjs-lite";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
 
-const SUPPORTED_FORMATS = new Set(["json", "csv", "xlsx", "tsv", "parquet"]);
+export type ExportFormat = "json" | "csv" | "xlsx" | "tsv" | "parquet";
+
+export const SUPPORTED_FORMATS: ReadonlySet<ExportFormat> = new Set<ExportFormat>(["json", "csv", "xlsx", "tsv", "parquet"]);
+
+export interface ExportResult {
+  buffer: Buffer;
+  contentType: string;
+  filename: string;
+}
+
+type ParquetPrimitive = "BOOLEAN" | "INT64" | "DOUBLE" | "TIMESTAMP_MILLIS" | "UTF8";
+
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)?$/;
 
 /**
  * Exports current query results for a given session.
  * Re-runs the *latest successful* SQL generation for the session to get a fresh cursor/result.
- *
- * @param {string} sessionId
- * @param {string} format 'json' | 'csv' | 'xlsx' | 'tsv' | 'parquet'
- * @returns {Promise<{
- *   buffer: Buffer | string,
- *   contentType: string,
- *   filename: string
- * }>}
  */
-async function exportQueryResult(sessionId, format = "json") {
+export async function exportQueryResult(sessionId: string, format: ExportFormat = "json"): Promise<ExportResult> {
   if (!SUPPORTED_FORMATS.has(format)) {
     throw new Error(`Unsupported format: ${format}`);
   }
 
   // 1. Fetch session and check data source info
-  const sessionResult = await appDb.query(
+  const sessionResult = await appDb.query<{
+    id: string;
+    data_source_id: string;
+    question: string | null;
+    connection_ref: string;
+    db_type: string;
+  }>(
     `
       SELECT
         qs.id,
@@ -50,7 +59,7 @@ async function exportQueryResult(sessionId, format = "json") {
   const session = sessionResult.rows[0];
 
   // 2. Fetch the latest successful attempt's SQL
-  const attemptResult = await appDb.query(
+  const attemptResult = await appDb.query<{ generated_sql: string | null }>(
     `
       SELECT qa.generated_sql
       FROM query_attempts qa
@@ -74,11 +83,11 @@ async function exportQueryResult(sessionId, format = "json") {
   // 3. Re-execute the SQL (Read-Only)
   // Note: For very large datasets, we should stream. For MVP, we load into memory.
   const adapter = createDatabaseAdapter(session.db_type, session.connection_ref);
-  let rows = [];
-  let columns = [];
+  let rows: Array<Record<string, unknown>> = [];
+  let columns: string[] = [];
   try {
     const execution = await adapter.executeReadOnly(sql, { maxRows: 100000 }); // Increase limit for export
-    rows = execution.rows;
+    rows = execution.rows as Array<Record<string, unknown>>;
     columns = execution.columns || [];
   } finally {
     await adapter.close();
@@ -90,8 +99,8 @@ async function exportQueryResult(sessionId, format = "json") {
   const filename = `${safeName}_${timestamp}.${format === "xlsx" ? "xlsx" : format}`;
   const columnOrder = getColumnOrder(columns, rows);
 
-  let buffer;
-  let contentType;
+  let buffer: Buffer;
+  let contentType: string;
 
   switch (format) {
     case "json": {
@@ -102,9 +111,6 @@ async function exportQueryResult(sessionId, format = "json") {
     }
 
     case "csv":
-      // csv-stringify handles objects if columns are consistent
-      // We can infer columns from the first row or passing 'columns' option if needed.
-      // stringify(rows, { header: true }) works well.
       buffer = Buffer.from(
         stringify(rows, { header: true, columns: columnOrder.length > 0 ? columnOrder : undefined }),
         "utf-8"
@@ -139,14 +145,17 @@ async function exportQueryResult(sessionId, format = "json") {
       buffer = await exportParquet(rows, columnOrder);
       contentType = "application/vnd.apache.parquet";
       break;
+
+    default:
+      throw new Error(`Unsupported format: ${format}`);
   }
 
   return { buffer, contentType, filename };
 }
 
-function getColumnOrder(columns, rows) {
+function getColumnOrder(columns: string[] | unknown, rows: Array<Record<string, unknown>>): string[] {
   if (Array.isArray(columns) && columns.length > 0) {
-    return columns;
+    return columns as string[];
   }
   if (rows.length > 0) {
     return Object.keys(rows[0]);
@@ -154,8 +163,8 @@ function getColumnOrder(columns, rows) {
   return [];
 }
 
-function normalizeRowForJson(row, columnOrder) {
-  const ordered = {};
+function normalizeRowForJson(row: Record<string, unknown>, columnOrder: string[]): Record<string, unknown> {
+  const ordered: Record<string, unknown> = {};
   const keys = Array.isArray(columnOrder) && columnOrder.length > 0
     ? columnOrder
     : Object.keys(row || {});
@@ -173,7 +182,7 @@ function normalizeRowForJson(row, columnOrder) {
   return ordered;
 }
 
-function normalizeJsonValue(value) {
+function normalizeJsonValue(value: unknown): unknown {
   if (value === null || value === undefined) {
     return null;
   }
@@ -203,9 +212,9 @@ function normalizeJsonValue(value) {
   }
 
   if (typeof value === "object") {
-    const out = {};
-    for (const key of Object.keys(value)) {
-      out[key] = normalizeJsonValue(value[key]);
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      out[key] = normalizeJsonValue((value as Record<string, unknown>)[key]);
     }
     return out;
   }
@@ -213,7 +222,7 @@ function normalizeJsonValue(value) {
   return String(value);
 }
 
-function inferParquetType(values) {
+function inferParquetType(values: unknown[]): ParquetPrimitive {
   const presentValues = values.filter((value) => value !== null && value !== undefined);
   if (presentValues.length === 0) {
     return "UTF8";
@@ -237,7 +246,7 @@ function inferParquetType(values) {
   return "UTF8";
 }
 
-function isDateLike(value) {
+function isDateLike(value: unknown): boolean {
   if (value instanceof Date) {
     return !Number.isNaN(value.getTime());
   }
@@ -250,7 +259,7 @@ function isDateLike(value) {
   return !Number.isNaN(Date.parse(value));
 }
 
-function normalizeParquetValue(value, type) {
+function normalizeParquetValue(value: unknown, type: ParquetPrimitive): unknown {
   if (value === null || value === undefined) {
     return null;
   }
@@ -280,19 +289,19 @@ function normalizeParquetValue(value, type) {
   }
 
   if (type === "TIMESTAMP_MILLIS") {
-    const dateValue = value instanceof Date ? value : new Date(value);
+    const dateValue = value instanceof Date ? value : new Date(value as string);
     return Number.isNaN(dateValue.getTime()) ? null : dateValue;
   }
 
   return String(value);
 }
 
-async function exportParquet(rows, columnOrder) {
+async function exportParquet(rows: Array<Record<string, unknown>>, columnOrder: string[]): Promise<Buffer> {
   if (!Array.isArray(columnOrder) || columnOrder.length === 0) {
     throw new Error("Cannot export parquet without columns");
   }
 
-  const schemaDefinition = {};
+  const schemaDefinition: Record<string, { type: ParquetPrimitive; optional: boolean }> = {};
   for (const column of columnOrder) {
     const values = rows.map((row) => row[column]);
     schemaDefinition[column] = {
@@ -301,21 +310,25 @@ async function exportParquet(rows, columnOrder) {
     };
   }
 
-  const schema = new parquet.ParquetSchema(schemaDefinition);
+  const schema = new (parquet as { ParquetSchema: new (def: unknown) => unknown }).ParquetSchema(schemaDefinition);
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "report-pilot-export-"));
   const filePath = path.join(tempDir, `export-${Date.now()}.parquet`);
 
-  let writer;
+  let writer: { appendRow: (row: Record<string, unknown>) => Promise<void>; close: () => Promise<void> } | null = null;
   try {
-    writer = await parquet.ParquetWriter.openFile(schema, filePath);
+    writer = await (parquet as {
+      ParquetWriter: {
+        openFile: (schema: unknown, path: string) => Promise<{ appendRow: (row: Record<string, unknown>) => Promise<void>; close: () => Promise<void> }>;
+      };
+    }).ParquetWriter.openFile(schema, filePath);
     for (const row of rows) {
-      const normalizedRow = {};
+      const normalizedRow: Record<string, unknown> = {};
       for (const column of columnOrder) {
         normalizedRow[column] = normalizeParquetValue(row[column], schemaDefinition[column].type);
       }
-      await writer.appendRow(normalizedRow);
+      await writer!.appendRow(normalizedRow);
     }
-    await writer.close();
+    await writer!.close();
     writer = null;
 
     return await fs.readFile(filePath);
@@ -327,14 +340,10 @@ async function exportParquet(rows, columnOrder) {
   }
 }
 
-module.exports = {
-  exportQueryResult,
-  SUPPORTED_FORMATS,
-  __private: {
-    getColumnOrder,
-    normalizeRowForJson,
-    normalizeJsonValue,
-    inferParquetType,
-    normalizeParquetValue
-  }
+export const __private = {
+  getColumnOrder,
+  normalizeRowForJson,
+  normalizeJsonValue,
+  inferParquetType,
+  normalizeParquetValue
 };

--- a/app/src/services/observabilityService.ts
+++ b/app/src/services/observabilityService.ts
@@ -1,6 +1,6 @@
-const fs = require("fs/promises");
-const path = require("path");
-const appDb = require("../lib/appDb");
+import * as fs from "fs/promises";
+import * as path from "path";
+import appDb = require("../lib/appDb");
 
 const DEFAULT_REPORT_DIR =
   process.env.BENCHMARK_REPORT_DIR || path.join(process.cwd(), "docs", "evals", "reports");
@@ -8,10 +8,71 @@ const DEFAULT_BENCHMARK_DATA_SOURCE = "dvdrental";
 const DEFAULT_BENCHMARK_CONNECTION_REF = "postgresql://postgres:postgres@host.docker.internal:5440/dvdrental";
 const DEFAULT_BENCHMARK_ORACLE_CONN = "postgresql://postgres:postgres@localhost:5440/dvdrental";
 
-async function buildObservabilityMetrics(opts = {}) {
+export interface NumberSummary {
+  count: number;
+  avg: number | null;
+  p50: number | null;
+  p95: number | null;
+  max: number | null;
+}
+
+export interface ObservabilityMetrics {
+  window_hours: number;
+  generated_at: string;
+  totals: {
+    attempts: number;
+    attempts_with_execution: number;
+    attempts_with_explain: number;
+  };
+  latency_ms: {
+    generation: NumberSummary;
+    execution: NumberSummary;
+  };
+  query_cost: {
+    explain_max_total_cost: NumberSummary;
+    explain_max_plan_rows: NumberSummary;
+    mean_explain_cost_per_attempt: number | null;
+  };
+  token_usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    avg_total_tokens_per_attempt: number | null;
+  };
+  provider_failures: Array<{ provider: string; failures: number }>;
+}
+
+export interface BenchmarkReleaseGates {
+  found: boolean;
+  source?: "database";
+  report_id?: string;
+  run_date?: string | Date | null;
+  data_source_id?: string | null;
+  summary?: Record<string, unknown> | null;
+  release_gates?: Record<string, unknown> | null;
+  report_file?: string;
+  message?: string;
+}
+
+export interface BenchmarkCommand {
+  command: string;
+  env: Record<string, string>;
+}
+
+export async function buildObservabilityMetrics(opts: { windowHours?: number } = {}): Promise<ObservabilityMetrics> {
   const windowHours = clampWindowHours(opts.windowHours);
 
-  const attemptsResult = await appDb.query(
+  interface AttemptRow {
+    id: string;
+    llm_provider: string | null;
+    latency_ms: number | string | null;
+    token_usage_json: Record<string, unknown> | null;
+    validation_result_json: Record<string, unknown> | null;
+    created_at: Date | string;
+    execution_duration_ms: number | string | null;
+  }
+
+  const attemptsResult = await appDb.query<AttemptRow>(
     `
       SELECT
         qa.id,
@@ -30,16 +91,16 @@ async function buildObservabilityMetrics(opts = {}) {
   );
 
   const rows = attemptsResult.rows;
-  const generationLatencies = [];
-  const executionLatencies = [];
-  const explainCosts = [];
-  const explainRows = [];
+  const generationLatencies: number[] = [];
+  const executionLatencies: number[] = [];
+  const explainCosts: number[] = [];
+  const explainRows: number[] = [];
 
   let tokenPrompt = 0;
   let tokenCompletion = 0;
   let tokenTotal = 0;
 
-  const providerFailureCounts = new Map();
+  const providerFailureCounts = new Map<string, number>();
   for (const row of rows) {
     const generationLatency = Number(row.latency_ms);
     if (Number.isFinite(generationLatency)) {
@@ -58,8 +119,9 @@ async function buildObservabilityMetrics(opts = {}) {
       tokenTotal += usage.total_tokens;
     }
 
-    const validation = row.validation_result_json || {};
-    const metrics = validation?.explain_budget?.metrics;
+    const validation = (row.validation_result_json || {}) as Record<string, unknown>;
+    const explainBudget = validation.explain_budget as Record<string, unknown> | undefined;
+    const metrics = explainBudget?.metrics as Record<string, unknown> | undefined;
     if (metrics && Number.isFinite(Number(metrics.maxTotalCost))) {
       explainCosts.push(Number(metrics.maxTotalCost));
     }
@@ -68,7 +130,7 @@ async function buildObservabilityMetrics(opts = {}) {
     }
 
     const providerAttempts = Array.isArray(validation.provider_attempts) ? validation.provider_attempts : [];
-    for (const attempt of providerAttempts) {
+    for (const attempt of providerAttempts as Array<Record<string, unknown>>) {
       if (attempt?.status !== "failed") {
         continue;
       }
@@ -114,8 +176,15 @@ async function buildObservabilityMetrics(opts = {}) {
   };
 }
 
-async function loadLatestBenchmarkReleaseGates(reportDir = DEFAULT_REPORT_DIR) {
-  const dbResult = await appDb.query(
+export async function loadLatestBenchmarkReleaseGates(reportDir: string = DEFAULT_REPORT_DIR): Promise<BenchmarkReleaseGates> {
+  interface BenchmarkRow {
+    id: string;
+    run_date: Date | string | null;
+    data_source_id: string | null;
+    summary_json: (Record<string, unknown> & { release_gates?: Record<string, unknown> }) | null;
+  }
+
+  const dbResult = await appDb.query<BenchmarkRow>(
     `
       SELECT
         id,
@@ -128,7 +197,7 @@ async function loadLatestBenchmarkReleaseGates(reportDir = DEFAULT_REPORT_DIR) {
     `
   );
 
-  if (dbResult.rowCount > 0) {
+  if ((dbResult.rowCount ?? 0) > 0) {
     const row = dbResult.rows[0];
     return {
       found: true,
@@ -147,7 +216,7 @@ async function loadLatestBenchmarkReleaseGates(reportDir = DEFAULT_REPORT_DIR) {
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
   } catch (err) {
-    if (err.code === "ENOENT") {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return {
         found: false,
         message: `No benchmark reports found at ${dir}`
@@ -180,19 +249,19 @@ async function loadLatestBenchmarkReleaseGates(reportDir = DEFAULT_REPORT_DIR) {
 
   const latest = stats.sort((a, b) => b.mtimeMs - a.mtimeMs)[0];
   const raw = await fs.readFile(latest.filePath, "utf8");
-  const parsed = JSON.parse(raw);
+  const parsed = JSON.parse(raw) as Record<string, unknown> & { summary?: Record<string, unknown> & { release_gates?: Record<string, unknown> } };
 
   return {
     found: true,
     report_file: latest.filePath,
-    run_date: parsed.run_date || null,
-    data_source_id: parsed.data_source_id || null,
+    run_date: (parsed.run_date as string | null) || null,
+    data_source_id: (parsed.data_source_id as string | null) || null,
     summary: parsed.summary || null,
     release_gates: parsed.summary?.release_gates || null
   };
 }
 
-function buildBenchmarkCommand() {
+export function buildBenchmarkCommand(): BenchmarkCommand {
   const dataSourceName = process.env.BENCHMARK_DATA_SOURCE_NAME || DEFAULT_BENCHMARK_DATA_SOURCE;
   const fallbackConn = process.env.BENCHMARK_DATA_SOURCE_CONN || DEFAULT_BENCHMARK_ORACLE_CONN;
   const connectionRef = process.env.BENCHMARK_CONNECTION_REF || fallbackConn || DEFAULT_BENCHMARK_CONNECTION_REF;
@@ -201,7 +270,7 @@ function buildBenchmarkCommand() {
   const provider = process.env.BENCHMARK_PROVIDER || "";
   const model = process.env.BENCHMARK_MODEL || "";
 
-  const env = {
+  const env: Record<string, string> = {
     BENCHMARK_DATA_SOURCE_NAME: dataSourceName,
     BENCHMARK_CONNECTION_REF: connectionRef,
     BENCHMARK_ORACLE_CONN: oracleConn
@@ -228,14 +297,21 @@ function buildBenchmarkCommand() {
   };
 }
 
-function normalizeTokenUsage(raw) {
+interface NormalizedTokenUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+function normalizeTokenUsage(raw: unknown): NormalizedTokenUsage | null {
   if (!raw || typeof raw !== "object") {
     return null;
   }
+  const r = raw as Record<string, unknown>;
 
-  const promptTokens = toFiniteNumber(raw.prompt_tokens ?? raw.promptTokenCount);
-  const completionTokens = toFiniteNumber(raw.completion_tokens ?? raw.candidatesTokenCount ?? raw.output_tokens);
-  const totalTokens = toFiniteNumber(raw.total_tokens ?? raw.totalTokenCount);
+  const promptTokens = toFiniteNumber(r.prompt_tokens ?? r.promptTokenCount);
+  const completionTokens = toFiniteNumber(r.completion_tokens ?? r.candidatesTokenCount ?? r.output_tokens);
+  const totalTokens = toFiniteNumber(r.total_tokens ?? r.totalTokenCount);
 
   const normalizedPrompt = promptTokens || 0;
   const normalizedCompletion = completionTokens || 0;
@@ -248,7 +324,7 @@ function normalizeTokenUsage(raw) {
   };
 }
 
-function summarizeNumbers(values) {
+function summarizeNumbers(values: number[]): NumberSummary {
   if (!Array.isArray(values) || values.length === 0) {
     return {
       count: 0,
@@ -272,7 +348,7 @@ function summarizeNumbers(values) {
   };
 }
 
-function percentileSorted(sorted, p) {
+function percentileSorted(sorted: number[], p: number): number {
   if (!Array.isArray(sorted) || sorted.length === 0) {
     return NaN;
   }
@@ -281,16 +357,16 @@ function percentileSorted(sorted, p) {
   return sorted[idx];
 }
 
-function round2(value) {
+function round2(value: number): number {
   return Number(Number(value).toFixed(2));
 }
 
-function toFiniteNumber(value) {
+function toFiniteNumber(value: unknown): number | null {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
 }
 
-function clampWindowHours(value) {
+function clampWindowHours(value: unknown): number {
   const n = Number(value || 24);
   if (!Number.isFinite(n)) {
     return 24;
@@ -298,14 +374,8 @@ function clampWindowHours(value) {
   return Math.max(1, Math.min(24 * 30, Math.round(n)));
 }
 
-function toShellLiteral(value) {
+function toShellLiteral(value: unknown): string {
   const source = String(value ?? "");
   const escaped = source.replace(/'/g, "'\\''");
   return `'${escaped}'`;
 }
-
-module.exports = {
-  buildObservabilityMetrics,
-  loadLatestBenchmarkReleaseGates,
-  buildBenchmarkCommand
-};


### PR DESCRIPTION
## Summary

Migrates the 6 services in this cluster from `.js` to `.ts` with explicit input/output types. No runtime behavior changes; tests stay green at 219/219.

## Files migrated

All in `app/src/services/`:

| File | Notes |
|---|---|
| `exportService.ts` | json/csv/tsv/xlsx/parquet export — typed `ExportFormat` union and per-format buffer/contentType handling. Tightened parquet schema construction. |
| `deliveryService.ts` | Download + email delivery orchestration. Typed `DeliveryMode`/`DeliveryFormat` unions and discriminated `CreateDeliveryResult`. |
| `emailService.ts` | Uses **`export = { ... }`** (the `lib/appDb.ts` pattern) because `app/test/savedQuerySchedulesApi.test.js` monkey-patches `emailService.sendExportEmail`. Under tsx/esbuild, named exports become immutable getters and the test patch silently no-ops — exactly the case TS-005 surfaced. |
| `observabilityService.ts` | Typed metric/summary shapes (`NumberSummary`, `ObservabilityMetrics`), benchmark report loading. |
| `auditService.ts` | Typed `WriteEventInput` / `ListEventsResult` / `AuditEventItem`. Preserves the `(client \|\| appDb) as typeof appDb` executor pattern. |
| `dataSourceAccessService.ts` | Typed `UserWithAccess`, grant/revoke args; audit entries still flow through `roleService.writeAuditEntry`. |

## Type decisions

- **`emailService` uses `export = { ... }`** — only service in this batch that needs it (verified by `grep "emailService\.[a-zA-Z_]+ ="` against the test suite). All other services use plain named exports.
- **Local-only interfaces in `emailService`** — `export interface ...` cannot coexist with `export = ...` in the same module, so the option/result shapes are file-local. They aren't imported externally yet (leaf migration).
- **No edits to `app/src/types/domain.ts`** — per the multi-agent ground rules. `AuditEvent` from domain.ts is not yet wired in here; the audit shapes live next to the service for now. Cross-service unification fits TS-014 (routes) or a follow-up.
- **`ParquetPrimitive`** is a local union in `exportService.ts` so the writer schema construction is type-safe without dragging in `parquetjs-lite` types (which the package doesn't ship).

## Verification

- `npm run typecheck` exits 0
- `npm test` 219/219 pass — including `exportService.test.js`, `auditEventsApi.test.js`, `dataSourceAccessApi.test.js`, `userDataSourceAccessMigration.test.js`, and the saved-query-schedule tests that monkey-patch `emailService.sendExportEmail`
- `app/src/services/` contains no leftover `.js` for these 6 modules

## Out of scope

- Routes calling these services (TS-014)
- Tests under `app/test/` (TS-016)

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)