### PR TITLE
TS-012 migrate saved-query services to TypeScript

### DIFF
--- a/app/src/services/cronExpression.ts
+++ b/app/src/services/cronExpression.ts
@@ -24,17 +24,39 @@
 // DST transitions are handled by the underlying Date math (we keep stepping
 // until a UTC instant is found that matches the local-wall-clock fields).
 
-const MINUTE_RANGE = [0, 59];
-const HOUR_RANGE = [0, 23];
-const DOM_RANGE = [1, 31];
-const MONTH_RANGE = [1, 12];
-const DOW_RANGE = [0, 6];
+type Range = readonly [number, number];
 
-function parseField(spec, [min, max]) {
+export interface ParsedCron {
+  expression: string;
+  minutes: Set<number>;
+  hours: Set<number>;
+  doms: Set<number>;
+  months: Set<number>;
+  dows: Set<number>;
+  domStarred: boolean;
+  dowStarred: boolean;
+}
+
+interface ZonedParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  dayOfWeek: number;
+}
+
+const MINUTE_RANGE: Range = [0, 59];
+const HOUR_RANGE: Range = [0, 23];
+const DOM_RANGE: Range = [1, 31];
+const MONTH_RANGE: Range = [1, 12];
+const DOW_RANGE: Range = [0, 6];
+
+function parseField(spec: string, [min, max]: Range): Set<number> {
   if (typeof spec !== "string" || !spec.length) {
     throw new Error(`cron field must be a non-empty string`);
   }
-  const result = new Set();
+  const result = new Set<number>();
   for (const part of spec.split(",")) {
     if (!part.length) {
       throw new Error(`cron field has empty list entry`);
@@ -45,8 +67,8 @@ function parseField(spec, [min, max]) {
     if (!Number.isInteger(step) || step <= 0) {
       throw new Error(`cron step must be a positive integer`);
     }
-    let rangeStart;
-    let rangeEnd;
+    let rangeStart: number;
+    let rangeEnd: number;
     if (base === "*") {
       rangeStart = min;
       rangeEnd = max;
@@ -71,7 +93,7 @@ function parseField(spec, [min, max]) {
   return result;
 }
 
-function parseCronExpression(expression) {
+export function parseCronExpression(expression: unknown): ParsedCron {
   if (typeof expression !== "string") {
     throw new Error("cron expression must be a string");
   }
@@ -103,7 +125,7 @@ function parseCronExpression(expression) {
   };
 }
 
-function isCronExpressionValid(expression) {
+export function isCronExpressionValid(expression: unknown): boolean {
   try {
     parseCronExpression(expression);
     return true;
@@ -112,10 +134,10 @@ function isCronExpressionValid(expression) {
   }
 }
 
-const FORMATTER_CACHE = new Map();
-const DOW_MAP = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+const FORMATTER_CACHE = new Map<string, Intl.DateTimeFormat>();
+const DOW_MAP: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
 
-function getFormatter(timezone) {
+function getFormatter(timezone: string): Intl.DateTimeFormat {
   let formatter = FORMATTER_CACHE.get(timezone);
   if (!formatter) {
     formatter = new Intl.DateTimeFormat("en-US", {
@@ -134,9 +156,9 @@ function getFormatter(timezone) {
   return formatter;
 }
 
-function getZonedParts(date, timezone) {
+function getZonedParts(date: Date, timezone: string): ZonedParts {
   const formatter = getFormatter(timezone);
-  const parts = {};
+  const parts: Record<string, string> = {};
   for (const part of formatter.formatToParts(date)) {
     if (part.type !== "literal") parts[part.type] = part.value;
   }
@@ -150,7 +172,7 @@ function getZonedParts(date, timezone) {
   };
 }
 
-function isTimezoneValid(timezone) {
+export function isTimezoneValid(timezone: unknown): timezone is string {
   if (typeof timezone !== "string" || !timezone.length) return false;
   try {
     // Will throw RangeError if invalid.
@@ -161,7 +183,7 @@ function isTimezoneValid(timezone) {
   }
 }
 
-function matchesCron(parsed, parts) {
+function matchesCron(parsed: ParsedCron, parts: ZonedParts): boolean {
   if (!parsed.minutes.has(parts.minute)) return false;
   if (!parsed.hours.has(parts.hour)) return false;
   if (!parsed.months.has(parts.month)) return false;
@@ -183,13 +205,8 @@ function matchesCron(parsed, parts) {
  *
  * Caps at 366 days of search; anything beyond that is a sign of an impossible
  * combination (e.g. "0 0 31 2 *").
- *
- * @param {string} expression  cron expression in `timezone`
- * @param {string} timezone    IANA tz name
- * @param {Date}   [fromDate]  defaults to "now"
- * @returns {Date}             next fire time as a UTC Date
  */
-function computeNextRun(expression, timezone, fromDate = new Date()) {
+export function computeNextRun(expression: string, timezone: string, fromDate: Date = new Date()): Date {
   const parsed = parseCronExpression(expression);
   if (!isTimezoneValid(timezone)) {
     throw new Error(`invalid timezone: ${timezone}`);
@@ -238,10 +255,3 @@ function computeNextRun(expression, timezone, fromDate = new Date()) {
   }
   throw new Error(`no cron match within 366 days for expression "${expression}"`);
 }
-
-module.exports = {
-  parseCronExpression,
-  isCronExpressionValid,
-  isTimezoneValid,
-  computeNextRun
-};

--- a/app/src/services/promptPresetService.ts
+++ b/app/src/services/promptPresetService.ts
@@ -10,16 +10,69 @@
 // via the FK (ON DELETE SET NULL in the migration). The frontend can filter
 // the list to "presets that apply to my current data source" on its own.
 
-const appDb = require("../lib/appDb");
+import appDb = require("../lib/appDb");
 
-const TITLE_MAX = 200;
-const PROMPT_MAX = 8 * 1024;
-const TAGS_MAX = 16;
-const TAG_MAX_LEN = 64;
-const ALLOWED_VISIBILITY = new Set(["private", "shared"]);
+export const TITLE_MAX = 200 as const;
+export const PROMPT_MAX = 8 * 1024;
+export const TAGS_MAX = 16 as const;
+export const TAG_MAX_LEN = 64 as const;
+export const ALLOWED_VISIBILITY: ReadonlySet<PresetVisibility> = new Set<PresetVisibility>(["private", "shared"]);
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-function rowToPreset(row) {
+export type PresetVisibility = "private" | "shared";
+
+export interface PromptPresetRow {
+  id: string;
+  owner_user_id: string;
+  title: string;
+  prompt_text: string;
+  data_source_id: string | null;
+  tags: string[] | null;
+  visibility: PresetVisibility;
+  created_at: string | Date;
+  updated_at: string | Date;
+}
+
+export interface PromptPreset {
+  id: string;
+  owner_user_id: string;
+  title: string;
+  prompt_text: string;
+  data_source_id: string | null;
+  tags: string[];
+  visibility: PresetVisibility;
+  created_at: string | Date;
+  updated_at: string | Date;
+}
+
+interface NormalizedPresetFields {
+  title?: string;
+  prompt_text?: string;
+  data_source_id?: string | null;
+  tags?: string[];
+  visibility?: PresetVisibility;
+}
+
+interface FieldValidationOk<T> {
+  ok: true;
+  value: T;
+}
+interface FieldValidationErr {
+  ok: false;
+  message?: string;
+}
+type FieldValidation<T> = FieldValidationOk<T> | FieldValidationErr;
+
+export type ValidatePresetResult =
+  | { ok: true; value: NormalizedPresetFields }
+  | { ok: false; code: string; message: string };
+
+export interface ServiceResult<T> {
+  statusCode: number;
+  body: T;
+}
+
+function rowToPreset(row: PromptPresetRow | null | undefined): PromptPreset | null {
   if (!row) return null;
   return {
     id: row.id,
@@ -34,12 +87,12 @@ function rowToPreset(row) {
   };
 }
 
-function normalizeTags(value) {
+function normalizeTags(value: unknown): string[] | null {
   if (value === undefined || value === null) return [];
   if (!Array.isArray(value)) return null;
   if (value.length > TAGS_MAX) return null;
-  const out = [];
-  const seen = new Set();
+  const out: string[] = [];
+  const seen = new Set<string>();
   for (const entry of value) {
     if (typeof entry !== "string") return null;
     const trimmed = entry.trim();
@@ -54,27 +107,33 @@ function normalizeTags(value) {
 }
 
 // Returns `{ ok: true, value }` or `{ ok: false, code, message }`.
-function validatePreset(body, { partial = false } = {}) {
+export function validatePreset(body: unknown, { partial = false }: { partial?: boolean } = {}): ValidatePresetResult {
   if (body == null || typeof body !== "object" || Array.isArray(body)) {
     return { ok: false, code: "invalid_body", message: "preset body must be a JSON object" };
   }
-  const value = {};
+  const input = body as Record<string, unknown>;
+  const value: NormalizedPresetFields = {};
 
-  const requireField = (key, validator, code, message) => {
-    const has = Object.prototype.hasOwnProperty.call(body, key);
+  function requireField<T>(
+    key: string,
+    validator: (raw: unknown) => FieldValidation<T>,
+    code: string,
+    message: string
+  ): ValidatePresetResult | null {
+    const has = Object.prototype.hasOwnProperty.call(input, key);
     if (!has) {
       if (partial) return null;
       return { ok: false, code, message };
     }
-    const validated = validator(body[key]);
-    if (validated.ok) {
-      value[key] = validated.value;
+    const validated = validator(input[key]);
+    if (validated.ok === true) {
+      (value as Record<string, unknown>)[key] = validated.value;
       return null;
     }
     return { ok: false, code, message: validated.message || message };
-  };
+  }
 
-  const titleErr = requireField(
+  const titleErr = requireField<string>(
     "title",
     (raw) => {
       if (typeof raw !== "string") return { ok: false, message: "title must be a string" };
@@ -88,7 +147,7 @@ function validatePreset(body, { partial = false } = {}) {
   );
   if (titleErr) return titleErr;
 
-  const promptErr = requireField(
+  const promptErr = requireField<string>(
     "prompt_text",
     (raw) => {
       if (typeof raw !== "string") return { ok: false, message: "prompt_text must be a string" };
@@ -104,8 +163,8 @@ function validatePreset(body, { partial = false } = {}) {
 
   // Optional fields. When omitted on create we apply sensible defaults;
   // when omitted on partial update we leave the existing column alone.
-  if (Object.prototype.hasOwnProperty.call(body, "data_source_id")) {
-    const raw = body.data_source_id;
+  if (Object.prototype.hasOwnProperty.call(input, "data_source_id")) {
+    const raw = input.data_source_id;
     if (raw === null || raw === "") {
       value.data_source_id = null;
     } else if (typeof raw === "string" && UUID_RE.test(raw)) {
@@ -117,8 +176,8 @@ function validatePreset(body, { partial = false } = {}) {
     value.data_source_id = null;
   }
 
-  if (Object.prototype.hasOwnProperty.call(body, "tags")) {
-    const tags = normalizeTags(body.tags);
+  if (Object.prototype.hasOwnProperty.call(input, "tags")) {
+    const tags = normalizeTags(input.tags);
     if (tags === null) {
       return { ok: false, code: "invalid_tags", message: `tags must be an array of up to ${TAGS_MAX} strings (each up to ${TAG_MAX_LEN} chars)` };
     }
@@ -127,12 +186,12 @@ function validatePreset(body, { partial = false } = {}) {
     value.tags = [];
   }
 
-  if (Object.prototype.hasOwnProperty.call(body, "visibility")) {
-    const raw = body.visibility;
-    if (typeof raw !== "string" || !ALLOWED_VISIBILITY.has(raw)) {
+  if (Object.prototype.hasOwnProperty.call(input, "visibility")) {
+    const raw = input.visibility;
+    if (typeof raw !== "string" || !ALLOWED_VISIBILITY.has(raw as PresetVisibility)) {
       return { ok: false, code: "invalid_visibility", message: `visibility must be one of: ${[...ALLOWED_VISIBILITY].join(", ")}` };
     }
-    value.visibility = raw;
+    value.visibility = raw as PresetVisibility;
   } else if (!partial) {
     value.visibility = "private";
   }
@@ -140,7 +199,7 @@ function validatePreset(body, { partial = false } = {}) {
   return { ok: true, value };
 }
 
-async function listForUser({ userId, includeShared = true } = {}) {
+export async function listForUser({ userId, includeShared = true }: { userId?: string | null; includeShared?: boolean } = {}): Promise<PromptPreset[]> {
   if (!userId) return [];
   const sql = includeShared
     ? `SELECT id, owner_user_id, title, prompt_text, data_source_id, tags,
@@ -153,13 +212,13 @@ async function listForUser({ userId, includeShared = true } = {}) {
          FROM prompt_presets
          WHERE owner_user_id = $1
          ORDER BY created_at DESC`;
-  const result = await appDb.query(sql, [userId]);
-  return result.rows.map(rowToPreset);
+  const result = await appDb.query<PromptPresetRow>(sql, [userId]);
+  return result.rows.map((row) => rowToPreset(row) as PromptPreset);
 }
 
-async function findById(id) {
+export async function findById(id: unknown): Promise<PromptPreset | null> {
   if (typeof id !== "string" || !id) return null;
-  const result = await appDb.query(
+  const result = await appDb.query<PromptPresetRow>(
     `SELECT id, owner_user_id, title, prompt_text, data_source_id, tags,
             visibility, created_at, updated_at
        FROM prompt_presets WHERE id = $1`,
@@ -168,12 +227,12 @@ async function findById(id) {
   return rowToPreset(result.rows[0] || null);
 }
 
-async function createPreset({ ownerUserId, body }) {
+export async function createPreset({ ownerUserId, body }: { ownerUserId?: string | null; body: unknown }): Promise<ServiceResult<unknown>> {
   if (!ownerUserId) {
     return { statusCode: 401, body: { error: "unauthenticated" } };
   }
   const parsed = validatePreset(body);
-  if (!parsed.ok) {
+  if (parsed.ok !== true) {
     return { statusCode: 400, body: { error: "bad_request", code: parsed.code, message: parsed.message } };
   }
   const v = parsed.value;
@@ -187,7 +246,7 @@ async function createPreset({ ownerUserId, body }) {
       };
     }
   }
-  const result = await appDb.query(
+  const result = await appDb.query<PromptPresetRow>(
     `INSERT INTO prompt_presets (owner_user_id, title, prompt_text, data_source_id, tags, visibility)
      VALUES ($1, $2, $3, $4, $5, $6)
      RETURNING id, owner_user_id, title, prompt_text, data_source_id, tags,
@@ -197,7 +256,7 @@ async function createPreset({ ownerUserId, body }) {
   return { statusCode: 201, body: rowToPreset(result.rows[0]) };
 }
 
-async function updatePreset({ ownerUserId, id, body }) {
+export async function updatePreset({ ownerUserId, id, body }: { ownerUserId?: string | null; id: unknown; body: unknown }): Promise<ServiceResult<unknown>> {
   if (!ownerUserId) return { statusCode: 401, body: { error: "unauthenticated" } };
   const existing = await findById(id);
   if (!existing) return { statusCode: 404, body: { error: "not_found", message: "preset not found" } };
@@ -206,7 +265,7 @@ async function updatePreset({ ownerUserId, id, body }) {
   }
   // Partial update: keep existing values for fields the caller doesn't send.
   const parsed = validatePreset(body, { partial: true });
-  if (!parsed.ok) {
+  if (parsed.ok !== true) {
     return { statusCode: 400, body: { error: "bad_request", code: parsed.code, message: parsed.message } };
   }
   const merged = { ...existing, ...parsed.value };
@@ -219,7 +278,7 @@ async function updatePreset({ ownerUserId, id, body }) {
       };
     }
   }
-  const result = await appDb.query(
+  const result = await appDb.query<PromptPresetRow>(
     `UPDATE prompt_presets
         SET title = $2,
             prompt_text = $3,
@@ -235,7 +294,7 @@ async function updatePreset({ ownerUserId, id, body }) {
   return { statusCode: 200, body: rowToPreset(result.rows[0]) };
 }
 
-async function deletePreset({ ownerUserId, id }) {
+export async function deletePreset({ ownerUserId, id }: { ownerUserId?: string | null; id: string }): Promise<ServiceResult<unknown>> {
   if (!ownerUserId) return { statusCode: 401, body: { error: "unauthenticated" } };
   const existing = await findById(id);
   if (!existing) return { statusCode: 404, body: { error: "not_found", message: "preset not found" } };
@@ -245,17 +304,3 @@ async function deletePreset({ ownerUserId, id }) {
   await appDb.query("DELETE FROM prompt_presets WHERE id = $1", [id]);
   return { statusCode: 200, body: { ok: true, id } };
 }
-
-module.exports = {
-  TITLE_MAX,
-  PROMPT_MAX,
-  TAGS_MAX,
-  TAG_MAX_LEN,
-  ALLOWED_VISIBILITY,
-  validatePreset,
-  listForUser,
-  findById,
-  createPreset,
-  updatePreset,
-  deletePreset
-};

--- a/app/src/services/savedQueryFolderService.ts
+++ b/app/src/services/savedQueryFolderService.ts
@@ -17,11 +17,11 @@
 //   folder's parent (NULL if it was a root folder). The reparent + delete
 //   happen in a single transaction so the move is atomic.
 
-const appDb = require("../lib/appDb");
-const { isUuid, isPgUniqueViolation } = require("../lib/validation");
+import appDb = require("../lib/appDb");
+import { isUuid, isPgUniqueViolation } from "../lib/validation";
 
-const FOLDER_NAME_MAX_LENGTH = 120;
-const MAX_FOLDER_DEPTH = 10;
+export const FOLDER_NAME_MAX_LENGTH = 120 as const;
+export const MAX_FOLDER_DEPTH = 10 as const;
 
 const FOLDER_COLUMNS = `
   id,
@@ -32,20 +32,52 @@ const FOLDER_COLUMNS = `
   updated_at
 `;
 
-function success(body, statusCode = 200) {
+export interface FolderRow {
+  id: string;
+  owner_id: string;
+  parent_id: string | null;
+  name: string;
+  created_at: string | Date;
+  updated_at: string | Date;
+}
+
+interface FolderNode extends FolderRow {
+  children: FolderNode[];
+}
+
+export interface ServiceSuccess<T> {
+  ok: true;
+  statusCode: number;
+  body: T;
+}
+export interface ServiceFailure<T = unknown> {
+  ok: false;
+  statusCode: number;
+  body: T;
+}
+export type ServiceResult<TSuccess, TFailure = unknown> = ServiceSuccess<TSuccess> | ServiceFailure<TFailure>;
+
+interface ErrorBody {
+  error: string;
+  message?: string;
+}
+
+function success<T>(body: T, statusCode = 200): ServiceSuccess<T> {
   return { ok: true, statusCode, body };
 }
 
-function failure(statusCode, body) {
+function failure<T>(statusCode: number, body: T): ServiceFailure<T> {
   return { ok: false, statusCode, body };
 }
 
-function normalizeName(value) {
+function normalizeName(value: unknown): string {
   if (typeof value !== "string") return "";
   return value.trim();
 }
 
-function normalizeParentId(value) {
+type ParentIdValidation = { ok: true; value: string | null | undefined } | { ok: false; message: string };
+
+function normalizeParentId(value: unknown): ParentIdValidation {
   if (value === undefined) return { ok: true, value: undefined };
   if (value === null) return { ok: true, value: null };
   if (typeof value === "string" && value.trim() === "") return { ok: true, value: null };
@@ -55,9 +87,9 @@ function normalizeParentId(value) {
   return { ok: true, value };
 }
 
-async function loadFolder(folderId) {
+async function loadFolder(folderId: string): Promise<FolderRow | null> {
   if (!isUuid(folderId)) return null;
-  const result = await appDb.query(
+  const result = await appDb.query<FolderRow>(
     `SELECT ${FOLDER_COLUMNS} FROM saved_query_folders WHERE id = $1`,
     [folderId]
   );
@@ -66,9 +98,9 @@ async function loadFolder(folderId) {
 
 // Returns the path from root → folder as an array of ids (inclusive).
 // Used both for depth checking and cycle detection on move.
-async function loadAncestorChain(folderId) {
+async function loadAncestorChain(folderId: string): Promise<string[]> {
   if (!isUuid(folderId)) return [];
-  const result = await appDb.query(
+  const result = await appDb.query<{ id: string }>(
     `
       WITH RECURSIVE chain AS (
         SELECT id, parent_id, 1 AS depth
@@ -88,7 +120,7 @@ async function loadAncestorChain(folderId) {
   return result.rows.map((row) => row.id);
 }
 
-async function isDescendantOf(candidateId, ancestorId) {
+async function isDescendantOf(candidateId: string, ancestorId: string): Promise<boolean> {
   // True if `candidateId` lives somewhere under `ancestorId`.
   if (!isUuid(candidateId) || !isUuid(ancestorId)) return false;
   if (candidateId === ancestorId) return true;
@@ -104,10 +136,18 @@ async function isDescendantOf(candidateId, ancestorId) {
     `,
     [ancestorId, candidateId]
   );
-  return result.rowCount > 0;
+  return result.rowCount! > 0;
 }
 
-async function validateParent(ownerId, parentId, { folderBeingMoved = null } = {}) {
+type ParentCheck =
+  | { ok: true; value: string | null }
+  | { ok: false; statusCode: number; message: string };
+
+async function validateParent(
+  ownerId: string,
+  parentId: string | null | undefined,
+  { folderBeingMoved = null }: { folderBeingMoved?: string | null } = {}
+): Promise<ParentCheck> {
   if (parentId === null || parentId === undefined) {
     return { ok: true, value: null };
   }
@@ -144,7 +184,13 @@ async function validateParent(ownerId, parentId, { folderBeingMoved = null } = {
   return { ok: true, value: parent.id };
 }
 
-async function createFolder({ ownerId, name, parentId }) {
+export interface CreateFolderInput {
+  ownerId: string | null | undefined;
+  name: unknown;
+  parentId?: unknown;
+}
+
+export async function createFolder({ ownerId, name, parentId }: CreateFolderInput): Promise<ServiceResult<FolderRow, ErrorBody>> {
   const ownerTrimmed = String(ownerId || "").trim();
   if (!ownerTrimmed) {
     return failure(401, { error: "unauthenticated" });
@@ -160,16 +206,16 @@ async function createFolder({ ownerId, name, parentId }) {
     });
   }
   const parentValidation = normalizeParentId(parentId);
-  if (!parentValidation.ok) {
+  if (parentValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: parentValidation.message });
   }
   const parentCheck = await validateParent(ownerTrimmed, parentValidation.value);
-  if (!parentCheck.ok) {
+  if (parentCheck.ok !== true) {
     return failure(parentCheck.statusCode, { error: "bad_request", message: parentCheck.message });
   }
 
   try {
-    const insertResult = await appDb.query(
+    const insertResult = await appDb.query<FolderRow>(
       `
         INSERT INTO saved_query_folders (owner_id, parent_id, name)
         VALUES ($1, $2, $3)
@@ -189,12 +235,17 @@ async function createFolder({ ownerId, name, parentId }) {
   }
 }
 
-async function listFolders({ ownerId }) {
+export interface ListFoldersResult {
+  items: FolderRow[];
+  tree: FolderNode[];
+}
+
+export async function listFolders({ ownerId }: { ownerId: string | null | undefined }): Promise<ServiceResult<ListFoldersResult, ErrorBody>> {
   const ownerTrimmed = String(ownerId || "").trim();
   if (!ownerTrimmed) {
     return failure(401, { error: "unauthenticated" });
   }
-  const result = await appDb.query(
+  const result = await appDb.query<FolderRow>(
     `
       SELECT ${FOLDER_COLUMNS}
         FROM saved_query_folders
@@ -209,15 +260,15 @@ async function listFolders({ ownerId }) {
   // tree. Each node carries a `children` array of folder nodes. Saved-query
   // membership lives on the saved-queries response (`folder_id`), so the
   // sidebar can join them in a single render pass.
-  const byId = new Map();
+  const byId = new Map<string, FolderNode>();
   for (const row of rows) {
     byId.set(row.id, { ...row, children: [] });
   }
-  const tree = [];
+  const tree: FolderNode[] = [];
   for (const row of rows) {
-    const node = byId.get(row.id);
+    const node = byId.get(row.id)!;
     if (row.parent_id && byId.has(row.parent_id)) {
-      byId.get(row.parent_id).children.push(node);
+      byId.get(row.parent_id)!.children.push(node);
     } else {
       tree.push(node);
     }
@@ -226,7 +277,13 @@ async function listFolders({ ownerId }) {
   return success({ items: rows, tree });
 }
 
-async function updateFolder(folderId, { ownerId, name, parentId }) {
+export interface UpdateFolderInput {
+  ownerId: string | null | undefined;
+  name?: unknown;
+  parentId?: unknown;
+}
+
+export async function updateFolder(folderId: string, { ownerId, name, parentId }: UpdateFolderInput): Promise<ServiceResult<FolderRow, ErrorBody>> {
   if (!isUuid(folderId)) {
     return failure(400, { error: "bad_request", message: "folderId must be a valid UUID" });
   }
@@ -259,20 +316,20 @@ async function updateFolder(folderId, { ownerId, name, parentId }) {
   let nextParentId = existing.parent_id;
   if (parentId !== undefined) {
     const parentValidation = normalizeParentId(parentId);
-    if (!parentValidation.ok) {
+    if (parentValidation.ok !== true) {
       return failure(400, { error: "bad_request", message: parentValidation.message });
     }
     const parentCheck = await validateParent(ownerTrimmed, parentValidation.value, {
       folderBeingMoved: folderId
     });
-    if (!parentCheck.ok) {
+    if (parentCheck.ok !== true) {
       return failure(parentCheck.statusCode, { error: "bad_request", message: parentCheck.message });
     }
     nextParentId = parentCheck.value;
   }
 
   try {
-    const updateResult = await appDb.query(
+    const updateResult = await appDb.query<FolderRow>(
       `
         UPDATE saved_query_folders
            SET name = $2,
@@ -298,7 +355,15 @@ async function updateFolder(folderId, { ownerId, name, parentId }) {
   }
 }
 
-async function deleteFolder(folderId, { ownerId }) {
+export interface DeleteFolderResult {
+  ok: true;
+  id: string;
+  reassigned_to: string | null;
+  reassigned_folder_ids: string[];
+  reassigned_saved_query_ids: string[];
+}
+
+export async function deleteFolder(folderId: string, { ownerId }: { ownerId: string | null | undefined }): Promise<ServiceResult<DeleteFolderResult, ErrorBody>> {
   if (!isUuid(folderId)) {
     return failure(400, { error: "bad_request", message: "folderId must be a valid UUID" });
   }
@@ -320,7 +385,7 @@ async function deleteFolder(folderId, { ownerId }) {
   // half-rewritten.
   const reassignedTo = existing.parent_id; // may be null (root)
   const summary = await appDb.withTransaction(async (client) => {
-    const childFolders = await client.query(
+    const childFolders = await client.query<{ id: string }>(
       `
         UPDATE saved_query_folders
            SET parent_id = $2,
@@ -330,7 +395,7 @@ async function deleteFolder(folderId, { ownerId }) {
       `,
       [folderId, reassignedTo]
     );
-    const childQueries = await client.query(
+    const childQueries = await client.query<{ id: string }>(
       `
         UPDATE saved_queries
            SET folder_id = $2,
@@ -351,13 +416,24 @@ async function deleteFolder(folderId, { ownerId }) {
     };
   });
 
-  return success({ ok: true, id: folderId, ...summary });
+  return success({ ok: true as const, id: folderId, ...summary });
+}
+
+export interface MoveSavedQueryInput {
+  ownerId: string | null | undefined;
+  folderId: unknown;
+}
+
+export interface MoveSavedQueryResult {
+  saved_query: unknown;
+  previous_folder_id: string | null;
+  folder_id: string | null;
 }
 
 // QUERY-008: move a saved query into a folder (or to root). Returns the
 // updated saved-query row plus the resolved folder reference so the sidebar
 // tree can patch state without a follow-up GET.
-async function moveSavedQuery(savedQueryId, { ownerId, folderId }) {
+export async function moveSavedQuery(savedQueryId: string, { ownerId, folderId }: MoveSavedQueryInput): Promise<ServiceResult<MoveSavedQueryResult, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -366,13 +442,13 @@ async function moveSavedQuery(savedQueryId, { ownerId, folderId }) {
     return failure(401, { error: "unauthenticated" });
   }
   const folderValidation = normalizeParentId(folderId);
-  if (!folderValidation.ok) {
+  if (folderValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: folderValidation.message.replace("parent_id", "folder_id") });
   }
 
   // Load the saved query and verify ownership. Folders are per-owner so a
   // recipient of a share grant cannot relocate someone else's query.
-  const queryRow = await appDb.query(
+  const queryRow = await appDb.query<{ id: string; owner_id: string; folder_id: string | null }>(
     `SELECT id, owner_id, folder_id FROM saved_queries WHERE id = $1`,
     [savedQueryId]
   );
@@ -384,7 +460,7 @@ async function moveSavedQuery(savedQueryId, { ownerId, folderId }) {
     return failure(403, { error: "forbidden", message: "Only the owner can move this saved query" });
   }
 
-  let resolvedFolderId = null;
+  let resolvedFolderId: string | null = null;
   if (folderValidation.value) {
     const folder = await loadFolder(folderValidation.value);
     if (!folder) {
@@ -426,13 +502,3 @@ async function moveSavedQuery(savedQueryId, { ownerId, folderId }) {
     folder_id: resolvedFolderId
   });
 }
-
-module.exports = {
-  createFolder,
-  listFolders,
-  updateFolder,
-  deleteFolder,
-  moveSavedQuery,
-  FOLDER_NAME_MAX_LENGTH,
-  MAX_FOLDER_DEPTH
-};

--- a/app/src/services/savedQueryScheduleService.ts
+++ b/app/src/services/savedQueryScheduleService.ts
@@ -10,17 +10,27 @@
 // are the owner's responsibility. Shared/granted recipients cannot schedule
 // other people's queries, matching the QUERY-006 share semantics.
 
-const appDb = require("../lib/appDb");
-const { isUuid } = require("../lib/validation");
-const { isCronExpressionValid, isTimezoneValid, computeNextRun } = require("./cronExpression");
-const { SUPPORTED_FORMATS } = require("./exportService");
-const { sendExportEmail } = require("./emailService");
-const { createDatabaseAdapter, isSupportedDbType } = require("../adapters/dbAdapterFactory");
-const { ensureLimit, sanitizeGeneratedSql, validateAndNormalizeSql } = require("./sqlSafety");
-const {
+import appDb = require("../lib/appDb");
+import { isUuid } from "../lib/validation";
+import { isCronExpressionValid, isTimezoneValid, computeNextRun } from "./cronExpression";
+import { SUPPORTED_FORMATS } from "./exportService";
+import emailService = require("./emailService");
+import { createDatabaseAdapter, isSupportedDbType } from "../adapters/dbAdapterFactory";
+import { ensureLimit, sanitizeGeneratedSql, validateAndNormalizeSql } from "./sqlSafety";
+import {
   validateParameterValues,
   substitutePlaceholdersForValidation
-} = require("./queryParameterService");
+} from "./queryParameterService";
+import type {
+  SavedQueryScheduleDeliveryMode,
+  SavedQueryScheduleFormat,
+  SavedQueryScheduleStatus,
+  SavedQueryScheduleRunStatus,
+  SavedQuerySchedule,
+  SavedQueryScheduleRun,
+  SavedQueryParameter
+} from "../types/domain";
+import type { ParameterSchemaEntry } from "./queryParameterParser";
 
 const SCHEDULE_COLUMNS = `
   id,
@@ -59,23 +69,65 @@ const RUN_COLUMNS = `
   error_message
 `;
 
-const ALLOWED_DELIVERY_MODES = new Set(["email", "download_artifact"]);
-const ALLOWED_FORMATS = new Set(["json", "csv", "tsv", "xlsx", "parquet"]);
-const ALLOWED_STATUSES = new Set(["active", "paused"]);
+const ALLOWED_DELIVERY_MODES: ReadonlySet<SavedQueryScheduleDeliveryMode> = new Set<SavedQueryScheduleDeliveryMode>(["email", "download_artifact"]);
+const ALLOWED_FORMATS: ReadonlySet<SavedQueryScheduleFormat> = new Set<SavedQueryScheduleFormat>(["json", "csv", "tsv", "xlsx", "parquet"]);
+const ALLOWED_STATUSES: ReadonlySet<SavedQueryScheduleStatus> = new Set<SavedQueryScheduleStatus>(["active", "paused"]);
 const MAX_RECIPIENTS = 25;
 const MAX_NAME_LENGTH = 200;
-const MAX_ATTEMPTS = 3;
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const MAX_ATTEMPTS = 3;
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-function success(body, statusCode = 200) {
+export interface ServiceSuccess<T> {
+  ok: true;
+  statusCode: number;
+  body: T;
+}
+export interface ServiceFailure<T = unknown> {
+  ok: false;
+  statusCode: number;
+  body: T;
+}
+export type ServiceResult<TSuccess, TFailure = unknown> = ServiceSuccess<TSuccess> | ServiceFailure<TFailure>;
+
+interface ErrorBody {
+  error: string;
+  message?: string;
+}
+
+function success<T>(body: T, statusCode = 200): ServiceSuccess<T> {
   return { ok: true, statusCode, body };
 }
-function failure(statusCode, body) {
+function failure<T>(statusCode: number, body: T): ServiceFailure<T> {
   return { ok: false, statusCode, body };
 }
 
-async function loadSavedQuery(savedQueryId) {
-  const result = await appDb.query(
+interface SavedQueryRow {
+  id: string;
+  owner_id: string;
+  sql: string;
+  data_source_id: string;
+  default_run_params: Record<string, unknown>;
+  parameter_schema: ParameterSchemaEntry[];
+}
+
+interface ExecutableSavedQueryRow extends SavedQueryRow {
+  name: string;
+  description: string | null;
+  tags: string[];
+  visibility: string;
+  created_at: string | Date;
+  updated_at: string | Date;
+  connection_ref: string;
+  db_type: string;
+}
+
+interface SchemaObjectMinimal {
+  schema_name: string;
+  object_name: string;
+}
+
+async function loadSavedQuery(savedQueryId: string): Promise<SavedQueryRow | null> {
+  const result = await appDb.query<SavedQueryRow>(
     `SELECT id, owner_id, sql, data_source_id, default_run_params, parameter_schema
        FROM saved_queries WHERE id = $1`,
     [savedQueryId]
@@ -83,15 +135,19 @@ async function loadSavedQuery(savedQueryId) {
   return result.rows[0] || null;
 }
 
-async function loadSchedule(scheduleId) {
-  const result = await appDb.query(
+async function loadSchedule(scheduleId: string): Promise<SavedQuerySchedule | null> {
+  const result = await appDb.query<SavedQuerySchedule>(
     `SELECT ${SCHEDULE_COLUMNS} FROM saved_query_schedules WHERE id = $1`,
     [scheduleId]
   );
   return result.rows[0] || null;
 }
 
-function normalizeRecipients(value, deliveryMode) {
+type ValidationOk<T> = { ok: true; value: T };
+type ValidationErr = { ok: false; message: string };
+type Validation<T> = ValidationOk<T> | ValidationErr;
+
+function normalizeRecipients(value: unknown, deliveryMode: SavedQueryScheduleDeliveryMode | string): Validation<string[]> {
   if (value === undefined || value === null) {
     if (deliveryMode === "email") {
       return { ok: false, message: "recipients are required for email delivery" };
@@ -101,8 +157,8 @@ function normalizeRecipients(value, deliveryMode) {
   if (!Array.isArray(value)) {
     return { ok: false, message: "recipients must be an array of email strings" };
   }
-  const cleaned = [];
-  const seen = new Set();
+  const cleaned: string[] = [];
+  const seen = new Set<string>();
   for (const entry of value) {
     if (typeof entry !== "string") {
       return { ok: false, message: "recipients must be an array of email strings" };
@@ -126,7 +182,7 @@ function normalizeRecipients(value, deliveryMode) {
   return { ok: true, value: cleaned };
 }
 
-function normalizeParameterOverrides(value) {
+function normalizeParameterOverrides(value: unknown): Validation<Record<string, unknown>> {
   if (value === undefined || value === null) {
     return { ok: true, value: {} };
   }
@@ -141,35 +197,50 @@ function normalizeParameterOverrides(value) {
   } catch {
     return { ok: false, message: "parameter_overrides is not JSON-serialisable" };
   }
-  return { ok: true, value };
+  return { ok: true, value: value as Record<string, unknown> };
 }
 
-function validateSchedulePayload(payload, { isUpdate = false } = {}) {
-  const out = {};
-  if (!isUpdate || payload.name !== undefined) {
-    if (typeof payload.name !== "string" || !payload.name.trim()) {
+interface ValidatedSchedulePayload {
+  name?: string;
+  cron_expression?: string;
+  timezone?: string;
+  delivery_mode?: SavedQueryScheduleDeliveryMode;
+  format?: SavedQueryScheduleFormat;
+  recipients?: string[];
+  parameter_overrides?: Record<string, unknown>;
+  status?: SavedQueryScheduleStatus;
+}
+
+export type ValidateSchedulePayloadResult = Validation<ValidatedSchedulePayload>;
+
+export function validateSchedulePayload(payload: Record<string, unknown> | null | undefined, { isUpdate = false }: { isUpdate?: boolean } = {}): ValidateSchedulePayloadResult {
+  const out: ValidatedSchedulePayload = {};
+  const input = (payload || {}) as Record<string, unknown>;
+
+  if (!isUpdate || input.name !== undefined) {
+    if (typeof input.name !== "string" || !input.name.trim()) {
       return { ok: false, message: "name is required" };
     }
-    if (payload.name.length > MAX_NAME_LENGTH) {
+    if (input.name.length > MAX_NAME_LENGTH) {
       return { ok: false, message: `name cannot exceed ${MAX_NAME_LENGTH} characters` };
     }
-    out.name = payload.name.trim();
+    out.name = input.name.trim();
   }
-  if (!isUpdate || payload.cron_expression !== undefined) {
-    if (!isCronExpressionValid(payload.cron_expression)) {
+  if (!isUpdate || input.cron_expression !== undefined) {
+    if (!isCronExpressionValid(input.cron_expression)) {
       return { ok: false, message: "cron_expression is not a valid 5-field cron" };
     }
-    out.cron_expression = String(payload.cron_expression).trim().replace(/\s+/g, " ");
+    out.cron_expression = String(input.cron_expression).trim().replace(/\s+/g, " ");
   }
-  if (!isUpdate || payload.timezone !== undefined) {
-    const tz = payload.timezone === undefined ? "UTC" : payload.timezone;
+  if (!isUpdate || input.timezone !== undefined) {
+    const tz = input.timezone === undefined ? "UTC" : input.timezone;
     if (!isTimezoneValid(tz)) {
       return { ok: false, message: `timezone is not a valid IANA name: ${tz}` };
     }
     out.timezone = tz;
   }
-  if (!isUpdate || payload.delivery_mode !== undefined) {
-    const mode = payload.delivery_mode === undefined ? "email" : payload.delivery_mode;
+  if (!isUpdate || input.delivery_mode !== undefined) {
+    const mode = (input.delivery_mode === undefined ? "email" : input.delivery_mode) as SavedQueryScheduleDeliveryMode;
     if (!ALLOWED_DELIVERY_MODES.has(mode)) {
       return {
         ok: false,
@@ -178,26 +249,26 @@ function validateSchedulePayload(payload, { isUpdate = false } = {}) {
     }
     out.delivery_mode = mode;
   }
-  if (!isUpdate || payload.format !== undefined) {
-    const fmt = payload.format === undefined ? "csv" : payload.format;
+  if (!isUpdate || input.format !== undefined) {
+    const fmt = (input.format === undefined ? "csv" : input.format) as SavedQueryScheduleFormat;
     if (!ALLOWED_FORMATS.has(fmt) || !SUPPORTED_FORMATS.has(fmt)) {
       return { ok: false, message: `format must be one of: ${[...ALLOWED_FORMATS].join(", ")}` };
     }
     out.format = fmt;
   }
-  if (!isUpdate || payload.recipients !== undefined) {
-    const deliveryMode = out.delivery_mode || payload.delivery_mode || "email";
-    const recipients = normalizeRecipients(payload.recipients, deliveryMode);
-    if (!recipients.ok) return recipients;
+  if (!isUpdate || input.recipients !== undefined) {
+    const deliveryMode = out.delivery_mode || (input.delivery_mode as SavedQueryScheduleDeliveryMode | undefined) || "email";
+    const recipients = normalizeRecipients(input.recipients, deliveryMode);
+    if (recipients.ok !== true) return { ok: false, message: recipients.message };
     out.recipients = recipients.value;
   }
-  if (!isUpdate || payload.parameter_overrides !== undefined) {
-    const overrides = normalizeParameterOverrides(payload.parameter_overrides);
-    if (!overrides.ok) return overrides;
+  if (!isUpdate || input.parameter_overrides !== undefined) {
+    const overrides = normalizeParameterOverrides(input.parameter_overrides);
+    if (overrides.ok !== true) return { ok: false, message: overrides.message };
     out.parameter_overrides = overrides.value;
   }
-  if (!isUpdate || payload.status !== undefined) {
-    const status = payload.status === undefined ? "active" : payload.status;
+  if (!isUpdate || input.status !== undefined) {
+    const status = (input.status === undefined ? "active" : input.status) as SavedQueryScheduleStatus;
     if (!ALLOWED_STATUSES.has(status)) {
       return { ok: false, message: `status must be one of: ${[...ALLOWED_STATUSES].join(", ")}` };
     }
@@ -206,7 +277,11 @@ function validateSchedulePayload(payload, { isUpdate = false } = {}) {
   return { ok: true, value: out };
 }
 
-async function createSchedule(savedQueryId, payload, { callerUserId }) {
+export interface CallerOptions {
+  callerUserId?: string | null;
+}
+
+export async function createSchedule(savedQueryId: string, payload: Record<string, unknown> | null | undefined, { callerUserId }: CallerOptions): Promise<ServiceResult<SavedQuerySchedule, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -224,7 +299,7 @@ async function createSchedule(savedQueryId, payload, { callerUserId }) {
     });
   }
   const validation = validateSchedulePayload(payload, { isUpdate: false });
-  if (!validation.ok) {
+  if (validation.ok !== true) {
     return failure(400, { error: "bad_request", message: validation.message });
   }
   const v = validation.value;
@@ -232,9 +307,9 @@ async function createSchedule(savedQueryId, payload, { callerUserId }) {
   // next matching minute and not retroactively for past minutes.
   const nextRunAt = v.status === "paused"
     ? null
-    : computeNextRun(v.cron_expression, v.timezone, new Date());
+    : computeNextRun(v.cron_expression!, v.timezone!, new Date());
 
-  const result = await appDb.query(
+  const result = await appDb.query<SavedQuerySchedule>(
     `
       INSERT INTO saved_query_schedules (
         saved_query_id, owner_user_id, name, cron_expression, timezone,
@@ -261,7 +336,11 @@ async function createSchedule(savedQueryId, payload, { callerUserId }) {
   return success(result.rows[0], 201);
 }
 
-async function listSchedules(savedQueryId, { callerUserId }) {
+interface ScheduleWithRuns extends SavedQuerySchedule {
+  recent_runs: SavedQueryScheduleRun[];
+}
+
+export async function listSchedules(savedQueryId: string, { callerUserId }: CallerOptions): Promise<ServiceResult<{ items: ScheduleWithRuns[] }, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -277,7 +356,7 @@ async function listSchedules(savedQueryId, { callerUserId }) {
       message: "Only the owner can view schedules for this saved query"
     });
   }
-  const result = await appDb.query(
+  const result = await appDb.query<SavedQuerySchedule>(
     `SELECT ${SCHEDULE_COLUMNS} FROM saved_query_schedules
       WHERE saved_query_id = $1
       ORDER BY created_at ASC`,
@@ -287,7 +366,7 @@ async function listSchedules(savedQueryId, { callerUserId }) {
   // "last delivered" / retry context without a second round trip.
   if (result.rows.length === 0) return success({ items: [] });
   const scheduleIds = result.rows.map((row) => row.id);
-  const runsResult = await appDb.query(
+  const runsResult = await appDb.query<SavedQueryScheduleRun>(
     `
       SELECT ${RUN_COLUMNS}
         FROM saved_query_schedule_runs
@@ -297,20 +376,20 @@ async function listSchedules(savedQueryId, { callerUserId }) {
     `,
     [scheduleIds]
   );
-  const runsBySchedule = new Map();
+  const runsBySchedule = new Map<string, SavedQueryScheduleRun[]>();
   for (const run of runsResult.rows) {
     if (!runsBySchedule.has(run.schedule_id)) runsBySchedule.set(run.schedule_id, []);
-    const list = runsBySchedule.get(run.schedule_id);
+    const list = runsBySchedule.get(run.schedule_id)!;
     if (list.length < 10) list.push(run);
   }
-  const items = result.rows.map((row) => ({
+  const items: ScheduleWithRuns[] = result.rows.map((row) => ({
     ...row,
     recent_runs: runsBySchedule.get(row.id) || []
   }));
   return success({ items });
 }
 
-async function updateSchedule(savedQueryId, scheduleId, payload, { callerUserId }) {
+export async function updateSchedule(savedQueryId: string, scheduleId: string, payload: Record<string, unknown> | null | undefined, { callerUserId }: CallerOptions): Promise<ServiceResult<SavedQuerySchedule, ErrorBody>> {
   if (!isUuid(savedQueryId) || !isUuid(scheduleId)) {
     return failure(400, { error: "bad_request", message: "Both ids must be valid UUIDs" });
   }
@@ -328,7 +407,7 @@ async function updateSchedule(savedQueryId, scheduleId, payload, { callerUserId 
   if (!existing || existing.saved_query_id !== savedQueryId) {
     return failure(404, { error: "not_found", message: "Schedule not found" });
   }
-  const merged = {
+  const merged: Record<string, unknown> = {
     name: existing.name,
     cron_expression: existing.cron_expression,
     timezone: existing.timezone,
@@ -337,16 +416,16 @@ async function updateSchedule(savedQueryId, scheduleId, payload, { callerUserId 
     format: existing.format,
     parameter_overrides: existing.parameter_overrides,
     status: existing.status,
-    ...payload
+    ...(payload || {})
   };
   const validation = validateSchedulePayload(merged, { isUpdate: false });
-  if (!validation.ok) {
+  if (validation.ok !== true) {
     return failure(400, { error: "bad_request", message: validation.message });
   }
   const v = validation.value;
   // Recompute next_run_at whenever cron / timezone / status changes, or when
   // resuming from paused. Always recompute on edit to keep semantics simple.
-  let nextRunAt = existing.next_run_at;
+  let nextRunAt: Date | string | null = existing.next_run_at;
   if (v.status === "paused") {
     nextRunAt = null;
   } else if (
@@ -355,10 +434,10 @@ async function updateSchedule(savedQueryId, scheduleId, payload, { callerUserId 
     || existing.status === "paused"
     || nextRunAt === null
   ) {
-    nextRunAt = computeNextRun(v.cron_expression, v.timezone, new Date());
+    nextRunAt = computeNextRun(v.cron_expression!, v.timezone!, new Date());
   }
 
-  const result = await appDb.query(
+  const result = await appDb.query<SavedQuerySchedule>(
     `
       UPDATE saved_query_schedules
          SET name = $2,
@@ -390,7 +469,7 @@ async function updateSchedule(savedQueryId, scheduleId, payload, { callerUserId 
   return success(result.rows[0]);
 }
 
-async function deleteSchedule(savedQueryId, scheduleId, { callerUserId }) {
+export async function deleteSchedule(savedQueryId: string, scheduleId: string, { callerUserId }: CallerOptions): Promise<ServiceResult<{ ok: true; id: string }, ErrorBody>> {
   if (!isUuid(savedQueryId) || !isUuid(scheduleId)) {
     return failure(400, { error: "bad_request", message: "Both ids must be valid UUIDs" });
   }
@@ -408,18 +487,18 @@ async function deleteSchedule(savedQueryId, scheduleId, { callerUserId }) {
   if (!existing || existing.saved_query_id !== savedQueryId) {
     return failure(404, { error: "not_found", message: "Schedule not found" });
   }
-  const result = await appDb.query(
+  const result = await appDb.query<{ id: string }>(
     `DELETE FROM saved_query_schedules WHERE id = $1 RETURNING id`,
     [scheduleId]
   );
   if (result.rowCount === 0) {
     return failure(404, { error: "not_found", message: "Schedule not found" });
   }
-  return success({ ok: true, id: result.rows[0].id });
+  return success({ ok: true as const, id: result.rows[0].id });
 }
 
-async function loadSavedQueryForExecution(savedQueryId) {
-  const result = await appDb.query(
+async function loadSavedQueryForExecution(savedQueryId: string): Promise<ExecutableSavedQueryRow | null> {
+  const result = await appDb.query<ExecutableSavedQueryRow>(
     `
       SELECT
         sq.id,
@@ -445,8 +524,8 @@ async function loadSavedQueryForExecution(savedQueryId) {
   return result.rows[0] || null;
 }
 
-async function loadSchemaObjects(dataSourceId) {
-  const result = await appDb.query(
+async function loadSchemaObjects(dataSourceId: string): Promise<SchemaObjectMinimal[]> {
+  const result = await appDb.query<SchemaObjectMinimal>(
     `
       SELECT schema_name, object_name
       FROM schema_objects
@@ -459,10 +538,17 @@ async function loadSchemaObjects(dataSourceId) {
   return result.rows;
 }
 
+interface RenderedExport {
+  buffer: Buffer;
+  contentType: string;
+  filename: string;
+  rowCount: number;
+}
+
 // Execute the saved query with the schedule's parameter overrides, render the
 // chosen format, and return a buffer+filename. Mirrors the manual /run + /export
 // path but is self-contained so manual flows stay untouched.
-async function runScheduledQuery(savedQueryId, parameterOverrides, format) {
+async function runScheduledQuery(savedQueryId: string, parameterOverrides: Record<string, unknown>, format: SavedQueryScheduleFormat): Promise<RenderedExport> {
   const savedQuery = await loadSavedQueryForExecution(savedQueryId);
   if (!savedQuery) {
     throw new Error(`Saved query not found: ${savedQueryId}`);
@@ -474,21 +560,22 @@ async function runScheduledQuery(savedQueryId, parameterOverrides, format) {
     savedQuery.parameter_schema,
     parameterOverrides || {}
   );
-  if (!parameterValidation.ok) {
+  if (parameterValidation.ok !== true) {
     throw new Error(
-      `Invalid scheduled parameters: ${parameterValidation.errors.map((e) => e.message || e).join("; ")}`
+      `Invalid scheduled parameters: ${parameterValidation.errors.map((e) => e.message || String(e)).join("; ")}`
     );
   }
   const dialect = savedQuery.db_type === "mssql" ? "mssql" : "postgres";
+  const defaults = (savedQuery.default_run_params || {}) as { max_rows?: number; timeout_ms?: number };
   const maxRows = Math.min(
-    Number(savedQuery.default_run_params?.max_rows) > 0
-      ? Number(savedQuery.default_run_params.max_rows)
+    Number(defaults.max_rows) > 0
+      ? Number(defaults.max_rows)
       : 10000,
     100000
   );
   const timeoutMs = Math.min(
-    Number(savedQuery.default_run_params?.timeout_ms) > 0
-      ? Number(savedQuery.default_run_params.timeout_ms)
+    Number(defaults.timeout_ms) > 0
+      ? Number(defaults.timeout_ms)
       : 60000,
     120000
   );
@@ -503,9 +590,9 @@ async function runScheduledQuery(savedQueryId, parameterOverrides, format) {
   if (!normalized.ok) {
     throw new Error(`SQL safety check failed: ${normalized.errors.join("; ")}`);
   }
-  let adapter = null;
-  let rows;
-  let columns;
+  let adapter: ReturnType<typeof createDatabaseAdapter> | null = null;
+  let rows: Record<string, unknown>[];
+  let columns: string[];
   try {
     adapter = createDatabaseAdapter(savedQuery.db_type, savedQuery.connection_ref);
     const adapterValidation = await adapter.validateSql(normalized.sql);
@@ -530,12 +617,12 @@ async function runScheduledQuery(savedQueryId, parameterOverrides, format) {
 // through exportService.exportQueryResult, because that helper rehydrates from
 // a query_session that scheduled runs do not have. Same dependencies, same
 // supported formats.
-async function renderExportInline(rows, columns, queryName, format) {
-  const { stringify } = require("csv-stringify/sync");
-  const xlsx = require("xlsx");
+async function renderExportInline(rows: Record<string, unknown>[], columns: string[] | undefined, queryName: string, format: SavedQueryScheduleFormat): Promise<RenderedExport> {
+  const { stringify } = require("csv-stringify/sync") as typeof import("csv-stringify/sync");
+  const xlsx = require("xlsx") as typeof import("xlsx");
   const safeName = String(queryName || "scheduled_report").replace(/[^a-z0-9]/gi, "_").slice(0, 50);
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const columnOrder = Array.isArray(columns) && columns.length > 0
+  const columnOrder: string[] = Array.isArray(columns) && columns.length > 0
     ? columns
     : (rows[0] ? Object.keys(rows[0]) : []);
 
@@ -582,28 +669,28 @@ async function renderExportInline(rows, columns, queryName, format) {
       };
     }
     const parquet = require("parquetjs-lite");
-    const fs = require("fs/promises");
-    const os = require("os");
-    const path = require("path");
-    const schemaDefinition = {};
+    const fs = require("fs/promises") as typeof import("fs/promises");
+    const os = require("os") as typeof import("os");
+    const path = require("path") as typeof import("path");
+    const schemaDefinition: Record<string, { type: string; optional: boolean }> = {};
     for (const column of columnOrder) {
       schemaDefinition[column] = { type: "UTF8", optional: true };
     }
     const schema = new parquet.ParquetSchema(schemaDefinition);
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "report-pilot-schedule-"));
     const filePath = path.join(tempDir, `export-${Date.now()}.parquet`);
-    let writer;
+    let writer: { appendRow: (row: Record<string, unknown>) => Promise<void>; close: () => Promise<void> } | null = null;
     try {
       writer = await parquet.ParquetWriter.openFile(schema, filePath);
       for (const row of rows) {
-        const normalizedRow = {};
+        const normalizedRow: Record<string, string | null> = {};
         for (const column of columnOrder) {
           const v = row[column];
           normalizedRow[column] = v === null || v === undefined ? null : String(v);
         }
-        await writer.appendRow(normalizedRow);
+        await writer!.appendRow(normalizedRow);
       }
-      await writer.close();
+      await writer!.close();
       writer = null;
       const buffer = await fs.readFile(filePath);
       return {
@@ -625,12 +712,25 @@ async function renderExportInline(rows, columns, queryName, format) {
   };
 }
 
+export interface DispatchScheduleOptions {
+  scheduledFor?: Date | string | null;
+  attempt?: number;
+}
+
+export interface DispatchScheduleResult {
+  ok: boolean;
+  runId: string;
+  filename?: string;
+  rowCount?: number;
+  error?: string;
+}
+
 // One full dispatch: insert a run row, attempt delivery, update both the run +
 // the schedule's next_run_at. Used by the dispatcher and by the retry endpoint.
-async function dispatchSchedule(schedule, { scheduledFor = null, attempt = 1 } = {}) {
+export async function dispatchSchedule(schedule: SavedQuerySchedule, { scheduledFor = null, attempt = 1 }: DispatchScheduleOptions = {}): Promise<DispatchScheduleResult> {
   const now = new Date();
   const runScheduledFor = scheduledFor || schedule.next_run_at || now;
-  const runResult = await appDb.query(
+  const runResult = await appDb.query<SavedQueryScheduleRun>(
     `
       INSERT INTO saved_query_schedule_runs (
         schedule_id, saved_query_id, scheduled_for, started_at, status, attempt,
@@ -661,7 +761,7 @@ async function dispatchSchedule(schedule, { scheduledFor = null, attempt = 1 } =
       schedule.format
     );
     if (schedule.delivery_mode === "email") {
-      await sendExportEmail({
+      await emailService.sendExportEmail({
         recipients: schedule.recipients,
         subject: `Report Pilot Scheduled Report: ${schedule.name}`,
         textBody:
@@ -706,7 +806,7 @@ async function dispatchSchedule(schedule, { scheduledFor = null, attempt = 1 } =
     );
     return { ok: true, runId: run.id, filename: rendered.filename, rowCount: rendered.rowCount };
   } catch (err) {
-    const errMessage = err && err.message ? String(err.message).slice(0, 2000) : "unknown error";
+    const errMessage = (err && (err as Error).message) ? String((err as Error).message).slice(0, 2000) : "unknown error";
     await appDb.query(
       `
         UPDATE saved_query_schedule_runs
@@ -736,8 +836,8 @@ async function dispatchSchedule(schedule, { scheduledFor = null, attempt = 1 } =
   }
 }
 
-async function listDueSchedules(now = new Date(), limit = 50) {
-  const result = await appDb.query(
+export async function listDueSchedules(now: Date = new Date(), limit = 50): Promise<SavedQuerySchedule[]> {
+  const result = await appDb.query<SavedQuerySchedule>(
     `
       SELECT ${SCHEDULE_COLUMNS}
         FROM saved_query_schedules
@@ -752,12 +852,18 @@ async function listDueSchedules(now = new Date(), limit = 50) {
   return result.rows;
 }
 
+interface RetryFailedRunResult {
+  ok: boolean;
+  run_id: string;
+  error: string | null;
+}
+
 // Manual retry: re-dispatch the latest run for this schedule. Bumps the
 // `attempt` counter so the runs table reflects the retry chain. Capped at
 // MAX_ATTEMPTS attempts to keep an owner from looping indefinitely on a
 // permanently-broken target — they can edit the schedule (recipients, SQL,
 // etc.) to reset the chain.
-async function retryFailedRun(savedQueryId, scheduleId, { callerUserId }) {
+export async function retryFailedRun(savedQueryId: string, scheduleId: string, { callerUserId }: CallerOptions): Promise<ServiceResult<RetryFailedRunResult, ErrorBody>> {
   if (!isUuid(savedQueryId) || !isUuid(scheduleId)) {
     return failure(400, { error: "bad_request", message: "Both ids must be valid UUIDs" });
   }
@@ -772,7 +878,7 @@ async function retryFailedRun(savedQueryId, scheduleId, { callerUserId }) {
   if (!schedule || schedule.saved_query_id !== savedQueryId) {
     return failure(404, { error: "not_found", message: "Schedule not found" });
   }
-  const latest = await appDb.query(
+  const latest = await appDb.query<{ attempt: number; status: SavedQueryScheduleRunStatus }>(
     `SELECT attempt, status FROM saved_query_schedule_runs
       WHERE schedule_id = $1 ORDER BY scheduled_for DESC LIMIT 1`,
     [scheduleId]
@@ -788,15 +894,5 @@ async function retryFailedRun(savedQueryId, scheduleId, { callerUserId }) {
   return success({ ok: dispatch.ok, run_id: dispatch.runId, error: dispatch.error || null });
 }
 
-module.exports = {
-  createSchedule,
-  listSchedules,
-  updateSchedule,
-  deleteSchedule,
-  dispatchSchedule,
-  listDueSchedules,
-  retryFailedRun,
-  validateSchedulePayload,
-  EMAIL_REGEX,
-  MAX_ATTEMPTS
-};
+// Mirror the JS shape for type imports; nothing else.
+export type ScheduleParameterSchema = SavedQueryParameter[];

--- a/app/src/services/savedQueryService.ts
+++ b/app/src/services/savedQueryService.ts
@@ -1,35 +1,59 @@
-const appDb = require("../lib/appDb");
-const versionService = require("./savedQueryVersionService");
-const {
+import appDb = require("../lib/appDb");
+import * as versionService from "./savedQueryVersionService";
+import type { SavedQuerySnapshot, SavedQueryVersionRow } from "./savedQueryVersionService";
+import {
   SAVED_QUERY_NAME_MAX_LENGTH,
   SAVED_QUERY_DESCRIPTION_MAX_LENGTH,
   SAVED_QUERY_TAG_MAX_LENGTH,
   SAVED_QUERY_MAX_TAGS
-} = require("../lib/constants");
-const {
+} from "../lib/constants";
+import {
   clamp,
   isUuid,
   isPgUniqueViolation,
   normalizeOptionalTrimmedString,
-  validateSavedQueryDefaultRunParams
-} = require("../lib/validation");
-const { createDatabaseAdapter, isSupportedDbType } = require("../adapters/dbAdapterFactory");
-const { validateAndNormalizeSql, sanitizeGeneratedSql, ensureLimit } = require("./sqlSafety");
-const {
+  validateSavedQueryDefaultRunParams,
+  type SavedQueryDefaultRunParams
+} from "../lib/validation";
+import { createDatabaseAdapter, isSupportedDbType } from "../adapters/dbAdapterFactory";
+import { validateAndNormalizeSql, sanitizeGeneratedSql, ensureLimit } from "./sqlSafety";
+import {
   extractPlaceholders,
-  buildParameterSchemaFromPlaceholders
-} = require("./queryParameterParser");
-const {
+  buildParameterSchemaFromPlaceholders,
+  type ParameterSchemaEntry
+} from "./queryParameterParser";
+import {
   validateParameterSchema,
   validateParameterValues,
   substitutePlaceholdersForValidation
-} = require("./queryParameterService");
+} from "./queryParameterService";
+import type { SavedQueryVisibility } from "../types/domain";
 
-function success(body, statusCode = 200) {
+export interface ServiceSuccess<T> {
+  ok: true;
+  statusCode: number;
+  body: T;
+}
+export interface ServiceFailure<T = unknown> {
+  ok: false;
+  statusCode: number;
+  body: T;
+}
+export type ServiceResult<TSuccess, TFailure = unknown> =
+  | ServiceSuccess<TSuccess>
+  | ServiceFailure<TFailure>;
+
+interface ErrorBody {
+  error: string;
+  message?: string;
+  errors?: unknown;
+}
+
+function success<T>(body: T, statusCode = 200): ServiceSuccess<T> {
   return { ok: true, statusCode, body };
 }
 
-function failure(statusCode, body) {
+function failure<T>(statusCode: number, body: T): ServiceFailure<T> {
   return { ok: false, statusCode, body };
 }
 
@@ -49,10 +73,52 @@ const SAVED_QUERY_COLUMNS = `
   updated_at
 `;
 
-const ALLOWED_VISIBILITY = new Set(["private", "shared"]);
-const ALLOWED_SHARE_PERMISSIONS = new Set(["view", "run"]);
+const ALLOWED_VISIBILITY: ReadonlySet<SavedQueryVisibility> = new Set<SavedQueryVisibility>(["private", "shared"]);
+export type SharePermission = "view" | "run";
+const ALLOWED_SHARE_PERMISSIONS: ReadonlySet<SharePermission> = new Set<SharePermission>(["view", "run"]);
 
-function normalizeTags(value) {
+export interface SavedQueryRow {
+  id: string;
+  owner_id: string;
+  name: string;
+  description: string | null;
+  data_source_id: string;
+  sql: string;
+  default_run_params: Record<string, unknown>;
+  parameter_schema: ParameterSchemaEntry[];
+  tags: string[];
+  visibility: SavedQueryVisibility;
+  folder_id: string | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+}
+
+interface ExecutableSavedQueryRow extends Omit<SavedQueryRow, "folder_id"> {
+  connection_ref: string;
+  db_type: string;
+}
+
+interface SchemaObjectMinimal {
+  schema_name: string;
+  object_name: string;
+}
+
+interface ShareRow {
+  saved_query_id: string;
+  user_id: string;
+  permission: SharePermission;
+  granted_by_user_id: string | null;
+  created_at: string | Date;
+}
+
+interface ShareGrant {
+  user_id: string;
+  permission: SharePermission;
+}
+
+type Validation<T> = { ok: true; value: T } | { ok: false; message: string };
+
+function normalizeTags(value: unknown): Validation<string[]> {
   if (value === undefined || value === null) {
     return { ok: true, value: [] };
   }
@@ -60,8 +126,8 @@ function normalizeTags(value) {
     return { ok: false, message: "tags must be an array of strings" };
   }
 
-  const seen = new Set();
-  const tags = [];
+  const seen = new Set<string>();
+  const tags: string[] = [];
   for (const entry of value) {
     if (typeof entry !== "string") {
       return { ok: false, message: "tags must be an array of strings" };
@@ -90,21 +156,21 @@ function normalizeTags(value) {
   return { ok: true, value: tags };
 }
 
-async function ensureDataSourceExists(dataSourceId) {
+async function ensureDataSourceExists(dataSourceId: string): Promise<boolean> {
   const sourceResult = await appDb.query("SELECT id FROM data_sources WHERE id = $1", [dataSourceId]);
-  return sourceResult.rowCount > 0;
+  return (sourceResult.rowCount ?? 0) > 0;
 }
 
-async function loadSavedQuery(savedQueryId) {
-  const result = await appDb.query(
+async function loadSavedQuery(savedQueryId: string): Promise<SavedQueryRow | null> {
+  const result = await appDb.query<SavedQueryRow>(
     `SELECT ${SAVED_QUERY_COLUMNS} FROM saved_queries WHERE id = $1`,
     [savedQueryId]
   );
   return result.rows[0] || null;
 }
 
-async function loadSavedQueryForExecution(savedQueryId) {
-  const result = await appDb.query(
+async function loadSavedQueryForExecution(savedQueryId: string): Promise<ExecutableSavedQueryRow | null> {
+  const result = await appDb.query<ExecutableSavedQueryRow>(
     `
       SELECT
         sq.id,
@@ -131,8 +197,8 @@ async function loadSavedQueryForExecution(savedQueryId) {
   return result.rows[0] || null;
 }
 
-async function loadSchemaObjects(dataSourceId) {
-  const result = await appDb.query(
+async function loadSchemaObjects(dataSourceId: string): Promise<SchemaObjectMinimal[]> {
+  const result = await appDb.query<SchemaObjectMinimal>(
     `
       SELECT schema_name, object_name
       FROM schema_objects
@@ -145,7 +211,11 @@ async function loadSchemaObjects(dataSourceId) {
   return result.rows;
 }
 
-function resolveParameterSchema(sql, providedParameterSchema, existingSchema) {
+function resolveParameterSchema(
+  sql: string,
+  providedParameterSchema: unknown,
+  existingSchema: ParameterSchemaEntry[] | unknown[]
+): Validation<ParameterSchemaEntry[]> {
   const placeholders = extractPlaceholders(sql);
 
   if (providedParameterSchema === undefined) {
@@ -166,10 +236,16 @@ function resolveParameterSchema(sql, providedParameterSchema, existingSchema) {
   };
 }
 
-function resolveRunOptions(defaultRunParams, requested) {
-  const merged = {
-    max_rows: defaultRunParams?.max_rows,
-    timeout_ms: defaultRunParams?.timeout_ms
+interface ResolvedRunOptions {
+  maxRows: number;
+  timeoutMs: number;
+}
+
+function resolveRunOptions(defaultRunParams: SavedQueryDefaultRunParams | Record<string, unknown> | null | undefined, requested?: { maxRows?: unknown; timeoutMs?: unknown }): ResolvedRunOptions {
+  const params = (defaultRunParams || {}) as Record<string, unknown>;
+  const merged: { max_rows?: unknown; timeout_ms?: unknown } = {
+    max_rows: params.max_rows,
+    timeout_ms: params.timeout_ms
   };
 
   if (requested && Object.prototype.hasOwnProperty.call(requested, "maxRows") && requested.maxRows !== undefined) {
@@ -188,7 +264,11 @@ function resolveRunOptions(defaultRunParams, requested) {
   };
 }
 
-async function getSavedQuery(savedQueryId, { callerUserId } = {}) {
+export interface CallerOptions {
+  callerUserId?: string | null;
+}
+
+export async function getSavedQuery(savedQueryId: string, { callerUserId }: CallerOptions = {}): Promise<ServiceResult<SavedQueryRow, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -205,7 +285,11 @@ async function getSavedQuery(savedQueryId, { callerUserId } = {}) {
   return success(savedQuery);
 }
 
-async function listSavedQueries(dataSourceId, tag, { callerUserId } = {}) {
+export interface ListSavedQueriesResult {
+  items: SavedQueryRow[];
+}
+
+export async function listSavedQueries(dataSourceId: unknown, tag: unknown, { callerUserId }: CallerOptions = {}): Promise<ServiceResult<ListSavedQueriesResult, ErrorBody>> {
   const filter = typeof dataSourceId === "string" ? dataSourceId.trim() : "";
   if (filter && !isUuid(filter)) {
     return failure(400, { error: "bad_request", message: "data_source_id must be a valid UUID" });
@@ -226,7 +310,7 @@ async function listSavedQueries(dataSourceId, tag, { callerUserId } = {}) {
   // The data-source-access filter still runs in the route layer so an admin
   // doesn't suddenly leak queries from sources they were never granted.
   if (callerUserId) {
-    const result = await appDb.query(
+    const result = await appDb.query<SavedQueryRow>(
       `
         SELECT ${SAVED_QUERY_COLUMNS}
         FROM saved_queries sq
@@ -247,7 +331,7 @@ async function listSavedQueries(dataSourceId, tag, { callerUserId } = {}) {
     return success({ items: result.rows });
   }
 
-  const result = await appDb.query(
+  const result = await appDb.query<SavedQueryRow>(
     `
       SELECT ${SAVED_QUERY_COLUMNS}
       FROM saved_queries
@@ -261,15 +345,27 @@ async function listSavedQueries(dataSourceId, tag, { callerUserId } = {}) {
   return success({ items: result.rows });
 }
 
-function normalizeVisibility(value, fallback = "private") {
+function normalizeVisibility(value: unknown, fallback: SavedQueryVisibility = "private"): Validation<SavedQueryVisibility> {
   if (value === undefined) return { ok: true, value: fallback };
-  if (typeof value !== "string" || !ALLOWED_VISIBILITY.has(value)) {
+  if (typeof value !== "string" || !ALLOWED_VISIBILITY.has(value as SavedQueryVisibility)) {
     return { ok: false, message: `visibility must be one of: ${[...ALLOWED_VISIBILITY].join(", ")}` };
   }
-  return { ok: true, value };
+  return { ok: true, value: value as SavedQueryVisibility };
 }
 
-async function createSavedQuery({
+export interface CreateSavedQueryInput {
+  ownerId?: string | null;
+  name?: unknown;
+  description?: unknown;
+  dataSourceId?: unknown;
+  sql?: unknown;
+  defaultRunParams?: unknown;
+  parameterSchema?: unknown;
+  tags?: unknown;
+  visibility?: unknown;
+}
+
+export async function createSavedQuery({
   ownerId,
   name,
   description,
@@ -279,7 +375,7 @@ async function createSavedQuery({
   parameterSchema,
   tags,
   visibility
-}) {
+}: CreateSavedQueryInput): Promise<ServiceResult<SavedQueryRow, ErrorBody>> {
   const trimmedOwnerId = String(ownerId || "anonymous").trim() || "anonymous";
   const trimmedDataSourceId = String(dataSourceId || "").trim();
   const trimmedName = typeof name === "string" ? name.trim() : "";
@@ -308,16 +404,16 @@ async function createSavedQuery({
       message: `description cannot exceed ${SAVED_QUERY_DESCRIPTION_MAX_LENGTH} characters`
     });
   }
-  if (!defaultRunParamsValidation.ok) {
+  if (defaultRunParamsValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: defaultRunParamsValidation.message });
   }
-  if (!parameterSchemaValidation.ok) {
+  if (parameterSchemaValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: parameterSchemaValidation.message });
   }
-  if (!tagsValidation.ok) {
+  if (tagsValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: tagsValidation.message });
   }
-  if (!visibilityValidation.ok) {
+  if (visibilityValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: visibilityValidation.message });
   }
 
@@ -326,7 +422,7 @@ async function createSavedQuery({
   }
 
   try {
-    const insertResult = await appDb.query(
+    const insertResult = await appDb.query<SavedQueryRow>(
       `
         INSERT INTO saved_queries (
           owner_id,
@@ -357,7 +453,7 @@ async function createSavedQuery({
     const created = insertResult.rows[0];
     await versionService.recordVersion(
       created.id,
-      versionService.snapshotFromSavedQuery(created),
+      versionService.snapshotFromSavedQuery(created) as SavedQuerySnapshot,
       { actorUserId: isUuid(trimmedOwnerId) ? trimmedOwnerId : null, changeSummary: "created" }
     );
     return success(created, 201);
@@ -372,7 +468,11 @@ async function createSavedQuery({
   }
 }
 
-async function updateSavedQuery(savedQueryId, {
+export interface UpdateSavedQueryInput extends CreateSavedQueryInput {
+  callerUserId?: string | null;
+}
+
+export async function updateSavedQuery(savedQueryId: string, {
   name,
   description,
   dataSourceId,
@@ -382,7 +482,7 @@ async function updateSavedQuery(savedQueryId, {
   tags,
   visibility,
   callerUserId
-}) {
+}: UpdateSavedQueryInput): Promise<ServiceResult<SavedQueryRow, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -401,7 +501,7 @@ async function updateSavedQuery(savedQueryId, {
   const normalizedDescription = normalizeOptionalTrimmedString(description);
   const defaultRunParamsValidation = validateSavedQueryDefaultRunParams(defaultRunParams);
   const parameterSchemaValidation = resolveParameterSchema(trimmedSql, parameterSchema, existing.parameter_schema);
-  const tagsValidation = tags === undefined
+  const tagsValidation: Validation<string[]> = tags === undefined
     ? { ok: true, value: existing.tags || [] }
     : normalizeTags(tags);
   const visibilityValidation = normalizeVisibility(visibility, existing.visibility || "private");
@@ -424,16 +524,16 @@ async function updateSavedQuery(savedQueryId, {
       message: `description cannot exceed ${SAVED_QUERY_DESCRIPTION_MAX_LENGTH} characters`
     });
   }
-  if (!defaultRunParamsValidation.ok) {
+  if (defaultRunParamsValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: defaultRunParamsValidation.message });
   }
-  if (!parameterSchemaValidation.ok) {
+  if (parameterSchemaValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: parameterSchemaValidation.message });
   }
-  if (!tagsValidation.ok) {
+  if (tagsValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: tagsValidation.message });
   }
-  if (!visibilityValidation.ok) {
+  if (visibilityValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: visibilityValidation.message });
   }
 
@@ -442,7 +542,7 @@ async function updateSavedQuery(savedQueryId, {
   }
 
   try {
-    const updateResult = await appDb.query(
+    const updateResult = await appDb.query<SavedQueryRow>(
       `
         UPDATE saved_queries
         SET
@@ -474,7 +574,7 @@ async function updateSavedQuery(savedQueryId, {
     const updated = updateResult.rows[0];
     await versionService.recordVersion(
       updated.id,
-      versionService.snapshotFromSavedQuery(updated),
+      versionService.snapshotFromSavedQuery(updated) as SavedQuerySnapshot,
       { actorUserId: callerUserId || null, changeSummary: "updated" }
     );
     return success(updated);
@@ -489,7 +589,7 @@ async function updateSavedQuery(savedQueryId, {
   }
 }
 
-async function deleteSavedQuery(savedQueryId, { callerUserId } = {}) {
+export async function deleteSavedQuery(savedQueryId: string, { callerUserId }: CallerOptions = {}): Promise<ServiceResult<{ ok: true; id: string }, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -504,7 +604,7 @@ async function deleteSavedQuery(savedQueryId, { callerUserId } = {}) {
     }
   }
 
-  const deleteResult = await appDb.query(
+  const deleteResult = await appDb.query<{ id: string }>(
     `DELETE FROM saved_queries WHERE id = $1 RETURNING id`,
     [savedQueryId]
   );
@@ -513,22 +613,24 @@ async function deleteSavedQuery(savedQueryId, { callerUserId } = {}) {
     return failure(404, { error: "not_found", message: "Saved query not found" });
   }
 
-  return success({ ok: true, id: deleteResult.rows[0].id });
+  return success({ ok: true as const, id: deleteResult.rows[0].id });
 }
 
-async function loadShareRecord(savedQueryId, userId) {
+async function loadShareRecord(savedQueryId: string, userId: string): Promise<{ permission: SharePermission } | null> {
   if (!isUuid(savedQueryId) || !userId) return null;
-  const result = await appDb.query(
+  const result = await appDb.query<{ permission: SharePermission }>(
     `SELECT permission FROM saved_query_shares WHERE saved_query_id = $1 AND user_id = $2`,
     [savedQueryId, userId]
   );
   return result.rows[0] || null;
 }
 
+export type CallerAccess = "owner" | SharePermission | null;
+
 // Effective access for the caller. Owner is always full. Visibility 'shared'
 // gives view; explicit share row gives view-or-run. Returns one of:
 // 'owner' | 'run' | 'view' | null
-async function resolveCallerAccess(savedQuery, callerUserId) {
+export async function resolveCallerAccess(savedQuery: Pick<SavedQueryRow, "id" | "owner_id" | "visibility"> | null, callerUserId: string | null | undefined): Promise<CallerAccess> {
   if (!savedQuery) return null;
   if (!callerUserId) return null;
   if (savedQuery.owner_id === callerUserId) return "owner";
@@ -538,7 +640,13 @@ async function resolveCallerAccess(savedQuery, callerUserId) {
   return null;
 }
 
-async function validateSavedQueryParams(savedQueryId, providedParams, { callerUserId } = {}) {
+interface ValidateParamsBody {
+  ok: boolean;
+  errors?: unknown[];
+  resolved_values?: Record<string, unknown>;
+}
+
+export async function validateSavedQueryParams(savedQueryId: string, providedParams: unknown, { callerUserId }: CallerOptions = {}): Promise<ServiceResult<ValidateParamsBody, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -555,14 +663,29 @@ async function validateSavedQueryParams(savedQueryId, providedParams, { callerUs
   }
 
   const validation = validateParameterValues(savedQuery.parameter_schema, providedParams);
-  if (!validation.ok) {
+  if (validation.ok !== true) {
     return success({ ok: false, errors: validation.errors });
   }
 
   return success({ ok: true, resolved_values: validation.resolvedValues });
 }
 
-async function executeSavedQuery(savedQueryId, { params, maxRows, timeoutMs, callerUserId } = {}) {
+export interface ExecuteSavedQueryInput {
+  params?: unknown;
+  maxRows?: unknown;
+  timeoutMs?: unknown;
+  callerUserId?: string | null;
+}
+
+export interface ExecuteSavedQueryResult {
+  sql: string;
+  columns: string[];
+  rows: Record<string, unknown>[];
+  row_count: number;
+  duration_ms: number;
+}
+
+export async function executeSavedQuery(savedQueryId: string, { params, maxRows, timeoutMs, callerUserId }: ExecuteSavedQueryInput = {}): Promise<ServiceResult<ExecuteSavedQueryResult, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -572,7 +695,10 @@ async function executeSavedQuery(savedQueryId, { params, maxRows, timeoutMs, cal
     return failure(404, { error: "not_found", message: "Saved query not found" });
   }
   if (callerUserId) {
-    const access = await resolveCallerAccess(savedQuery, callerUserId);
+    const access = await resolveCallerAccess(
+      { id: savedQuery.id, owner_id: savedQuery.owner_id, visibility: savedQuery.visibility },
+      callerUserId
+    );
     if (!access || access === "view") {
       return failure(403, {
         error: "forbidden",
@@ -590,7 +716,7 @@ async function executeSavedQuery(savedQueryId, { params, maxRows, timeoutMs, cal
   }
 
   const parameterValidation = validateParameterValues(savedQuery.parameter_schema, params);
-  if (!parameterValidation.ok) {
+  if (parameterValidation.ok !== true) {
     return failure(400, {
       error: "bad_request",
       message: "Invalid saved query parameters",
@@ -620,7 +746,7 @@ async function executeSavedQuery(savedQueryId, { params, maxRows, timeoutMs, cal
     });
   }
 
-  let adapter = null;
+  let adapter: ReturnType<typeof createDatabaseAdapter> | null = null;
   try {
     adapter = createDatabaseAdapter(savedQuery.db_type, savedQuery.connection_ref);
     const adapterValidation = await adapter.validateSql(normalized.sql);
@@ -653,8 +779,8 @@ async function executeSavedQuery(savedQueryId, { params, maxRows, timeoutMs, cal
   }
 }
 
-async function listSharesForQuery(savedQueryId) {
-  const result = await appDb.query(
+async function listSharesForQuery(savedQueryId: string): Promise<ShareRow[]> {
+  const result = await appDb.query<ShareRow>(
     `
       SELECT saved_query_id, user_id, permission, granted_by_user_id, created_at
       FROM saved_query_shares
@@ -666,18 +792,19 @@ async function listSharesForQuery(savedQueryId) {
   return result.rows;
 }
 
-function normalizeShareGrants(grants) {
+function normalizeShareGrants(grants: unknown): Validation<ShareGrant[] | undefined> {
   if (grants === undefined) return { ok: true, value: undefined };
   if (!Array.isArray(grants)) {
     return { ok: false, message: "shares must be an array" };
   }
-  const seen = new Set();
-  const normalized = [];
+  const seen = new Set<string>();
+  const normalized: ShareGrant[] = [];
   for (const entry of grants) {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
       return { ok: false, message: "each share entry must be an object" };
     }
-    const userId = typeof entry.user_id === "string" ? entry.user_id.trim() : "";
+    const record = entry as Record<string, unknown>;
+    const userId = typeof record.user_id === "string" ? record.user_id.trim() : "";
     if (!isUuid(userId)) {
       return { ok: false, message: "each share entry must include a user_id UUID" };
     }
@@ -685,23 +812,40 @@ function normalizeShareGrants(grants) {
       return { ok: false, message: `duplicate share entry for user ${userId}` };
     }
     seen.add(userId);
-    const permission = typeof entry.permission === "string" ? entry.permission : "";
-    if (!ALLOWED_SHARE_PERMISSIONS.has(permission)) {
+    const permission = typeof record.permission === "string" ? record.permission : "";
+    if (!ALLOWED_SHARE_PERMISSIONS.has(permission as SharePermission)) {
       return {
         ok: false,
         message: `permission must be one of: ${[...ALLOWED_SHARE_PERMISSIONS].join(", ")}`
       };
     }
-    normalized.push({ user_id: userId, permission });
+    normalized.push({ user_id: userId, permission: permission as SharePermission });
   }
   return { ok: true, value: normalized };
+}
+
+export interface ShareSavedQueryInput {
+  callerUserId?: string | null;
+  visibility?: unknown;
+  shares?: unknown;
+}
+
+export interface ShareSavedQueryResult {
+  visibility: SavedQueryVisibility;
+  previous_visibility: SavedQueryVisibility;
+  shares: ShareRow[];
+  diff: {
+    added: ShareGrant[];
+    updated: Array<ShareGrant & { previous_permission: SharePermission }>;
+    removed: ShareGrant[];
+  };
 }
 
 // Replace-semantics: the body's `shares` array fully replaces whatever
 // rows exist for this query. Pass `shares: []` to revoke everyone.
 // Visibility is optional and only changed when present in the body.
 // Returns the new access summary plus a diff so callers can audit each change.
-async function shareSavedQuery(savedQueryId, { callerUserId, visibility, shares } = {}) {
+export async function shareSavedQuery(savedQueryId: string, { callerUserId, visibility, shares }: ShareSavedQueryInput = {}): Promise<ServiceResult<ShareSavedQueryResult, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -718,20 +862,20 @@ async function shareSavedQuery(savedQueryId, { callerUserId, visibility, shares 
   }
 
   const visibilityValidation = visibility === undefined
-    ? { ok: true, value: existing.visibility || "private" }
+    ? { ok: true as const, value: (existing.visibility || "private") as SavedQueryVisibility }
     : normalizeVisibility(visibility, existing.visibility || "private");
-  if (!visibilityValidation.ok) {
+  if (visibilityValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: visibilityValidation.message });
   }
 
   const sharesValidation = normalizeShareGrants(shares);
-  if (!sharesValidation.ok) {
+  if (sharesValidation.ok !== true) {
     return failure(400, { error: "bad_request", message: sharesValidation.message });
   }
 
   const previousVisibility = existing.visibility || "private";
   const previousShares = await listSharesForQuery(savedQueryId);
-  const previousByUser = new Map(previousShares.map((row) => [row.user_id, row.permission]));
+  const previousByUser = new Map<string, SharePermission>(previousShares.map((row) => [row.user_id, row.permission]));
 
   if (visibility !== undefined && visibilityValidation.value !== previousVisibility) {
     await appDb.query(
@@ -740,12 +884,12 @@ async function shareSavedQuery(savedQueryId, { callerUserId, visibility, shares 
     );
   }
 
-  const added = [];
-  const updated = [];
-  const removed = [];
+  const added: ShareGrant[] = [];
+  const updated: Array<ShareGrant & { previous_permission: SharePermission }> = [];
+  const removed: ShareGrant[] = [];
 
   if (sharesValidation.value !== undefined) {
-    const nextByUser = new Map(sharesValidation.value.map((row) => [row.user_id, row.permission]));
+    const nextByUser = new Map<string, SharePermission>(sharesValidation.value.map((row) => [row.user_id, row.permission]));
 
     for (const [userId, permission] of nextByUser) {
       const prev = previousByUser.get(userId);
@@ -789,7 +933,14 @@ async function shareSavedQuery(savedQueryId, { callerUserId, visibility, shares 
   });
 }
 
-async function getSavedQueryAccess(savedQueryId, { callerUserId } = {}) {
+export interface SavedQueryAccessResult {
+  saved_query_id: string;
+  owner_id: string;
+  visibility: SavedQueryVisibility;
+  shares: ShareRow[];
+}
+
+export async function getSavedQueryAccess(savedQueryId: string, { callerUserId }: CallerOptions = {}): Promise<ServiceResult<SavedQueryAccessResult, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -812,7 +963,7 @@ async function getSavedQueryAccess(savedQueryId, { callerUserId } = {}) {
   });
 }
 
-async function listSavedQueryVersions(savedQueryId, { callerUserId } = {}) {
+export async function listSavedQueryVersions(savedQueryId: string, { callerUserId }: CallerOptions = {}): Promise<ServiceResult<{ items: SavedQueryVersionRow[] }, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -830,7 +981,13 @@ async function listSavedQueryVersions(savedQueryId, { callerUserId } = {}) {
   return success({ items: versions });
 }
 
-async function restoreSavedQueryVersion(savedQueryId, versionId, { callerUserId } = {}) {
+export interface RestoreVersionResult {
+  saved_query: SavedQueryRow;
+  restored_from_version_number: number;
+  new_version: SavedQueryVersionRow;
+}
+
+export async function restoreSavedQueryVersion(savedQueryId: string, versionId: string, { callerUserId }: CallerOptions = {}): Promise<ServiceResult<RestoreVersionResult, ErrorBody>> {
   if (!isUuid(savedQueryId)) {
     return failure(400, { error: "bad_request", message: "savedQueryId must be a valid UUID" });
   }
@@ -853,7 +1010,7 @@ async function restoreSavedQueryVersion(savedQueryId, versionId, { callerUserId 
   // UPDATE shape so visibility/tags/parameter_schema all flow through the
   // existing column list. The restore itself becomes a new version row so
   // the timeline reads top-to-bottom.
-  const updateResult = await appDb.query(
+  const updateResult = await appDb.query<SavedQueryRow>(
     `
       UPDATE saved_queries
       SET
@@ -885,7 +1042,7 @@ async function restoreSavedQueryVersion(savedQueryId, versionId, { callerUserId 
 
   const newVersion = await versionService.recordVersion(
     savedQueryId,
-    versionService.snapshotFromSavedQuery(restored),
+    versionService.snapshotFromSavedQuery(restored) as SavedQuerySnapshot,
     {
       actorUserId: callerUserId || null,
       changeSummary: `restored from version ${version.version_number}`
@@ -898,18 +1055,3 @@ async function restoreSavedQueryVersion(savedQueryId, versionId, { callerUserId 
     new_version: newVersion
   });
 }
-
-module.exports = {
-  getSavedQuery,
-  listSavedQueries,
-  createSavedQuery,
-  updateSavedQuery,
-  deleteSavedQuery,
-  validateSavedQueryParams,
-  executeSavedQuery,
-  shareSavedQuery,
-  getSavedQueryAccess,
-  listSavedQueryVersions,
-  restoreSavedQueryVersion,
-  resolveCallerAccess
-};

--- a/app/src/services/savedQueryVersionService.ts
+++ b/app/src/services/savedQueryVersionService.ts
@@ -6,8 +6,10 @@
 // surface serialises edits per saved_query (one HTTP request at a time),
 // collisions are unlikely in practice, but the retry loop keeps it safe.
 
-const appDb = require("../lib/appDb");
-const { isUuid, isPgUniqueViolation } = require("../lib/validation");
+import appDb = require("../lib/appDb");
+import { isUuid, isPgUniqueViolation } from "../lib/validation";
+import type { SavedQueryVisibility } from "../types/domain";
+import type { ParameterSchemaEntry } from "./queryParameterParser";
 
 const VERSION_COLUMNS = `
   id,
@@ -26,7 +28,54 @@ const VERSION_COLUMNS = `
   created_at
 `;
 
-function snapshotFromSavedQuery(savedQuery) {
+export interface SavedQuerySnapshot {
+  name: string;
+  description: string | null;
+  data_source_id: string;
+  sql: string;
+  default_run_params: Record<string, unknown>;
+  parameter_schema: ParameterSchemaEntry[];
+  tags: string[];
+  visibility: SavedQueryVisibility;
+}
+
+export interface SavedQueryVersionRow {
+  id: string;
+  saved_query_id: string;
+  version_number: number;
+  name: string;
+  description: string | null;
+  data_source_id: string;
+  sql: string;
+  default_run_params: Record<string, unknown>;
+  parameter_schema: ParameterSchemaEntry[];
+  tags: string[];
+  visibility: SavedQueryVisibility;
+  change_summary: string | null;
+  created_by_user_id: string | null;
+  created_at: string | Date;
+}
+
+export interface RecordVersionOptions {
+  actorUserId?: string | null;
+  changeSummary?: string | null;
+}
+
+/**
+ * Build a snapshot payload from a live saved-query row. Defensive about
+ * missing/nullable fields so callers can pass either the OpenAPI shape or
+ * the raw DB row.
+ */
+export function snapshotFromSavedQuery(savedQuery: {
+  name: string;
+  description?: string | null;
+  data_source_id: string;
+  sql: string;
+  default_run_params?: Record<string, unknown> | null;
+  parameter_schema?: ParameterSchemaEntry[] | null;
+  tags?: string[] | null;
+  visibility?: SavedQueryVisibility | null;
+}): SavedQuerySnapshot {
   return {
     name: savedQuery.name,
     description: savedQuery.description ?? null,
@@ -39,17 +88,21 @@ function snapshotFromSavedQuery(savedQuery) {
   };
 }
 
-async function nextVersionNumber(savedQueryId) {
-  const result = await appDb.query(
+async function nextVersionNumber(savedQueryId: string): Promise<number> {
+  const result = await appDb.query<{ max_version: number | string | null }>(
     `SELECT COALESCE(MAX(version_number), 0) AS max_version
        FROM saved_query_versions
       WHERE saved_query_id = $1`,
     [savedQueryId]
   );
-  return (result.rows[0]?.max_version ?? 0) + 1;
+  return Number(result.rows[0]?.max_version ?? 0) + 1;
 }
 
-async function recordVersion(savedQueryId, snapshot, { actorUserId = null, changeSummary = null } = {}) {
+export async function recordVersion(
+  savedQueryId: string,
+  snapshot: SavedQuerySnapshot,
+  { actorUserId = null, changeSummary = null }: RecordVersionOptions = {}
+): Promise<SavedQueryVersionRow> {
   if (!isUuid(savedQueryId)) {
     throw new Error("recordVersion: savedQueryId must be a UUID");
   }
@@ -63,7 +116,7 @@ async function recordVersion(savedQueryId, snapshot, { actorUserId = null, chang
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const versionNumber = await nextVersionNumber(savedQueryId);
     try {
-      const result = await appDb.query(
+      const result = await appDb.query<SavedQueryVersionRow>(
         `
           INSERT INTO saved_query_versions (
             saved_query_id,
@@ -111,8 +164,8 @@ async function recordVersion(savedQueryId, snapshot, { actorUserId = null, chang
   throw new Error("recordVersion: failed to claim a version_number after retries");
 }
 
-async function listVersions(savedQueryId) {
-  const result = await appDb.query(
+export async function listVersions(savedQueryId: string): Promise<SavedQueryVersionRow[]> {
+  const result = await appDb.query<SavedQueryVersionRow>(
     `
       SELECT ${VERSION_COLUMNS}
         FROM saved_query_versions
@@ -124,17 +177,10 @@ async function listVersions(savedQueryId) {
   return result.rows;
 }
 
-async function getVersionById(versionId) {
-  const result = await appDb.query(
+export async function getVersionById(versionId: string): Promise<SavedQueryVersionRow | null> {
+  const result = await appDb.query<SavedQueryVersionRow>(
     `SELECT ${VERSION_COLUMNS} FROM saved_query_versions WHERE id = $1`,
     [versionId]
   );
   return result.rows[0] || null;
 }
-
-module.exports = {
-  snapshotFromSavedQuery,
-  recordVersion,
-  listVersions,
-  getVersionById
-};

--- a/app/src/services/scheduleDispatcher.ts
+++ b/app/src/services/scheduleDispatcher.ts
@@ -16,13 +16,20 @@
 // Disable in tests by leaving `SCHEDULE_DISPATCHER_ENABLED` unset (default
 // "false"). Enable in prod by setting it to "true" in the environment.
 
-const scheduleService = require("./savedQueryScheduleService");
-const { logEvent } = require("../lib/observability");
+import * as scheduleService from "./savedQueryScheduleService";
+import { logEvent } from "../lib/observability";
 
-let intervalHandle = null;
+let intervalHandle: NodeJS.Timeout | null = null;
 let runningTick = false;
 
-async function tickOnce() {
+export interface TickResult {
+  skipped?: boolean;
+  dispatched?: number;
+  succeeded?: number;
+  failed?: number;
+}
+
+export async function tickOnce(): Promise<TickResult> {
   if (runningTick) return { skipped: true };
   runningTick = true;
   try {
@@ -42,7 +49,7 @@ async function tickOnce() {
         logEvent("schedule_dispatch_error", {
           schedule_id: schedule.id,
           saved_query_id: schedule.saved_query_id,
-          error: err && err.message ? err.message : String(err)
+          error: (err && (err as Error).message) ? (err as Error).message : String(err)
         }, "error");
       }
     }
@@ -57,12 +64,12 @@ async function tickOnce() {
   }
 }
 
-function startDispatcher({ tickIntervalMs = 60_000 } = {}) {
+export function startDispatcher({ tickIntervalMs = 60_000 }: { tickIntervalMs?: number } = {}): NodeJS.Timeout {
   if (intervalHandle) return intervalHandle;
   intervalHandle = setInterval(() => {
-    tickOnce().catch((err) => {
+    tickOnce().catch((err: unknown) => {
       logEvent("schedule_dispatcher_tick_error", {
-        error: err && err.message ? err.message : String(err)
+        error: (err && (err as Error).message) ? (err as Error).message : String(err)
       }, "error");
     });
   }, tickIntervalMs);
@@ -73,20 +80,13 @@ function startDispatcher({ tickIntervalMs = 60_000 } = {}) {
   return intervalHandle;
 }
 
-function stopDispatcher() {
+export function stopDispatcher(): void {
   if (intervalHandle) {
     clearInterval(intervalHandle);
     intervalHandle = null;
   }
 }
 
-function isEnabled() {
+export function isEnabled(): boolean {
   return String(process.env.SCHEDULE_DISPATCHER_ENABLED || "false") === "true";
 }
-
-module.exports = {
-  startDispatcher,
-  stopDispatcher,
-  tickOnce,
-  isEnabled
-};


### PR DESCRIPTION
Closes #143.

## Summary

Migrates the seven saved-query family services from `.js` to `.ts`:

- `cronExpression`
- `savedQueryVersionService`
- `promptPresetService`
- `savedQueryFolderService`
- `savedQueryService` (~915 lines, the largest backend file)
- `savedQueryScheduleService`
- `scheduleDispatcher`

Each service is now strongly typed. Saved-query row, version, folder, schedule, and prompt-preset shapes are imported from `domain.ts` where present and declared locally otherwise. Validation results use the project's discriminated-union pattern with explicit `=== true` / `!== true` narrowing to play well with the current `strict: false` tsconfig (same convention as `queryParameterService.ts`).

`scheduleService` no longer relies on dynamic `require()` for the cron helpers or `emailService`; both are imported at the top. The dispatcher keeps the in-process polling loop and the `SCHEDULE_DISPATCHER_ENABLED` toggle unchanged.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build:be` succeeds
- [x] Full `npm test` — all 219 tests pass
- [x] Targeted: `cronExpression`, `promptPresets*`, `savedQueries*`, `savedQueryFolders*`, `savedQuerySchedules*`, `savedQueryParametersMigration`

## Out of scope

- Route handlers (TS-014)
- Tests (TS-016)

## Unblocks

- TS-014 (HTTP route handlers can now consume the typed services)