### PR TITLE
TS-009 Migrate SQL generation, validation, and safety services

### DIFF
--- a/app/src/adapters/llm/customAdapter.ts
+++ b/app/src/adapters/llm/customAdapter.ts
@@ -14,7 +14,7 @@ const { postJson, extractJsonObject } = require("./httpClient");
  * `provider` so this adapter can stand in for any OpenAI-shaped REST endpoint.
  * Embeddings are not assumed to be supported and `embed()` throws.
  */
-class CustomAdapter implements LlmAdapter {
+export class CustomAdapter implements LlmAdapter {
   provider: string;
   apiKey: string;
   defaultModel: string;

--- a/app/src/adapters/llm/deepSeekAdapter.ts
+++ b/app/src/adapters/llm/deepSeekAdapter.ts
@@ -12,7 +12,7 @@ const { postJson, extractJsonObject } = require("./httpClient");
  * Adapter for DeepSeek's OpenAI-compatible chat-completions endpoint.
  * Embeddings are not yet implemented upstream, so `embed()` throws.
  */
-class DeepSeekAdapter implements LlmAdapter {
+export class DeepSeekAdapter implements LlmAdapter {
   readonly provider: string;
   apiKey: string;
   defaultModel: string;

--- a/app/src/adapters/llm/geminiAdapter.ts
+++ b/app/src/adapters/llm/geminiAdapter.ts
@@ -15,7 +15,7 @@ const { postJson, extractJsonObject } = require("./httpClient");
  * embeddings use a separate `:embedContent` endpoint and must be requested
  * per-text (unlike OpenAI which batches).
  */
-class GeminiAdapter implements LlmAdapter {
+export class GeminiAdapter implements LlmAdapter {
   readonly provider: string;
   apiKey: string;
   defaultModel: string;

--- a/app/src/adapters/llm/httpClient.ts
+++ b/app/src/adapters/llm/httpClient.ts
@@ -66,7 +66,7 @@ async function postJson(
  * fenced code blocks (```json ... ```) and trims to the first/last brace as a
  * last resort. Throws when nothing parseable is found.
  */
-function extractJsonObject(text: unknown): unknown {
+export function extractJsonObject(text: unknown): unknown {
   const raw = String(text || "").trim();
   if (!raw) {
     throw new Error("Model response is empty");
@@ -99,7 +99,7 @@ function extractJsonObject(text: unknown): unknown {
  *
  * If `ref` is empty/missing, falls back to `process.env[defaultEnvKey]`.
  */
-function resolveApiKey(ref?: string | null, defaultEnvKey?: string | null): string {
+export function resolveApiKey(ref?: string | null, defaultEnvKey?: string | null): string {
   const candidates: string[] = [];
   if (ref) {
     candidates.push(ref);

--- a/app/src/adapters/llm/openAiAdapter.ts
+++ b/app/src/adapters/llm/openAiAdapter.ts
@@ -10,7 +10,7 @@ import type {
 const { postJson, extractJsonObject } = require("./httpClient");
 
 /** Adapter for OpenAI's REST API (chat completions + embeddings). */
-class OpenAiAdapter implements LlmAdapter {
+export class OpenAiAdapter implements LlmAdapter {
   readonly provider: string;
   apiKey: string;
   defaultModel: string;

--- a/app/src/adapters/llm/openRouterAdapter.ts
+++ b/app/src/adapters/llm/openRouterAdapter.ts
@@ -14,7 +14,7 @@ const { postJson, extractJsonObject } = require("./httpClient");
  * variables to satisfy OpenRouter's attribution guidelines. Embeddings are not
  * exposed by this provider, so `embed()` throws.
  */
-class OpenRouterAdapter implements LlmAdapter {
+export class OpenRouterAdapter implements LlmAdapter {
   readonly provider: string;
   apiKey: string;
   defaultModel: string;

--- a/app/src/services/embeddingRouter.ts
+++ b/app/src/services/embeddingRouter.ts
@@ -1,19 +1,33 @@
-const { OpenAiAdapter } = require("../adapters/llm/openAiAdapter");
-const { GeminiAdapter } = require("../adapters/llm/geminiAdapter");
-const { resolveApiKey } = require("../adapters/llm/httpClient");
-const { EMBEDDING_MODEL: LOCAL_EMBEDDING_MODEL, embedText } = require("./localEmbedding");
+import { OpenAiAdapter } from "../adapters/llm/openAiAdapter";
+import { GeminiAdapter } from "../adapters/llm/geminiAdapter";
+import { resolveApiKey } from "../adapters/llm/httpClient";
+import { EMBEDDING_MODEL as LOCAL_EMBEDDING_MODEL, embedText } from "./localEmbedding";
 
 const OPENAI_DEFAULT_EMBED_MODEL = process.env.RAG_EMBED_MODEL_OPENAI || "text-embedding-3-small";
 const GEMINI_DEFAULT_EMBED_MODEL = process.env.RAG_EMBED_MODEL_GEMINI || "text-embedding-004";
 
-function buildEmbeddingModelId(provider, model) {
+export type EmbeddingProvider = "local" | "openai" | "gemini" | "auto" | string;
+
+export interface EmbedTextsResult {
+  provider: EmbeddingProvider;
+  embeddingModel: string;
+  vectors: number[][];
+}
+
+export interface EmbedOptions {
+  provider?: EmbeddingProvider;
+}
+
+export { LOCAL_EMBEDDING_MODEL };
+
+export function buildEmbeddingModelId(provider: EmbeddingProvider, model: string | null | undefined): string {
   if (provider === "local") {
     return LOCAL_EMBEDDING_MODEL;
   }
   return `${provider}:${model}`;
 }
 
-function parseEmbeddingModelId(embeddingModel) {
+export function parseEmbeddingModelId(embeddingModel: unknown): { provider: EmbeddingProvider; model: string } {
   const text = String(embeddingModel || "").trim();
   if (!text || text === LOCAL_EMBEDDING_MODEL) {
     return { provider: "local", model: LOCAL_EMBEDDING_MODEL };
@@ -30,11 +44,11 @@ function parseEmbeddingModelId(embeddingModel) {
   };
 }
 
-function embedTextsLocal(texts) {
+function embedTextsLocal(texts: string[]): number[][] {
   return texts.map((text) => embedText(text));
 }
 
-async function embedTextsForIndexing(texts, opts = {}) {
+export async function embedTextsForIndexing(texts: string[], opts: EmbedOptions = {}): Promise<EmbedTextsResult> {
   if (!Array.isArray(texts) || texts.length === 0) {
     return {
       provider: "local",
@@ -58,7 +72,7 @@ async function embedTextsForIndexing(texts, opts = {}) {
     try {
       const response = await embedTextsWithProvider(provider, texts);
       return response;
-    } catch (err) {
+    } catch {
       // try next provider
     }
   }
@@ -70,7 +84,7 @@ async function embedTextsForIndexing(texts, opts = {}) {
   };
 }
 
-async function embedQueryForModel(question, embeddingModel) {
+export async function embedQueryForModel(question: string, embeddingModel: string): Promise<number[] | null> {
   const parsed = parseEmbeddingModelId(embeddingModel);
   if (parsed.provider === "local") {
     return embedText(question);
@@ -84,7 +98,7 @@ async function embedQueryForModel(question, embeddingModel) {
   }
 }
 
-async function embedTextsWithProvider(provider, texts, modelOverride) {
+async function embedTextsWithProvider(provider: string, texts: string[], modelOverride?: string): Promise<EmbedTextsResult> {
   if (provider === "openai") {
     const apiKey = resolveApiKey(process.env.RAG_EMBED_API_KEY_REF_OPENAI || "env:OPENAI_API_KEY", "OPENAI_API_KEY");
     if (!apiKey) {
@@ -124,7 +138,7 @@ async function embedTextsWithProvider(provider, texts, modelOverride) {
   throw new Error(`Unsupported embedding provider: ${provider}`);
 }
 
-function providerOrder(preferred) {
+function providerOrder(preferred: string): string[] {
   if (preferred === "openai") {
     return ["openai", "local"];
   }
@@ -136,11 +150,3 @@ function providerOrder(preferred) {
   }
   return ["openai", "gemini", "local"];
 }
-
-module.exports = {
-  LOCAL_EMBEDDING_MODEL,
-  buildEmbeddingModelId,
-  parseEmbeddingModelId,
-  embedTextsForIndexing,
-  embedQueryForModel
-};

--- a/app/src/services/llmDebug.ts
+++ b/app/src/services/llmDebug.ts
@@ -1,16 +1,30 @@
-const { logEvent } = require("../lib/observability");
+import { logEvent } from "../lib/observability";
 
 const LLM_DEBUG_LOG_ENABLED = String(process.env.LLM_DEBUG_LOG || "false") === "true";
 const LLM_DEBUG_MAX_CHARS = clampPositiveInt(process.env.LLM_DEBUG_MAX_CHARS, 16000);
 
-function normalizeTokenUsage(raw) {
+export interface NormalizedTokenUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+export interface LlmDebugPayload {
+  prompt?: string;
+  system_prompt?: string;
+  sql?: string;
+  [key: string]: unknown;
+}
+
+export function normalizeTokenUsage(raw: unknown): NormalizedTokenUsage | null {
   if (!raw || typeof raw !== "object") {
     return null;
   }
+  const r = raw as Record<string, unknown>;
 
-  const promptTokens = toFiniteNumber(raw.prompt_tokens ?? raw.promptTokenCount);
-  const completionTokens = toFiniteNumber(raw.completion_tokens ?? raw.candidatesTokenCount ?? raw.output_tokens);
-  const totalTokens = toFiniteNumber(raw.total_tokens ?? raw.totalTokenCount);
+  const promptTokens = toFiniteNumber(r.prompt_tokens ?? r.promptTokenCount);
+  const completionTokens = toFiniteNumber(r.completion_tokens ?? r.candidatesTokenCount ?? r.output_tokens);
+  const totalTokens = toFiniteNumber(r.total_tokens ?? r.totalTokenCount);
 
   return {
     prompt_tokens: promptTokens || 0,
@@ -19,16 +33,16 @@ function normalizeTokenUsage(raw) {
   };
 }
 
-function normalizeStatusCode(value) {
+export function normalizeStatusCode(value: unknown): number | null {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
 }
 
-function logLlmDebug(payload) {
+export function logLlmDebug(payload: LlmDebugPayload): void {
   if (!LLM_DEBUG_LOG_ENABLED) {
     return;
   }
-  const safePayload = Object.assign({}, payload);
+  const safePayload: LlmDebugPayload = Object.assign({}, payload);
   if (typeof safePayload.prompt === "string") {
     safePayload.prompt = truncateText(safePayload.prompt);
   }
@@ -41,12 +55,12 @@ function logLlmDebug(payload) {
   logEvent("llm_debug", safePayload);
 }
 
-function toFiniteNumber(value) {
+function toFiniteNumber(value: unknown): number | null {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
 }
 
-function truncateText(value) {
+function truncateText(value: unknown): string {
   const text = String(value || "");
   if (text.length <= LLM_DEBUG_MAX_CHARS) {
     return text;
@@ -54,16 +68,10 @@ function truncateText(value) {
   return `${text.slice(0, LLM_DEBUG_MAX_CHARS)}... [truncated ${text.length - LLM_DEBUG_MAX_CHARS} chars]`;
 }
 
-function clampPositiveInt(raw, fallback) {
+function clampPositiveInt(raw: unknown, fallback: number): number {
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) {
     return fallback;
   }
   return Math.floor(n);
 }
-
-module.exports = {
-  logLlmDebug,
-  normalizeStatusCode,
-  normalizeTokenUsage
-};

--- a/app/src/services/llmPromptBuilder.ts
+++ b/app/src/services/llmPromptBuilder.ts
@@ -1,4 +1,56 @@
-function buildSqlPrompt(context) {
+import type { SqlDialect } from "./sqlGenerator";
+
+export interface PromptSchemaObject {
+  schema_name: string;
+  object_name: string;
+  object_type: string;
+}
+
+export interface PromptSchemaColumn {
+  schema_name: string;
+  object_name: string;
+  column_name: string;
+  data_type: string;
+}
+
+export interface PromptSemanticEntity {
+  business_name: string;
+  target_ref: string;
+  entity_type: string;
+}
+
+export interface PromptMetricDefinition {
+  business_name: string;
+  sql_expression: string;
+}
+
+export interface PromptJoinPolicy {
+  left_ref: string;
+  join_type: string;
+  right_ref: string;
+  on_clause: string;
+}
+
+export interface PromptRagDocument {
+  doc_type: string;
+  ref_id: string;
+  content: string;
+  score?: number;
+}
+
+export interface SqlPromptContext {
+  dialect?: SqlDialect | string;
+  question: string;
+  maxRows: number;
+  schemaObjects?: PromptSchemaObject[];
+  columns?: PromptSchemaColumn[];
+  semanticEntities?: PromptSemanticEntity[];
+  metricDefinitions?: PromptMetricDefinition[];
+  joinPolicies?: PromptJoinPolicy[];
+  ragDocuments?: PromptRagDocument[];
+}
+
+export function buildSqlPrompt(context: SqlPromptContext): string {
   const dialect = String(context.dialect || "postgres").toLowerCase();
   const dialectLabel = dialect === "mssql" ? "Microsoft SQL Server (T-SQL)" : "PostgreSQL";
 
@@ -68,7 +120,7 @@ function buildSqlPrompt(context) {
   ].join("\n");
 }
 
-function buildSqlSystemPrompt(dialect) {
+export function buildSqlSystemPrompt(dialect: SqlDialect | string | null | undefined): string {
   const normalized = String(dialect || "postgres").toLowerCase();
   if (normalized === "mssql") {
     return "Generate a single Microsoft SQL Server (T-SQL) SELECT query for reporting. Output only SQL, no explanation.";
@@ -76,15 +128,10 @@ function buildSqlSystemPrompt(dialect) {
   return "Generate a single PostgreSQL SELECT query for reporting. Output only SQL, no explanation.";
 }
 
-function indent(text, spaces) {
+function indent(text: unknown, spaces: number): string {
   const prefix = " ".repeat(spaces);
   return String(text || "")
     .split("\n")
     .map((line) => `${prefix}${line}`)
     .join("\n");
 }
-
-module.exports = {
-  buildSqlPrompt,
-  buildSqlSystemPrompt
-};

--- a/app/src/services/llmProviderRouting.ts
+++ b/app/src/services/llmProviderRouting.ts
@@ -1,16 +1,36 @@
-const appDb = require("../lib/appDb");
-const { OpenAiAdapter } = require("../adapters/llm/openAiAdapter");
-const { GeminiAdapter } = require("../adapters/llm/geminiAdapter");
-const { DeepSeekAdapter } = require("../adapters/llm/deepSeekAdapter");
-const { OpenRouterAdapter } = require("../adapters/llm/openRouterAdapter");
-const { CustomAdapter } = require("../adapters/llm/customAdapter");
-const { resolveApiKey } = require("../adapters/llm/httpClient");
+import appDb = require("../lib/appDb");
+import { OpenAiAdapter } from "../adapters/llm/openAiAdapter";
+import { GeminiAdapter } from "../adapters/llm/geminiAdapter";
+import { DeepSeekAdapter } from "../adapters/llm/deepSeekAdapter";
+import { OpenRouterAdapter } from "../adapters/llm/openRouterAdapter";
+import { CustomAdapter } from "../adapters/llm/customAdapter";
+import { resolveApiKey } from "../adapters/llm/httpClient";
+import type { LlmAdapter } from "../adapters/llm/types";
 
-const DEFAULT_PROVIDER_ORDER = ["openai", "gemini", "deepseek", "openrouter"];
+const DEFAULT_PROVIDER_ORDER = ["openai", "gemini", "deepseek", "openrouter"] as const;
 
-function buildProviderOrder(requestedProvider, routingRule, providerConfigs) {
+export interface ProviderConfigRow {
+  provider: string;
+  api_key_ref: string | null;
+  default_model: string | null;
+  base_url: string | null;
+  display_name: string | null;
+  enabled: boolean;
+}
+
+export interface RoutingRule {
+  primary_provider: string | null;
+  fallback_providers: string[] | null;
+  strategy: string | null;
+}
+
+export function buildProviderOrder(
+  requestedProvider: string | null | undefined,
+  routingRule: RoutingRule | null | undefined,
+  providerConfigs: Map<string, ProviderConfigRow>
+): string[] {
   if (requestedProvider) {
-    const order = [requestedProvider];
+    const order: string[] = [requestedProvider];
     const fallback = routingRule?.fallback_providers || [];
     for (const provider of fallback) {
       if (!order.includes(provider)) {
@@ -26,7 +46,7 @@ function buildProviderOrder(requestedProvider, routingRule, providerConfigs) {
   }
 
   if (routingRule?.primary_provider) {
-    const order = [routingRule.primary_provider];
+    const order: string[] = [routingRule.primary_provider];
     for (const provider of routingRule.fallback_providers || []) {
       if (!order.includes(provider)) {
         order.push(provider);
@@ -40,13 +60,17 @@ function buildProviderOrder(requestedProvider, routingRule, providerConfigs) {
     return filterEnabled(order, providerConfigs);
   }
 
-  return filterEnabled(DEFAULT_PROVIDER_ORDER.slice(), providerConfigs);
+  return filterEnabled([...DEFAULT_PROVIDER_ORDER], providerConfigs);
 }
 
-function buildAdapter(provider, providerConfig, requestedModel) {
+export function buildAdapter(
+  provider: string,
+  providerConfig: ProviderConfigRow | null | undefined,
+  requestedModel: string | null | undefined
+): LlmAdapter {
   const opts = {
-    apiKey: resolveProviderApiKey(provider, providerConfig?.api_key_ref),
-    defaultModel: requestedModel || providerConfig?.default_model
+    apiKey: resolveProviderApiKey(provider, providerConfig?.api_key_ref ?? null),
+    defaultModel: requestedModel || providerConfig?.default_model || undefined
   };
 
   if (provider === "openai") {
@@ -71,22 +95,22 @@ function buildAdapter(provider, providerConfig, requestedModel) {
   throw new Error(`Unsupported provider: ${provider}`);
 }
 
-async function loadProviderConfigs() {
-  const result = await appDb.query(
+export async function loadProviderConfigs(): Promise<Map<string, ProviderConfigRow>> {
+  const result = await appDb.query<ProviderConfigRow>(
     `
       SELECT provider, api_key_ref, default_model, base_url, display_name, enabled
       FROM llm_providers
     `
   );
-  const map = new Map();
+  const map = new Map<string, ProviderConfigRow>();
   for (const row of result.rows) {
     map.set(row.provider, row);
   }
   return map;
 }
 
-async function loadRoutingRule(dataSourceId) {
-  const result = await appDb.query(
+export async function loadRoutingRule(dataSourceId: string): Promise<RoutingRule | null> {
+  const result = await appDb.query<RoutingRule>(
     `
       SELECT primary_provider, fallback_providers, strategy
       FROM llm_routing_rules
@@ -97,7 +121,7 @@ async function loadRoutingRule(dataSourceId) {
   return result.rows[0] || null;
 }
 
-function filterEnabled(order, providerConfigs) {
+function filterEnabled(order: string[], providerConfigs: Map<string, ProviderConfigRow>): string[] {
   const enabled = order.filter((provider) => {
     const config = providerConfigs.get(provider);
     if (!config) {
@@ -105,10 +129,10 @@ function filterEnabled(order, providerConfigs) {
     }
     return config.enabled;
   });
-  return enabled.length > 0 ? enabled : DEFAULT_PROVIDER_ORDER.slice();
+  return enabled.length > 0 ? enabled : [...DEFAULT_PROVIDER_ORDER];
 }
 
-function resolveProviderApiKey(provider, ref) {
+function resolveProviderApiKey(provider: string, ref: string | null | undefined): string | undefined {
   if (provider === "openai") {
     return resolveApiKey(ref, "OPENAI_API_KEY");
   }
@@ -123,10 +147,3 @@ function resolveProviderApiKey(provider, ref) {
   }
   return resolveApiKey(ref, null);
 }
-
-module.exports = {
-  buildAdapter,
-  buildProviderOrder,
-  loadProviderConfigs,
-  loadRoutingRule
-};

--- a/app/src/services/llmSqlService.ts
+++ b/app/src/services/llmSqlService.ts
@@ -1,14 +1,49 @@
-const { generateSqlFromQuestion } = require("./sqlGenerator");
-const {
+import { generateSqlFromQuestion, type SchemaObjectLite, type SqlDialect } from "./sqlGenerator";
+import {
   buildAdapter,
   buildProviderOrder,
   loadProviderConfigs,
   loadRoutingRule
-} = require("./llmProviderRouting");
-const { buildSqlPrompt, buildSqlSystemPrompt } = require("./llmPromptBuilder");
-const { logLlmDebug, normalizeStatusCode, normalizeTokenUsage } = require("./llmDebug");
+} from "./llmProviderRouting";
+import { buildSqlPrompt, buildSqlSystemPrompt } from "./llmPromptBuilder";
+import { logLlmDebug, normalizeStatusCode, normalizeTokenUsage, type NormalizedTokenUsage } from "./llmDebug";
 
-async function generateSqlWithRouting(input) {
+export interface GenerateSqlWithRoutingInput {
+  dataSourceId: string;
+  question: string;
+  maxRows: number;
+  dialect: SqlDialect | string;
+  requestedProvider?: string | null;
+  requestedModel?: string | null;
+  schemaObjects: SchemaObjectLite[];
+  columns?: unknown[];
+  semanticEntities?: unknown[];
+  metricDefinitions?: unknown[];
+  joinPolicies?: unknown[];
+  ragDocuments?: unknown[];
+  requestId?: string | null;
+}
+
+export interface ProviderAttempt {
+  provider: string;
+  model: string | null;
+  status: "success" | "failed";
+  status_code: number | null;
+  latency_ms: number;
+  usage?: NormalizedTokenUsage | null;
+  error?: string;
+}
+
+export interface GenerateSqlWithRoutingResult {
+  sql: string;
+  provider: string;
+  model: string | null;
+  attempts: ProviderAttempt[];
+  tokenUsage: NormalizedTokenUsage | null;
+  promptVersion: string;
+}
+
+export async function generateSqlWithRouting(input: GenerateSqlWithRoutingInput): Promise<GenerateSqlWithRoutingResult> {
   const {
     dataSourceId,
     question,
@@ -32,12 +67,12 @@ async function generateSqlWithRouting(input) {
     dialect,
     question,
     maxRows,
-    schemaObjects,
-    columns,
-    semanticEntities,
-    metricDefinitions,
-    joinPolicies,
-    ragDocuments
+    schemaObjects: schemaObjects as never,
+    columns: columns as never,
+    semanticEntities: semanticEntities as never,
+    metricDefinitions: metricDefinitions as never,
+    joinPolicies: joinPolicies as never,
+    ragDocuments: ragDocuments as never
   });
   logLlmDebug({
     stage: "request_compiled",
@@ -51,7 +86,7 @@ async function generateSqlWithRouting(input) {
     system_prompt: systemPrompt
   });
 
-  const attempts = [];
+  const attempts: ProviderAttempt[] = [];
   for (const provider of providerOrder) {
     const providerConfig = providerConfigs.get(provider) || null;
 
@@ -114,7 +149,8 @@ async function generateSqlWithRouting(input) {
       };
     } catch (err) {
       const latencyMs = Date.now() - startedAt;
-      const statusCode = normalizeStatusCode(err?.statusCode);
+      const e = err as { statusCode?: number | string; message?: string };
+      const statusCode = normalizeStatusCode(e?.statusCode);
       logLlmDebug({
         stage: "provider_error",
         request_id: input.requestId || null,
@@ -122,7 +158,7 @@ async function generateSqlWithRouting(input) {
         model,
         status_code: statusCode,
         latency_ms: latencyMs,
-        error: err.message || String(err)
+        error: e.message || String(err)
       });
       attempts.push({
         provider,
@@ -130,7 +166,7 @@ async function generateSqlWithRouting(input) {
         status: "failed",
         status_code: statusCode,
         latency_ms: latencyMs,
-        error: err.message
+        error: e.message
       });
     }
   }
@@ -141,7 +177,7 @@ async function generateSqlWithRouting(input) {
     throw new Error(`All LLM providers failed. Reasons: ${reasons}`);
   }
 
-  const fallbackSql = generateSqlFromQuestion(question, schemaObjects, maxRows, dialect);
+  const fallbackSql = generateSqlFromQuestion(question, schemaObjects, maxRows, (dialect as SqlDialect) || "postgres");
   attempts.push({
     provider: "local-fallback",
     model: "rule-based-v0",
@@ -167,6 +203,3 @@ async function generateSqlWithRouting(input) {
     promptVersion: "v2-llm-router"
   };
 }
-module.exports = {
-  generateSqlWithRouting
-};

--- a/app/src/services/localEmbedding.ts
+++ b/app/src/services/localEmbedding.ts
@@ -1,9 +1,9 @@
 const DEFAULT_DIM = Number(process.env.RAG_EMBED_DIM || 64);
-const EMBEDDING_MODEL = "local-hash-v1";
+export const EMBEDDING_MODEL = "local-hash-v1";
 
-function embedText(text, dim = DEFAULT_DIM) {
+export function embedText(text: unknown, dim: number = DEFAULT_DIM): number[] {
   const tokens = tokenize(text);
-  const vector = new Array(dim).fill(0);
+  const vector: number[] = new Array(dim).fill(0);
 
   if (tokens.length === 0) {
     return vector;
@@ -17,7 +17,7 @@ function embedText(text, dim = DEFAULT_DIM) {
   return normalize(vector);
 }
 
-function cosineSimilarity(a, b) {
+export function cosineSimilarity(a: number[] | unknown, b: number[] | unknown): number {
   if (!Array.isArray(a) || !Array.isArray(b) || a.length === 0 || b.length === 0) {
     return 0;
   }
@@ -38,7 +38,7 @@ function cosineSimilarity(a, b) {
   return dot / (Math.sqrt(normA) * Math.sqrt(normB));
 }
 
-function tokenize(text) {
+function tokenize(text: unknown): string[] {
   return String(text || "")
     .toLowerCase()
     .replace(/[^a-z0-9_]+/g, " ")
@@ -47,7 +47,7 @@ function tokenize(text) {
     .filter((t) => t.length >= 2);
 }
 
-function normalize(vector) {
+function normalize(vector: number[]): number[] {
   const norm = Math.sqrt(vector.reduce((sum, v) => sum + v * v, 0));
   if (!norm) {
     return vector;
@@ -55,7 +55,7 @@ function normalize(vector) {
   return vector.map((v) => v / norm);
 }
 
-function hash(str) {
+function hash(str: string): number {
   let h = 5381;
   for (let i = 0; i < str.length; i += 1) {
     h = ((h << 5) + h) + str.charCodeAt(i);
@@ -63,9 +63,3 @@ function hash(str) {
   }
   return h;
 }
-
-module.exports = {
-  EMBEDDING_MODEL,
-  embedText,
-  cosineSimilarity
-};

--- a/app/src/services/providerConfigService.ts
+++ b/app/src/services/providerConfigService.ts
@@ -1,11 +1,35 @@
-function createBadRequestError(message) {
-  const err = new Error(message);
+export interface ProviderUpsertInput {
+  provider: string;
+  apiKeyRef: string;
+  defaultModel: string;
+  baseUrl: string | null;
+  displayName: string | null;
+  enabled: boolean;
+}
+
+export interface ExistingProvider {
+  api_key_ref?: string | null;
+  base_url?: string | null;
+  display_name?: string | null;
+  [key: string]: unknown;
+}
+
+interface BadRequestError extends Error {
+  statusCode: number;
+}
+
+function createBadRequestError(message: string): BadRequestError {
+  const err = new Error(message) as BadRequestError;
   err.statusCode = 400;
   return err;
 }
 
-function normalizeProviderUpsertInput(body, existingProvider, knownProviders) {
-  const requestBody = body && typeof body === "object" ? body : {};
+export function normalizeProviderUpsertInput(
+  body: unknown,
+  existingProvider: ExistingProvider | null | undefined,
+  knownProviders: ReadonlySet<string>
+): ProviderUpsertInput {
+  const requestBody = (body && typeof body === "object" ? body : {}) as Record<string, unknown>;
   const provider = typeof requestBody.provider === "string" ? requestBody.provider.trim() : "";
   const defaultModel = typeof requestBody.default_model === "string" ? requestBody.default_model.trim() : "";
   const requestedBaseUrl =
@@ -42,7 +66,7 @@ function normalizeProviderUpsertInput(body, existingProvider, knownProviders) {
   if (requestedBaseUrl && isKnown) {
     throw createBadRequestError("base_url is only allowed for custom providers");
   }
-  if (isCustom && !/^https?:\/\/.+/.test(baseUrl)) {
+  if (isCustom && !/^https?:\/\/.+/.test(baseUrl as string)) {
     throw createBadRequestError("Invalid base_url");
   }
 
@@ -55,7 +79,3 @@ function normalizeProviderUpsertInput(body, existingProvider, knownProviders) {
     enabled
   };
 }
-
-module.exports = {
-  normalizeProviderUpsertInput
-};

--- a/app/src/services/queryBudget.ts
+++ b/app/src/services/queryBudget.ts
@@ -1,14 +1,35 @@
-function extractRootPlan(explainRows) {
+export interface ExplainPlanNode {
+  "Total Cost"?: number;
+  "Plan Rows"?: number;
+  Plans?: ExplainPlanNode[];
+  [key: string]: unknown;
+}
+
+export interface ExplainBudgetMetrics {
+  maxTotalCost: number;
+  maxPlanRows: number;
+}
+
+export type EvaluateExplainBudgetResult =
+  | { ok: true; errors: []; metrics: ExplainBudgetMetrics }
+  | { ok: false; errors: string[]; metrics: ExplainBudgetMetrics | null };
+
+export interface ExplainBudgetOptions {
+  maxTotalCost?: number;
+  maxPlanRows?: number;
+}
+
+function extractRootPlan(explainRows: unknown): ExplainPlanNode | null {
   if (!Array.isArray(explainRows) || explainRows.length === 0) {
     return null;
   }
 
-  const first = explainRows[0];
+  const first = explainRows[0] as Record<string, unknown> | undefined;
   if (!first) {
     return null;
   }
 
-  const queryPlan = first["QUERY PLAN"] || first.query_plan;
+  const queryPlan = (first["QUERY PLAN"] || first.query_plan) as Array<{ Plan?: ExplainPlanNode }> | undefined;
   if (!Array.isArray(queryPlan) || queryPlan.length === 0) {
     return null;
   }
@@ -16,7 +37,7 @@ function extractRootPlan(explainRows) {
   return queryPlan[0]?.Plan || null;
 }
 
-function walkPlans(plan, fn) {
+function walkPlans(plan: ExplainPlanNode | null | undefined, fn: (node: ExplainPlanNode) => void): void {
   if (!plan) {
     return;
   }
@@ -27,8 +48,8 @@ function walkPlans(plan, fn) {
   }
 }
 
-function collectPlanMetrics(rootPlan) {
-  const metrics = {
+function collectPlanMetrics(rootPlan: ExplainPlanNode): ExplainBudgetMetrics {
+  const metrics: ExplainBudgetMetrics = {
     maxTotalCost: 0,
     maxPlanRows: 0
   };
@@ -48,7 +69,7 @@ function collectPlanMetrics(rootPlan) {
   return metrics;
 }
 
-function evaluateExplainBudget(explainRows, opts = {}) {
+export function evaluateExplainBudget(explainRows: unknown, opts: ExplainBudgetOptions = {}): EvaluateExplainBudgetResult {
   const rootPlan = extractRootPlan(explainRows);
   if (!rootPlan) {
     return {
@@ -62,7 +83,7 @@ function evaluateExplainBudget(explainRows, opts = {}) {
   const maxTotalCost = Number(opts.maxTotalCost || 500000);
   const maxPlanRows = Number(opts.maxPlanRows || 1000000);
 
-  const errors = [];
+  const errors: string[] = [];
   if (metrics.maxTotalCost > maxTotalCost) {
     errors.push(`Estimated total cost ${metrics.maxTotalCost} exceeds budget ${maxTotalCost}`);
   }
@@ -72,11 +93,7 @@ function evaluateExplainBudget(explainRows, opts = {}) {
 
   return {
     ok: errors.length === 0,
-    errors,
+    errors: errors as never,
     metrics
   };
 }
-
-module.exports = {
-  evaluateExplainBudget
-};

--- a/app/src/services/sqlAstValidator.ts
+++ b/app/src/services/sqlAstValidator.ts
@@ -1,8 +1,27 @@
-const { Parser } = require("node-sql-parser");
+import { Parser } from "node-sql-parser";
+import type { SqlDialect } from "./sqlGenerator";
+
+export interface SchemaObjectAllowlistEntry {
+  schema_name: string;
+  object_name: string;
+  [key: string]: unknown;
+}
+
+export interface ParsedRef {
+  schema: string;
+  object: string;
+  raw: string;
+}
+
+export interface ValidateAstReadOnlyResult {
+  ok: boolean;
+  errors: string[];
+  refs: ParsedRef[];
+}
 
 const parser = new Parser();
 
-function normalizeIdentifier(identifier) {
+function normalizeIdentifier(identifier: unknown): string {
   return String(identifier || "")
     .replace(/^"+|"+$/g, "")
     .replace(/^\[+|\]+$/g, "")
@@ -10,20 +29,24 @@ function normalizeIdentifier(identifier) {
     .toLowerCase();
 }
 
-function parserDialectsFor(dialect) {
+function parserDialectsFor(dialect: SqlDialect | string): string[] {
   if (dialect === "mssql") {
     return ["TransactSQL", "MSSQL", "TSQL"];
   }
   return ["Postgresql"];
 }
 
-function parseAst(sql, dialect = "postgres") {
-  let lastError = null;
+interface ParseAstFailure {
+  error: string;
+}
+
+function parseAst(sql: string, dialect: SqlDialect | string = "postgres"): unknown | ParseAstFailure {
+  let lastError: Error | null = null;
   for (const parserDialect of parserDialectsFor(dialect)) {
     try {
       return parser.astify(sql, { database: parserDialect });
     } catch (err) {
-      lastError = err;
+      lastError = err as Error;
     }
   }
   return {
@@ -31,13 +54,13 @@ function parseAst(sql, dialect = "postgres") {
   };
 }
 
-function validateSingleSelect(ast) {
+function validateSingleSelect(ast: unknown): { ok: boolean; errors: string[] } {
   const statements = Array.isArray(ast) ? ast : [ast];
   if (statements.length !== 1) {
     return { ok: false, errors: ["Only one SQL statement is allowed"] };
   }
 
-  const statement = statements[0];
+  const statement = statements[0] as { type?: string } | null;
   if (!statement || statement.type !== "select") {
     return { ok: false, errors: ["Only SELECT queries are allowed"] };
   }
@@ -45,8 +68,8 @@ function validateSingleSelect(ast) {
   return { ok: true, errors: [] };
 }
 
-function extractRefsFromTableList(sql, dialect = "postgres") {
-  let rawRefs = [];
+function extractRefsFromTableList(sql: string, dialect: SqlDialect | string = "postgres"): ParsedRef[] {
+  let rawRefs: string[] = [];
   for (const parserDialect of parserDialectsFor(dialect)) {
     try {
       rawRefs = parser.tableList(sql, { database: parserDialect });
@@ -72,10 +95,14 @@ function extractRefsFromTableList(sql, dialect = "postgres") {
       const object = normalizeIdentifier(objectPart);
       return { schema, object, raw: `${schema}.${object}` };
     })
-    .filter(Boolean);
+    .filter((entry): entry is ParsedRef => entry !== null);
 }
 
-function validateAllowlistedObjects(sql, schemaObjects, dialect = "postgres") {
+function validateAllowlistedObjects(
+  sql: string,
+  schemaObjects: SchemaObjectAllowlistEntry[] | unknown,
+  dialect: SqlDialect | string = "postgres"
+): ValidateAstReadOnlyResult {
   const refs = extractRefsFromTableList(sql, dialect);
 
   if (!Array.isArray(schemaObjects) || schemaObjects.length === 0) {
@@ -83,7 +110,7 @@ function validateAllowlistedObjects(sql, schemaObjects, dialect = "postgres") {
   }
 
   const allowSet = new Set(
-    (schemaObjects || []).map((obj) => `${obj.schema_name.toLowerCase()}.${obj.object_name.toLowerCase()}`)
+    schemaObjects.map((obj) => `${obj.schema_name.toLowerCase()}.${obj.object_name.toLowerCase()}`)
   );
 
   const unknown = refs.filter((ref) => !allowSet.has(`${ref.schema}.${ref.object}`));
@@ -103,10 +130,10 @@ function validateAllowlistedObjects(sql, schemaObjects, dialect = "postgres") {
   };
 }
 
-function extractRefsWithRegex(sql) {
-  const refs = [];
+function extractRefsWithRegex(sql: string): ParsedRef[] {
+  const refs: ParsedRef[] = [];
   const pattern = /\b(?:from|join)\s+([a-z0-9_\[\]."]+)/gi;
-  let match;
+  let match: RegExpExecArray | null;
 
   while ((match = pattern.exec(sql)) !== null) {
     const normalized = normalizeObjectRef(match[1]);
@@ -119,7 +146,7 @@ function extractRefsWithRegex(sql) {
   return refs;
 }
 
-function normalizeObjectRef(rawRef) {
+function normalizeObjectRef(rawRef: unknown): ParsedRef | null {
   const cleaned = String(rawRef || "")
     .replace(/[;,]+$/g, "")
     .trim();
@@ -144,7 +171,10 @@ function normalizeObjectRef(rawRef) {
   return { schema, object, raw: `${schema}.${object}` };
 }
 
-function validateMssqlReadOnlyFallback(sql, schemaObjects) {
+function validateMssqlReadOnlyFallback(
+  sql: unknown,
+  schemaObjects: SchemaObjectAllowlistEntry[] | unknown
+): ValidateAstReadOnlyResult {
   const text = String(sql || "").trim();
   if (!/^\s*(select|with)\b/i.test(text)) {
     return { ok: false, errors: ["Only SELECT queries are allowed"], refs: [] };
@@ -175,13 +205,17 @@ function validateMssqlReadOnlyFallback(sql, schemaObjects) {
   return { ok: true, errors: [], refs };
 }
 
-function validateAstReadOnly(sql, schemaObjects, dialect = "postgres") {
+export function validateAstReadOnly(
+  sql: string,
+  schemaObjects: SchemaObjectAllowlistEntry[] | unknown,
+  dialect: SqlDialect | string = "postgres"
+): ValidateAstReadOnlyResult {
   const parsed = parseAst(sql, dialect);
-  if (parsed.error) {
+  if ((parsed as ParseAstFailure).error) {
     if (dialect === "mssql") {
       return validateMssqlReadOnlyFallback(sql, schemaObjects);
     }
-    return { ok: false, errors: [parsed.error], refs: [] };
+    return { ok: false, errors: [(parsed as ParseAstFailure).error], refs: [] };
   }
 
   const statementCheck = validateSingleSelect(parsed);
@@ -191,7 +225,3 @@ function validateAstReadOnly(sql, schemaObjects, dialect = "postgres") {
 
   return validateAllowlistedObjects(sql, schemaObjects, dialect);
 }
-
-module.exports = {
-  validateAstReadOnly
-};

--- a/app/src/services/sqlGenerator.ts
+++ b/app/src/services/sqlGenerator.ts
@@ -1,4 +1,17 @@
-function generateSqlFromQuestion(question, schemaObjects, maxRows, dialect = "postgres") {
+export type SqlDialect = "postgres" | "mssql";
+
+export interface SchemaObjectLite {
+  schema_name: string;
+  object_name: string;
+  [key: string]: unknown;
+}
+
+export function generateSqlFromQuestion(
+  question: unknown,
+  schemaObjects: SchemaObjectLite[],
+  maxRows: unknown,
+  dialect: SqlDialect = "postgres"
+): string {
   const normalizedQuestion = String(question || "").toLowerCase();
   const limit = Number.isFinite(Number(maxRows)) ? Number(maxRows) : 1000;
 
@@ -19,7 +32,7 @@ function generateSqlFromQuestion(question, schemaObjects, maxRows, dialect = "po
   return `SELECT * FROM ${qualifiedTable} LIMIT ${limit};`;
 }
 
-function isCountQuestion(question) {
+function isCountQuestion(question: string): boolean {
   return (
     question.includes("count") ||
     question.includes("how many") ||
@@ -27,7 +40,7 @@ function isCountQuestion(question) {
   );
 }
 
-function pickObjectFromQuestion(question, schemaObjects) {
+function pickObjectFromQuestion(question: string, schemaObjects: SchemaObjectLite[]): SchemaObjectLite | undefined {
   return schemaObjects.find((obj) => {
     const fullName = `${obj.schema_name}.${obj.object_name}`.toLowerCase();
     const simpleName = String(obj.object_name).toLowerCase();
@@ -35,13 +48,9 @@ function pickObjectFromQuestion(question, schemaObjects) {
   });
 }
 
-function quoteIdentifier(identifier, dialect = "postgres") {
+function quoteIdentifier(identifier: string, dialect: SqlDialect = "postgres"): string {
   if (dialect === "mssql") {
     return `[${String(identifier).replace(/]/g, "]]")}]`;
   }
   return `"${String(identifier).replace(/"/g, "\"\"")}"`;
 }
-
-module.exports = {
-  generateSqlFromQuestion
-};

--- a/app/src/services/sqlSafety.ts
+++ b/app/src/services/sqlSafety.ts
@@ -1,6 +1,20 @@
-const { validateAstReadOnly } = require("./sqlAstValidator");
+import { validateAstReadOnly } from "./sqlAstValidator";
+import type { SqlDialect } from "./sqlGenerator";
 
-function sanitizeGeneratedSql(raw) {
+export interface SqlSafetyOptions {
+  maxRows?: number;
+  schemaObjects?: unknown[];
+  dialect?: SqlDialect | string;
+}
+
+export interface ValidateAndNormalizeResult {
+  ok: boolean;
+  sql: string;
+  errors: string[];
+  refs: unknown[];
+}
+
+export function sanitizeGeneratedSql(raw: unknown): string {
   let text = String(raw || "").trim();
   if (!text) {
     return "";
@@ -13,33 +27,33 @@ function sanitizeGeneratedSql(raw) {
 
   // If model returns explanation + SQL, keep from first SELECT/WITH onward.
   const startMatch = text.match(/\b(select|with)\b/i);
-  if (startMatch && startMatch.index > 0) {
+  if (startMatch && startMatch.index! > 0) {
     text = text.slice(startMatch.index).trim();
   }
 
   return text;
 }
 
-function stripTrailingSemicolon(sql) {
+function stripTrailingSemicolon(sql: string): string {
   return sql.replace(/;\s*$/, "").trim();
 }
 
-function hasMultipleStatements(sql) {
+function hasMultipleStatements(sql: string): boolean {
   const trimmed = sql.trim();
   const withoutTrailing = trimmed.replace(/;\s*$/, "");
   return withoutTrailing.includes(";");
 }
 
-function hasLimitClause(sql) {
+function hasLimitClause(sql: string): boolean {
   return /\blimit\s+\d+\b/i.test(sql);
 }
 
-function hasTopClause(sql) {
+function hasTopClause(sql: string): boolean {
   return /^\s*select\s+(?:distinct\s+)?top\s+\(?\d+\)?\b/i.test(sql);
 }
 
-function splitTopLevelCsv(selectPart) {
-  const items = [];
+function splitTopLevelCsv(selectPart: string): string[] {
+  const items: string[] = [];
   let current = "";
   let depth = 0;
   for (let i = 0; i < selectPart.length; i += 1) {
@@ -69,7 +83,7 @@ function splitTopLevelCsv(selectPart) {
   return items;
 }
 
-function isSingleRowAggregateQuery(sql) {
+function isSingleRowAggregateQuery(sql: unknown): boolean {
   const text = String(sql || "").trim();
   if (!text) {
     return false;
@@ -113,13 +127,13 @@ function isSingleRowAggregateQuery(sql) {
   return expressions.every((expr) => AGGREGATE_FN.test(expr));
 }
 
-function stripTrailingLimit(sql) {
+function stripTrailingLimit(sql: string): string {
   const noSemi = stripTrailingSemicolon(sql);
   const withoutLimit = noSemi.replace(/\s+limit\s+\d+\s*$/i, "").trim();
   return `${withoutLimit};`;
 }
 
-function ensureLimit(sql, maxRows, dialect = "postgres") {
+export function ensureLimit(sql: string, maxRows: number, dialect: SqlDialect | string = "postgres"): string {
   if (isSingleRowAggregateQuery(sql)) {
     // Aggregate singleton queries (COUNT/SUM/etc.) should not carry LIMIT.
     if (dialect === "postgres") {
@@ -151,7 +165,7 @@ function ensureLimit(sql, maxRows, dialect = "postgres") {
   return `${stripTrailingSemicolon(sql)} LIMIT ${Number(maxRows)};`;
 }
 
-function validateAndNormalizeSql(rawSql, opts = {}) {
+export function validateAndNormalizeSql(rawSql: unknown, opts: SqlSafetyOptions = {}): ValidateAndNormalizeResult {
   const maxRows = Number(opts.maxRows || 1000);
   const schemaObjects = Array.isArray(opts.schemaObjects) ? opts.schemaObjects : [];
   const dialect = String(opts.dialect || "postgres").toLowerCase();
@@ -179,9 +193,3 @@ function validateAndNormalizeSql(rawSql, opts = {}) {
 
   return { ok: true, sql, errors: [], refs: refsCheck.refs };
 }
-
-module.exports = {
-  validateAndNormalizeSql,
-  sanitizeGeneratedSql,
-  ensureLimit
-};


### PR DESCRIPTION
## Summary

Migrates the 11 services in the SQL pipeline + LLM routing cluster from `.js` to `.ts`. The `LlmAdapter` interface from TS-007 is now consumed end-to-end by the routing layer. No runtime behavior changes; tests stay green at 219/219.

## Files migrated

All in `app/src/services/`:

| File | Notes |
|---|---|
| `sqlAstValidator.ts` | node-sql-parser AST validation, table allowlisting, MSSQL regex fallback |
| `sqlSafety.ts` | sanitize generated SQL, multi-statement guard, LIMIT/TOP enforcement, single-row-aggregate detection |
| `sqlGenerator.ts` | rule-based fallback generator with typed `SqlDialect` |
| `llmSqlService.ts` | `generateSqlWithRouting` orchestrator with typed `ProviderAttempt` and `GenerateSqlWithRoutingResult` |
| `llmPromptBuilder.ts` | typed `SqlPromptContext` + per-block prompt assembly |
| `llmProviderRouting.ts` | typed `ProviderConfigRow` / `RoutingRule`; `buildAdapter` returns `LlmAdapter`; `loadProviderConfigs` typed |
| `llmDebug.ts` | typed `NormalizedTokenUsage`, `LlmDebugPayload` |
| `providerConfigService.ts` | typed `ProviderUpsertInput` validation |
| `queryBudget.ts` | typed `ExplainPlanNode`, `ExplainBudgetMetrics`, discriminated `EvaluateExplainBudgetResult` |
| `embeddingRouter.ts` | typed `EmbedTextsResult`, provider fallback chain |
| `localEmbedding.ts` | typed local hash embedder |

## Drive-by fix: dual-export pattern for LLM adapters

When TS-009's typed routing layer tried to `import { OpenAiAdapter } from "../adapters/llm/openAiAdapter"`, TypeScript reported "declares 'OpenAiAdapter' locally, but it is not exported". 

The TS-007 adapter migration (`openAiAdapter.ts`, `geminiAdapter.ts`, `deepSeekAdapter.ts`, `openRouterAdapter.ts`, `customAdapter.ts`, `httpClient.ts`) declared classes/functions **without** an `export` keyword and relied solely on a trailing `module.exports = { ... }` for the public surface. That works at runtime for `.js` consumers via plain `require`, but `.ts` consumers couldn't import the named symbols because TS doesn't model `module.exports = ...` as a module's export shape.

Fix: added `export` to each class declaration plus `httpClient.extractJsonObject` / `httpClient.resolveApiKey`. The trailing `module.exports = { ... }` still wins at runtime, so existing `.js` callers (`services/*.js` and route handlers) keep working unchanged. This is the same dual-export pattern that TS-006 already established for the DB adapters.

## Verification

- `npm run typecheck` exits 0
- `npm test` 219/219 pass — including `sqlSafety.test.js`, `llmHelpers.test.js`, `providerConfigService.test.js`, `customAdapter.test.js`, plus the API integration tests that exercise the SQL pipeline
- `app/src/services/` contains no leftover `.js` for the migrated files

## Out of scope

- Routes that consume these services (TS-014)
- Tests under `app/test/` (TS-016)

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)