### PR TITLE
TS-011 Migrate introspection, RAG, and column policy services

### DIFF
--- a/app/src/services/columnPolicyService.ts
+++ b/app/src/services/columnPolicyService.ts
@@ -1,3 +1,26 @@
+export interface ForbiddenColumn {
+  schema: string;
+  object: string;
+  column: string;
+  note_id?: string | null;
+}
+
+export interface KnownColumn {
+  schema_name: string;
+  object_name: string;
+  column_name: string;
+}
+
+export interface ParsedRefInput {
+  schema: string;
+  object: string;
+}
+
+export interface ColumnPolicyValidationResult {
+  ok: boolean;
+  errors: string[];
+}
+
 const NEGATIVE_KEYWORDS = [
   "do not use",
   "don't use",
@@ -14,9 +37,22 @@ const NEGATIVE_KEYWORDS = [
   "ban"
 ];
 
-function extractForbiddenColumnsFromRagNotes(notes, knownColumns) {
+interface ColumnRef {
+  kind: "two_part" | "three_part";
+  parts: string[];
+}
+
+interface KnownColumnMaps {
+  byFull: Map<string, ForbiddenColumn>;
+  byObjectColumn: Map<string, ForbiddenColumn[]>;
+}
+
+export function extractForbiddenColumnsFromRagNotes(
+  notes: Array<{ id?: string | null; title?: string | null; content?: string | null }> | unknown,
+  knownColumns: KnownColumn[] | unknown
+): ForbiddenColumn[] {
   const normalizedColumns = buildKnownColumnMaps(knownColumns);
-  const dedupe = new Map();
+  const dedupe = new Map<string, ForbiddenColumn>();
 
   for (const note of Array.isArray(notes) ? notes : []) {
     const text = [note?.title, note?.content].filter(Boolean).join("\n");
@@ -43,18 +79,23 @@ function extractForbiddenColumnsFromRagNotes(notes, knownColumns) {
   return [...dedupe.values()];
 }
 
-function validateSqlAgainstForbiddenColumns(sql, forbiddenColumns, refs, dialect = "postgres") {
+export function validateSqlAgainstForbiddenColumns(
+  sql: string,
+  forbiddenColumns: ForbiddenColumn[] | unknown,
+  refs: ParsedRefInput[] | unknown,
+  _dialect: string = "postgres"
+): ColumnPolicyValidationResult {
   if (!Array.isArray(forbiddenColumns) || forbiddenColumns.length === 0) {
     return { ok: true, errors: [] };
   }
 
   const sqlText = String(sql || "");
   const referencedObjects = new Set(
-    (Array.isArray(refs) ? refs : []).map((ref) => `${normalizeIdentifier(ref.schema)}.${normalizeIdentifier(ref.object)}`)
+    (Array.isArray(refs) ? refs as ParsedRefInput[] : []).map((ref) => `${normalizeIdentifier(ref.schema)}.${normalizeIdentifier(ref.object)}`)
   );
   const aliasesByObject = extractObjectAliases(sqlText);
 
-  const errors = [];
+  const errors: string[] = [];
   for (const blocked of forbiddenColumns) {
     const schema = normalizeIdentifier(blocked.schema);
     const object = normalizeIdentifier(blocked.object);
@@ -65,7 +106,7 @@ function validateSqlAgainstForbiddenColumns(sql, forbiddenColumns, refs, dialect
       continue;
     }
 
-    const aliasSet = aliasesByObject.get(objectKey) || new Set();
+    const aliasSet = aliasesByObject.get(objectKey) || new Set<string>();
     const hasQualified = sqlMentionsQualifiedColumn(sqlText, schema, object, column, aliasSet);
 
     // Only apply bare-column checks for single-object queries to reduce false positives.
@@ -85,13 +126,13 @@ function validateSqlAgainstForbiddenColumns(sql, forbiddenColumns, refs, dialect
   };
 }
 
-function containsNegativeKeyword(text) {
+function containsNegativeKeyword(text: string): boolean {
   const normalized = String(text || "").toLowerCase();
   return NEGATIVE_KEYWORDS.some((keyword) => normalized.includes(keyword));
 }
 
-function extractColumnRefs(text) {
-  const refs = [];
+function extractColumnRefs(text: string): ColumnRef[] {
+  const refs: ColumnRef[] = [];
   const content = String(text || "");
 
   // schema.object.column (supports bare, quoted, and bracketed identifiers)
@@ -99,7 +140,7 @@ function extractColumnRefs(text) {
   // object.column fallback
   const twoPart = /((?:\[[^\]]+\]|"[^"]+"|[a-z_][\w$]*)\s*\.\s*(?:\[[^\]]+\]|"[^"]+"|[a-z_][\w$]*))/gi;
 
-  let match;
+  let match: RegExpExecArray | null;
   while ((match = threePart.exec(content)) !== null) {
     const parsed = splitIdentifierPath(match[1]);
     if (parsed.length === 3) {
@@ -118,7 +159,7 @@ function extractColumnRefs(text) {
   return refs;
 }
 
-function resolveColumnRef(ref, knownColumns) {
+function resolveColumnRef(ref: ColumnRef, knownColumns: KnownColumnMaps): ForbiddenColumn | null {
   if (!ref || !Array.isArray(ref.parts)) {
     return null;
   }
@@ -139,9 +180,9 @@ function resolveColumnRef(ref, knownColumns) {
   return null;
 }
 
-function buildKnownColumnMaps(knownColumns) {
-  const byFull = new Map();
-  const byObjectColumn = new Map();
+function buildKnownColumnMaps(knownColumns: KnownColumn[] | unknown): KnownColumnMaps {
+  const byFull = new Map<string, ForbiddenColumn>();
+  const byObjectColumn = new Map<string, ForbiddenColumn[]>();
 
   for (const col of Array.isArray(knownColumns) ? knownColumns : []) {
     const schema = normalizeIdentifier(col.schema_name);
@@ -151,7 +192,7 @@ function buildKnownColumnMaps(knownColumns) {
       continue;
     }
 
-    const normalized = {
+    const normalized: ForbiddenColumn = {
       schema: col.schema_name,
       object: col.object_name,
       column: col.column_name
@@ -164,20 +205,20 @@ function buildKnownColumnMaps(knownColumns) {
     if (!byObjectColumn.has(objectColumnKey)) {
       byObjectColumn.set(objectColumnKey, []);
     }
-    byObjectColumn.get(objectColumnKey).push(normalized);
+    byObjectColumn.get(objectColumnKey)!.push(normalized);
   }
 
   return { byFull, byObjectColumn };
 }
 
-function splitIdentifierPath(value) {
+function splitIdentifierPath(value: unknown): string[] {
   return String(value || "")
     .split(".")
     .map((part) => normalizeIdentifier(part))
     .filter(Boolean);
 }
 
-function normalizeIdentifier(identifier) {
+function normalizeIdentifier(identifier: unknown): string {
   return String(identifier || "")
     .trim()
     .replace(/^\[|\]$/g, "")
@@ -185,16 +226,16 @@ function normalizeIdentifier(identifier) {
     .toLowerCase();
 }
 
-function escapeRegExp(value) {
+function escapeRegExp(value: unknown): string {
   return String(value || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function identifierPattern(identifier) {
+function identifierPattern(identifier: string): string {
   const escaped = escapeRegExp(identifier);
   return `(?:\\[${escaped}\\]|"${escaped}"|${escaped})`;
 }
 
-function sqlMentionsQualifiedColumn(sql, schema, object, column, aliases) {
+function sqlMentionsQualifiedColumn(sql: string, schema: string, object: string, column: string, aliases: Set<string>): boolean {
   const prefixes = [
     `${identifierPattern(schema)}\\s*\\.\\s*${identifierPattern(object)}`,
     identifierPattern(object),
@@ -210,20 +251,20 @@ function sqlMentionsQualifiedColumn(sql, schema, object, column, aliases) {
   return false;
 }
 
-function sqlMentionsColumnToken(sql, column) {
+function sqlMentionsColumnToken(sql: string, column: string): boolean {
   const startsAlpha = /^[a-z_]/i.test(column);
   const bare = startsAlpha ? `|${escapeRegExp(column)}\\b` : "";
   const pattern = new RegExp(`(^|[^\\w])(?:\\[${escapeRegExp(column)}\\]|"${escapeRegExp(column)}"${bare})`, "i");
   return pattern.test(sql);
 }
 
-function extractObjectAliases(sql) {
-  const aliasesByObject = new Map();
+function extractObjectAliases(sql: string): Map<string, Set<string>> {
+  const aliasesByObject = new Map<string, Set<string>>();
   const text = String(sql || "");
   const pattern = /\b(?:from|join)\s+([a-z0-9_\[\]."]+)(?:\s+(?:as\s+)?([a-z0-9_\[\]"]+))?/gi;
   const blockedAliasTokens = new Set(["on", "where", "join", "group", "order", "limit", "top"]);
 
-  let match;
+  let match: RegExpExecArray | null;
   while ((match = pattern.exec(text)) !== null) {
     const objectRef = normalizeObjectRef(match[1]);
     if (!objectRef) {
@@ -231,20 +272,20 @@ function extractObjectAliases(sql) {
     }
     const objectKey = `${objectRef.schema}.${objectRef.object}`;
     if (!aliasesByObject.has(objectKey)) {
-      aliasesByObject.set(objectKey, new Set());
+      aliasesByObject.set(objectKey, new Set<string>());
     }
 
     const aliasCandidate = normalizeIdentifier(match[2]);
     if (!aliasCandidate || blockedAliasTokens.has(aliasCandidate)) {
       continue;
     }
-    aliasesByObject.get(objectKey).add(aliasCandidate);
+    aliasesByObject.get(objectKey)!.add(aliasCandidate);
   }
 
   return aliasesByObject;
 }
 
-function normalizeObjectRef(rawRef) {
+function normalizeObjectRef(rawRef: unknown): { schema: string; object: string } | null {
   const cleaned = String(rawRef || "")
     .replace(/[;,]+$/g, "")
     .trim();
@@ -267,15 +308,11 @@ function normalizeObjectRef(rawRef) {
   };
 }
 
-module.exports = {
-  extractForbiddenColumnsFromRagNotes,
-  validateSqlAgainstForbiddenColumns,
-  __private: {
-    containsNegativeKeyword,
-    extractColumnRefs,
-    resolveColumnRef,
-    extractObjectAliases,
-    sqlMentionsColumnToken,
-    sqlMentionsQualifiedColumn
-  }
+export const __private = {
+  containsNegativeKeyword,
+  extractColumnRefs,
+  resolveColumnRef,
+  extractObjectAliases,
+  sqlMentionsColumnToken,
+  sqlMentionsQualifiedColumn
 };

--- a/app/src/services/ddlImportService.ts
+++ b/app/src/services/ddlImportService.ts
@@ -3,26 +3,67 @@
  * produced by mssqlAdapter.introspectSchema().
  */
 
-function parseSchemaFromDdl(ddlText) {
+interface DdlObject {
+  schemaName: string;
+  objectName: string;
+  objectType: "table" | "view";
+}
+
+interface DdlColumn {
+  schemaName: string;
+  objectName: string;
+  columnName: string;
+  dataType: string;
+  nullable: boolean;
+  isPk: boolean;
+  ordinalPosition: number;
+}
+
+interface DdlRelationship {
+  fromSchema: string;
+  fromObject: string;
+  fromColumn: string;
+  toSchema: string;
+  toObject: string;
+  toColumn: string;
+  relationshipType: "fk";
+}
+
+interface DdlIndex {
+  schemaName: string;
+  objectName: string;
+  indexName: string;
+  columns: string[];
+  isUnique: boolean;
+}
+
+export interface DdlSnapshot {
+  objects: DdlObject[];
+  columns: DdlColumn[];
+  relationships: DdlRelationship[];
+  indexes: DdlIndex[];
+}
+
+export function parseSchemaFromDdl(ddlText: unknown): DdlSnapshot {
   // Strip BOM, null bytes (residual UTF-16 if client didn't decode properly),
   // and normalize line endings
   const text = String(ddlText || "")
-    .replace(/^\uFEFF/, "")
+    .replace(/^﻿/, "")
     .replace(/\0/g, "")
     .replace(/\r\n/g, "\n");
-  const objects = [];
-  const columns = [];
-  const relationships = [];
-  const indexes = [];
+  const objects: DdlObject[] = [];
+  const columns: DdlColumn[] = [];
+  const relationships: DdlRelationship[] = [];
+  const indexes: DdlIndex[] = [];
 
   // Track which columns are PKs (populated by inline and out-of-line constraints)
-  const pkSet = new Set();
+  const pkSet = new Set<string>();
 
   // ── 1. Parse CREATE TABLE statements (balanced-paren extraction) ──
   const createTableHeaderRe =
     /CREATE\s+TABLE\s+(\[?[\w.]+\]?\.?\[?[\w.]+\]?)\s*\(/gi;
 
-  let headerMatch;
+  let headerMatch: RegExpExecArray | null;
   while ((headerMatch = createTableHeaderRe.exec(text)) !== null) {
     const rawName = headerMatch[1];
     const bodyStart = headerMatch.index + headerMatch[0].length;
@@ -34,7 +75,7 @@ function parseSchemaFromDdl(ddlText) {
     objects.push({
       schemaName: schema,
       objectName: name,
-      objectType: "table",
+      objectType: "table"
     });
 
     parseTableBody(schema, name, body, columns, pkSet, relationships);
@@ -44,13 +85,13 @@ function parseSchemaFromDdl(ddlText) {
   const createViewRe =
     /CREATE\s+VIEW\s+(\[?[\w.]+\]?\.?\[?[\w.]+\]?)\s/gi;
 
-  let match;
+  let match: RegExpExecArray | null;
   while ((match = createViewRe.exec(text)) !== null) {
     const { schema, name } = parseQualifiedName(match[1]);
     objects.push({
       schemaName: schema,
       objectName: name,
-      objectType: "view",
+      objectType: "view"
     });
   }
 
@@ -72,7 +113,7 @@ function parseSchemaFromDdl(ddlText) {
         toSchema: to.schema,
         toObject: to.name,
         toColumn: toCols[i] || fromCols[i],
-        relationshipType: "fk",
+        relationshipType: "fk"
       });
     }
   }
@@ -103,7 +144,7 @@ function parseSchemaFromDdl(ddlText) {
       objectName: tbl.name,
       indexName: unquote(match[2]),
       columns: idxCols,
-      isUnique,
+      isUnique
     });
   }
 
@@ -123,7 +164,7 @@ function parseSchemaFromDdl(ddlText) {
  * Starting right after an opening '(', extract everything up to the
  * matching closing ')' respecting nested parens.
  */
-function extractBalancedBody(text, startIndex) {
+function extractBalancedBody(text: string, startIndex: number): string | null {
   let depth = 1;
   let i = startIndex;
   while (i < text.length && depth > 0) {
@@ -135,7 +176,14 @@ function extractBalancedBody(text, startIndex) {
   return text.slice(startIndex, i);
 }
 
-function parseTableBody(schema, tableName, body, columns, pkSet, relationships) {
+function parseTableBody(
+  schema: string,
+  tableName: string,
+  body: string,
+  columns: DdlColumn[],
+  pkSet: Set<string>,
+  relationships: DdlRelationship[]
+): void {
   const lines = splitTableBody(body);
   let ordinal = 0;
 
@@ -171,7 +219,7 @@ function parseTableBody(schema, tableName, body, columns, pkSet, relationships) 
             toSchema: to.schema,
             toObject: to.name,
             toColumn: toCols[i] || fromCols[i],
-            relationshipType: "fk",
+            relationshipType: "fk"
           });
         }
       }
@@ -206,13 +254,13 @@ function parseTableBody(schema, tableName, body, columns, pkSet, relationships) 
       dataType,
       nullable: isInlinePk ? false : !hasNotNull,
       isPk: false, // will be set in step 6
-      ordinalPosition: ordinal,
+      ordinalPosition: ordinal
     });
   }
 }
 
-function splitTableBody(body) {
-  const lines = [];
+function splitTableBody(body: string): string[] {
+  const lines: string[] = [];
   let current = "";
   let depth = 0;
 
@@ -232,27 +280,27 @@ function splitTableBody(body) {
   return lines;
 }
 
-function parseQualifiedName(raw) {
+function parseQualifiedName(raw: unknown): { schema: string; name: string } {
   const cleaned = String(raw || "").trim();
   // Handle [schema].[name] or schema.name
   const parts = cleaned.split(".");
   if (parts.length >= 2) {
     return {
       schema: unquote(parts[parts.length - 2]),
-      name: unquote(parts[parts.length - 1]),
+      name: unquote(parts[parts.length - 1])
     };
   }
   return { schema: "dbo", name: unquote(parts[0]) };
 }
 
-function unquote(s) {
+function unquote(s: unknown): string {
   return String(s || "")
     .trim()
     .replace(/^\[/, "")
     .replace(/\]$/, "");
 }
 
-function normalizeDataType(raw) {
+function normalizeDataType(raw: unknown): string {
   return String(raw || "")
     .trim()
     .replace(/\[([^\]]+)\]/g, "$1")
@@ -260,13 +308,13 @@ function normalizeDataType(raw) {
     .toLowerCase();
 }
 
-function dedupeSnapshot(snapshot) {
-  const objects = [];
-  const columns = [];
-  const relationships = [];
-  const indexes = [];
+function dedupeSnapshot(snapshot: DdlSnapshot): DdlSnapshot {
+  const objects: DdlObject[] = [];
+  const columns: DdlColumn[] = [];
+  const relationships: DdlRelationship[] = [];
+  const indexes: DdlIndex[] = [];
 
-  const objectKeys = new Set();
+  const objectKeys = new Set<string>();
   for (const object of snapshot.objects || []) {
     const key = `${String(object.schemaName || "").toLowerCase()}.${String(object.objectName || "").toLowerCase()}`;
     if (objectKeys.has(key)) continue;
@@ -274,7 +322,7 @@ function dedupeSnapshot(snapshot) {
     objects.push(object);
   }
 
-  const columnKeys = new Set();
+  const columnKeys = new Set<string>();
   for (const column of snapshot.columns || []) {
     const key = [
       String(column.schemaName || "").toLowerCase(),
@@ -286,7 +334,7 @@ function dedupeSnapshot(snapshot) {
     columns.push(column);
   }
 
-  const relationshipKeys = new Set();
+  const relationshipKeys = new Set<string>();
   for (const relationship of snapshot.relationships || []) {
     const key = [
       String(relationship.fromSchema || "").toLowerCase(),
@@ -302,7 +350,7 @@ function dedupeSnapshot(snapshot) {
     relationships.push(relationship);
   }
 
-  const indexKeys = new Set();
+  const indexKeys = new Set<string>();
   for (const index of snapshot.indexes || []) {
     const key = [
       String(index.schemaName || "").toLowerCase(),
@@ -317,7 +365,7 @@ function dedupeSnapshot(snapshot) {
   return { objects, columns, relationships, indexes };
 }
 
-function splitColumnList(raw) {
+function splitColumnList(raw: unknown): string[] {
   return String(raw || "")
     .split(",")
     .map((s) => {
@@ -326,7 +374,3 @@ function splitColumnList(raw) {
     })
     .filter(Boolean);
 }
-
-module.exports = {
-  parseSchemaFromDdl,
-};

--- a/app/src/services/introspectionService.ts
+++ b/app/src/services/introspectionService.ts
@@ -1,8 +1,16 @@
-const crypto = require("crypto");
-const { createDatabaseAdapter } = require("../adapters/dbAdapterFactory");
-const appDb = require("../lib/appDb");
+import { createHash } from "crypto";
+import type { PoolClient } from "pg";
+import { createDatabaseAdapter } from "../adapters/dbAdapterFactory";
+import appDb = require("../lib/appDb");
+import type { SchemaIntrospection } from "../adapters/types";
 
-async function runIntrospection(dataSource) {
+export interface IntrospectionDataSource {
+  id: string;
+  db_type: string;
+  connection_ref: string;
+}
+
+export async function runIntrospection(dataSource: IntrospectionDataSource): Promise<SchemaIntrospection> {
   const adapter = createDatabaseAdapter(dataSource.db_type, dataSource.connection_ref);
   try {
     const snapshot = await adapter.introspectSchema();
@@ -13,9 +21,9 @@ async function runIntrospection(dataSource) {
   }
 }
 
-async function persistSnapshot(dataSourceId, snapshot) {
-  await appDb.withTransaction(async (client) => {
-    const existingObjectsResult = await client.query(
+export async function persistSnapshot(dataSourceId: string, snapshot: SchemaIntrospection): Promise<void> {
+  await appDb.withTransaction(async (client: PoolClient) => {
+    const existingObjectsResult = await client.query<{ schema_name: string; object_name: string; is_ignored: boolean }>(
       `
         SELECT schema_name, object_name, is_ignored
         FROM schema_objects
@@ -30,13 +38,13 @@ async function persistSnapshot(dataSourceId, snapshot) {
 
     await client.query("DELETE FROM schema_objects WHERE data_source_id = $1", [dataSourceId]);
 
-    const objectIdByKey = new Map();
+    const objectIdByKey = new Map<string, string>();
 
     for (const object of snapshot.objects) {
       const key = objectKey(object.schemaName, object.objectName);
       const isIgnored = ignoredByObjectKey.get(key) === true;
       const hash = computeObjectHash(object, snapshot.columns, snapshot.relationships);
-      const objectInsert = await client.query(
+      const objectInsert = await client.query<{ id: string }>(
         `
           INSERT INTO schema_objects (
             data_source_id,
@@ -126,11 +134,15 @@ async function persistSnapshot(dataSourceId, snapshot) {
   });
 }
 
-function objectKey(schemaName, objectName) {
+function objectKey(schemaName: string, objectName: string): string {
   return `${schemaName}.${objectName}`.toLowerCase();
 }
 
-function computeObjectHash(object, allColumns, allRelationships) {
+function computeObjectHash(
+  object: SchemaIntrospection["objects"][number],
+  allColumns: SchemaIntrospection["columns"],
+  allRelationships: SchemaIntrospection["relationships"]
+): string {
   const columns = allColumns
     .filter((column) => column.schemaName === object.schemaName && column.objectName === object.objectName)
     .map((column) => `${column.columnName}:${column.dataType}:${column.nullable}:${column.isPk}`)
@@ -145,13 +157,7 @@ function computeObjectHash(object, allColumns, allRelationships) {
     .map((rel) => `${rel.fromColumn}->${rel.toSchema}.${rel.toObject}.${rel.toColumn}`)
     .sort();
 
-  return crypto
-    .createHash("sha256")
+  return createHash("sha256")
     .update(JSON.stringify({ object, columns, relationships }))
     .digest("hex");
 }
-
-module.exports = {
-  runIntrospection,
-  persistSnapshot
-};

--- a/app/src/services/queryOrchestrationService.ts
+++ b/app/src/services/queryOrchestrationService.ts
@@ -255,13 +255,13 @@ export async function orchestrateQueryRun({
       metricDefinitions: context.metricDefinitions,
       joinPolicies: context.joinPolicies
     }) as Citations;
-    citations.rag_documents = ragDocuments.map((doc: Record<string, unknown>) => ({
-      id: doc.id as string,
-      doc_type: doc.doc_type as string,
-      ref_id: doc.ref_id as string,
+    citations.rag_documents = ragDocuments.map((doc) => ({
+      id: doc.id,
+      doc_type: doc.doc_type,
+      ref_id: doc.ref_id,
       score: Number(doc.score || 0),
       rerank_score: Number(doc.rerank_score || 0),
-      embedding_model: (doc.embedding_model as string | null) || null
+      embedding_model: doc.embedding_model || null
     }));
 
     const confidence = computeConfidence({

--- a/app/src/services/ragDocumentBuilder.ts
+++ b/app/src/services/ragDocumentBuilder.ts
@@ -1,6 +1,79 @@
-const appDb = require("../lib/appDb");
+import appDb = require("../lib/appDb");
 
-async function buildRagDocuments(dataSourceId) {
+export interface RagDocument {
+  docType: "schema" | "semantic" | "policy" | "example";
+  refId: string;
+  metadata: Record<string, unknown>;
+  content: string;
+}
+
+interface SchemaObjectRow {
+  id: string;
+  object_type: string;
+  schema_name: string;
+  object_name: string;
+  description: string | null;
+}
+
+interface ColumnRow {
+  id: string;
+  schema_object_id: string;
+  column_name: string;
+  data_type: string;
+  nullable: boolean;
+  is_pk: boolean;
+}
+
+interface RelationshipRow {
+  id: string;
+  from_object_id: string;
+  from_column: string;
+  to_object_id: string;
+  to_column: string;
+  relationship_type: string;
+}
+
+interface SemanticEntityRow {
+  id: string;
+  entity_type: string;
+  target_ref: string;
+  business_name: string;
+  description: string | null;
+  owner: string | null;
+}
+
+interface MetricDefinitionRow {
+  id: string;
+  semantic_entity_id: string;
+  sql_expression: string;
+  grain: string | null;
+  business_name: string;
+}
+
+interface JoinPolicyRow {
+  id: string;
+  left_ref: string;
+  right_ref: string;
+  join_type: string;
+  on_clause: string;
+  notes: string | null;
+}
+
+interface NlSqlExampleRow {
+  id: string;
+  question: string;
+  sql: string;
+  quality_score: number | null;
+  source: string | null;
+}
+
+interface RagNoteRow {
+  id: string;
+  title: string;
+  content: string;
+}
+
+export async function buildRagDocuments(dataSourceId: string): Promise<RagDocument[]> {
   const [
     schemaObjectsResult,
     columnsResult,
@@ -11,7 +84,7 @@ async function buildRagDocuments(dataSourceId) {
     examplesResult,
     ragNotesResult
   ] = await Promise.all([
-    appDb.query(
+    appDb.query<SchemaObjectRow>(
       `
         SELECT id, object_type, schema_name, object_name, description
         FROM schema_objects
@@ -21,7 +94,7 @@ async function buildRagDocuments(dataSourceId) {
       `,
       [dataSourceId]
     ),
-    appDb.query(
+    appDb.query<ColumnRow>(
       `
         SELECT
           c.id,
@@ -38,7 +111,7 @@ async function buildRagDocuments(dataSourceId) {
       `,
       [dataSourceId]
     ),
-    appDb.query(
+    appDb.query<RelationshipRow>(
       `
         SELECT
           r.id,
@@ -56,7 +129,7 @@ async function buildRagDocuments(dataSourceId) {
       `,
       [dataSourceId]
     ),
-    appDb.query(
+    appDb.query<SemanticEntityRow>(
       `
         SELECT id, entity_type, target_ref, business_name, description, owner
         FROM semantic_entities
@@ -65,7 +138,7 @@ async function buildRagDocuments(dataSourceId) {
       `,
       [dataSourceId]
     ),
-    appDb.query(
+    appDb.query<MetricDefinitionRow>(
       `
         SELECT md.id, md.semantic_entity_id, md.sql_expression, md.grain, se.business_name
         FROM metric_definitions md
@@ -75,7 +148,7 @@ async function buildRagDocuments(dataSourceId) {
       `,
       [dataSourceId]
     ),
-    appDb.query(
+    appDb.query<JoinPolicyRow>(
       `
         SELECT id, left_ref, right_ref, join_type, on_clause, notes
         FROM join_policies
@@ -84,7 +157,7 @@ async function buildRagDocuments(dataSourceId) {
       `,
       [dataSourceId]
     ),
-    appDb.query(
+    appDb.query<NlSqlExampleRow>(
       `
         SELECT id, question, sql, quality_score, source
         FROM nl_sql_examples
@@ -94,7 +167,7 @@ async function buildRagDocuments(dataSourceId) {
       `,
       [dataSourceId]
     ),
-    appDb.query(
+    appDb.query<RagNoteRow>(
       `
         SELECT id, title, content
         FROM rag_notes
@@ -111,7 +184,7 @@ async function buildRagDocuments(dataSourceId) {
     schemaObjectsResult.rows.map((obj) => [obj.id, `${obj.schema_name}.${obj.object_name}`])
   );
 
-  const docs = [];
+  const docs: RagDocument[] = [];
 
   for (const obj of schemaObjectsResult.rows) {
     const columns = columnsByObject.get(obj.id) || [];
@@ -231,18 +304,14 @@ async function buildRagDocuments(dataSourceId) {
   return docs;
 }
 
-function groupBy(rows, keyFn) {
-  const map = new Map();
+function groupBy<T>(rows: T[], keyFn: (row: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
   for (const row of rows) {
     const key = keyFn(row);
     if (!map.has(key)) {
       map.set(key, []);
     }
-    map.get(key).push(row);
+    map.get(key)!.push(row);
   }
   return map;
 }
-
-module.exports = {
-  buildRagDocuments
-};

--- a/app/src/services/ragRetrieval.ts
+++ b/app/src/services/ragRetrieval.ts
@@ -1,8 +1,28 @@
-const appDb = require("../lib/appDb");
-const { LOCAL_EMBEDDING_MODEL, embedQueryForModel } = require("./embeddingRouter");
-const { cosineSimilarity } = require("./localEmbedding");
+import appDb = require("../lib/appDb");
+import { LOCAL_EMBEDDING_MODEL, embedQueryForModel } from "./embeddingRouter";
+import { cosineSimilarity } from "./localEmbedding";
 
-async function retrieveRagContext(dataSourceId, question, opts = {}) {
+export interface RagRetrievalDoc {
+  id: string;
+  doc_type: string;
+  ref_id: string;
+  content: string;
+  metadata_json: Record<string, unknown> | null;
+  vector_json: number[] | null;
+  score: number;
+  embedding_model: string;
+  rerank_score?: number;
+}
+
+export interface RetrieveRagContextOptions {
+  limit?: number;
+}
+
+export async function retrieveRagContext(
+  dataSourceId: string,
+  question: string,
+  opts: RetrieveRagContextOptions = {}
+): Promise<RagRetrievalDoc[]> {
   const limit = Number(opts.limit || 12);
   const q = String(question || "").trim();
 
@@ -11,7 +31,14 @@ async function retrieveRagContext(dataSourceId, question, opts = {}) {
   }
 
   const embeddingModel = await selectEmbeddingModel(dataSourceId);
-  const result = await appDb.query(
+  const result = await appDb.query<{
+    id: string;
+    doc_type: string;
+    ref_id: string;
+    content: string;
+    metadata_json: Record<string, unknown> | null;
+    vector_json: number[] | null;
+  }>(
     `
       SELECT
         rd.id,
@@ -33,7 +60,7 @@ async function retrieveRagContext(dataSourceId, question, opts = {}) {
 
   const tokens = tokenize(q);
   const qVector = await embedQueryForModel(q, embeddingModel);
-  const ranked = result.rows
+  const ranked: RagRetrievalDoc[] = result.rows
     .map((row) => ({
       ...row,
       score: computeHybridScore(q, tokens, qVector, row.content, row.vector_json),
@@ -48,7 +75,7 @@ async function retrieveRagContext(dataSourceId, question, opts = {}) {
   }
 
   const usedIds = new Set(reranked.map((row) => row.id));
-  const fill = result.rows
+  const fill: RagRetrievalDoc[] = result.rows
     .filter((row) => !usedIds.has(row.id))
     .slice(0, Math.max(0, limit - reranked.length))
     .map((row) => ({ ...row, score: 0, embedding_model: embeddingModel, rerank_score: 0 }));
@@ -56,8 +83,8 @@ async function retrieveRagContext(dataSourceId, question, opts = {}) {
   return reranked.concat(fill);
 }
 
-async function selectEmbeddingModel(dataSourceId) {
-  const result = await appDb.query(
+async function selectEmbeddingModel(dataSourceId: string): Promise<string> {
+  const result = await appDb.query<{ embedding_model: string; doc_count: number | string }>(
     `
       SELECT re.embedding_model, COUNT(*) AS doc_count
       FROM rag_embeddings re
@@ -73,7 +100,7 @@ async function selectEmbeddingModel(dataSourceId) {
   return result.rows[0]?.embedding_model || LOCAL_EMBEDDING_MODEL;
 }
 
-function tokenize(text) {
+function tokenize(text: unknown): string[] {
   return String(text || "")
     .toLowerCase()
     .replace(/[^a-z0-9_]+/g, " ")
@@ -82,13 +109,19 @@ function tokenize(text) {
     .filter((t) => t.length >= 2);
 }
 
-function computeHybridScore(question, tokens, qVector, content, vectorJson) {
+function computeHybridScore(
+  question: string,
+  tokens: string[],
+  qVector: number[] | null,
+  content: string,
+  vectorJson: number[] | null
+): number {
   const lexical = computeLexicalScore(question, tokens, content);
   const vector = computeVectorScore(qVector, vectorJson);
   return Number((lexical + (vector * 2)).toFixed(4));
 }
 
-function rerankDocuments(question, tokens, rows) {
+function rerankDocuments(question: string, tokens: string[], rows: RagRetrievalDoc[]): RagRetrievalDoc[] {
   const q = String(question || "").toLowerCase();
   return rows
     .map((row) => {
@@ -102,10 +135,10 @@ function rerankDocuments(question, tokens, rows) {
         rerank_score: rerankScore
       };
     })
-    .sort((a, b) => b.rerank_score - a.rerank_score);
+    .sort((a, b) => (b.rerank_score || 0) - (a.rerank_score || 0));
 }
 
-function tokenCoverage(tokens, content) {
+function tokenCoverage(tokens: string[], content: string): number {
   if (!tokens || tokens.length === 0) {
     return 0;
   }
@@ -119,7 +152,7 @@ function tokenCoverage(tokens, content) {
   return hits / set.size;
 }
 
-function docTypeBoost(docType) {
+function docTypeBoost(docType: string): number {
   if (docType === "semantic") {
     return 0.9;
   }
@@ -132,7 +165,7 @@ function docTypeBoost(docType) {
   return 0.2;
 }
 
-function computeLexicalScore(question, tokens, content) {
+function computeLexicalScore(question: string, tokens: string[], content: string): number {
   const haystack = String(content || "").toLowerCase();
   if (!haystack) {
     return 0;
@@ -154,7 +187,7 @@ function computeLexicalScore(question, tokens, content) {
   return score;
 }
 
-function computeVectorScore(queryVector, vectorJson) {
+function computeVectorScore(queryVector: number[] | null, vectorJson: number[] | null): number {
   if (!Array.isArray(queryVector) || queryVector.length === 0) {
     return 0;
   }
@@ -168,7 +201,3 @@ function computeVectorScore(queryVector, vectorJson) {
   }
   return cosine;
 }
-
-module.exports = {
-  retrieveRagContext
-};

--- a/app/src/services/ragService.ts
+++ b/app/src/services/ragService.ts
@@ -1,21 +1,28 @@
-const crypto = require("crypto");
-const appDb = require("../lib/appDb");
-const { embedTextsForIndexing } = require("./embeddingRouter");
-const { buildRagDocuments } = require("./ragDocumentBuilder");
+import { createHash } from "crypto";
+import type { PoolClient } from "pg";
+import appDb = require("../lib/appDb");
+import { embedTextsForIndexing } from "./embeddingRouter";
+import { buildRagDocuments } from "./ragDocumentBuilder";
 
-async function reindexRagDocuments(dataSourceId) {
+interface ReindexResult {
+  data_source_id: string;
+  documents_indexed: number;
+  embedding_model: string;
+}
+
+async function reindexRagDocuments(dataSourceId: string): Promise<ReindexResult> {
   const docs = await buildRagDocuments(dataSourceId);
   const embedResponse = await embedTextsForIndexing(docs.map((doc) => doc.content));
   const vectors = embedResponse.vectors || [];
   const embeddingModel = embedResponse.embeddingModel;
 
-  await appDb.withTransaction(async (client) => {
+  await appDb.withTransaction(async (client: PoolClient) => {
     await client.query("DELETE FROM rag_documents WHERE data_source_id = $1", [dataSourceId]);
 
     for (let idx = 0; idx < docs.length; idx += 1) {
       const doc = docs[idx];
       const contentHash = sha256(doc.content);
-      const insertResult = await client.query(
+      const insertResult = await client.query<{ id: string }>(
         `
           INSERT INTO rag_documents (
             data_source_id,
@@ -53,26 +60,37 @@ async function reindexRagDocuments(dataSourceId) {
   };
 }
 
-function triggerRagReindexAsync(dataSourceId) {
+function triggerRagReindexAsync(dataSourceId: string | null | undefined): void {
   if (!dataSourceId) {
     return;
   }
 
   setImmediate(() => {
-    module.exports.reindexRagDocuments(dataSourceId).catch((err) => {
+    // Read through the export object so test monkey-patches of
+    // ragService.reindexRagDocuments are honored.
+    moduleExports.reindexRagDocuments(dataSourceId).catch((err: Error) => {
       console.error(`[rag] reindex failed for ${dataSourceId}: ${err.message}`);
     });
   });
 }
 
-function sha256(content) {
-  return crypto.createHash("sha256").update(content).digest("hex");
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
 }
 
-module.exports = {
+// Use `export = { ... }` so `app/test/ragNotesApi.test.js` can monkey-patch
+// `ragService.reindexRagDocuments`. Named `export` statements compile to
+// immutable getters under tsx/esbuild (see lib/appDb.ts for the same gotcha).
+//
+// `triggerRagReindexAsync` reads through this object so monkey-patches at
+// test time (after the module is loaded) are honored. Using `exports`
+// directly would point to the original (empty) module export object
+// because `export = { ... }` reassigns `module.exports` to a new object.
+const moduleExports = {
   reindexRagDocuments,
   triggerRagReindexAsync,
   __private: {
     buildRagDocuments
   }
 };
+export = moduleExports;


### PR DESCRIPTION
## Summary

Migrates the 6 services in the introspection/RAG cluster from `.js` to `.ts`. `introspectionService` now consumes the typed `SchemaIntrospection` contract from TS-006. `ragRetrieval` returns a typed `RagRetrievalDoc[]` that lets `queryOrchestrationService` drop its inline row cast. No runtime behavior changes; tests stay green at 219/219.

## Files migrated

All in `app/src/services/`:

| File | Notes |
|---|---|
| `introspectionService.ts` | `runIntrospection` / `persistSnapshot` wired to `DbAdapter.introspectSchema()`; uses `SchemaIntrospection` from `adapters/types` |
| `ddlImportService.ts` | typed `parseSchemaFromDdl` with explicit `DdlObject` / `DdlColumn` / `DdlRelationship` / `DdlIndex` / `DdlSnapshot` shapes |
| `ragService.ts` | uses `export = { ... }` because `app/test/ragNotesApi.test.js` monkey-patches `ragService.reindexRagDocuments` |
| `ragDocumentBuilder.ts` | typed `RagDocument` output + per-table row shapes for every SELECT |
| `ragRetrieval.ts` | typed `RagRetrievalDoc` with hybrid scoring + rerank |
| `columnPolicyService.ts` | typed `ForbiddenColumn` extraction and qualified/bare column reference validation |

## Two CJS-interop gotchas (and fixes)

**1. `export = { ... }` + named `export interface ...` cannot coexist.** TS reports "export assignment cannot be used in a module with other exported elements." For modules that need `export =` for test monkey-patch support, helper interfaces stay file-local. Same pattern hit in TS-013's `emailService`.

**2. `exports.foo` inside a same-file dispatcher fails after `export = obj`.** The trailing reassignment to `module.exports` makes a new object — but the original `exports` binding still points at the now-empty initial object. `ragService.triggerRagReindexAsync` was calling `exports.reindexRagDocuments(dataSourceId)` inside a `setImmediate`, which threw `TypeError: exports.reindexRagDocuments is not a function` at test time. Fix: capture the export object as a local `const moduleExports = { ... }; export = moduleExports`, then read through `moduleExports.reindexRagDocuments`. Preserves the monkey-patch contract because writes from tests go through `module.exports.reindexRagDocuments` which is the same object identity as `moduleExports`.

## Drive-by

`queryOrchestrationService.ts` (from TS-010) updated in place to drop its inline `(doc: Record<string, unknown>)` cast — `ragRetrieval` now returns `RagRetrievalDoc[]`. One less untyped boundary.

## Verification

- `npm run typecheck` exits 0
- `npm test` 219/219 pass — including `ddlImportService.test.js`, `ragNotesApi.test.js` (the monkey-patch one that surfaced gotcha #2), `ragNotesMigration.test.js`, `columnPolicyService.test.js`
- `app/src/services/` contains no leftover `.js` for these 6 modules

## Out of scope

- Routes that invoke these services (TS-014)
- Tests under `app/test/` (TS-016)

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)