### PR TITLE
TS-015 migrate entry points and ops scripts to TypeScript

### DIFF
--- a/app/src/benchmark/runMvpBenchmark.ts
+++ b/app/src/benchmark/runMvpBenchmark.ts
@@ -1,6 +1,7 @@
-const fs = require("fs/promises");
-const path = require("path");
-const { Client } = require("pg");
+import * as fs from "fs/promises";
+import * as path from "path";
+import { Client } from "pg";
+import { errorMessage } from "../lib/http";
 
 const APP_BASE_URL = String(process.env.BENCHMARK_APP_BASE_URL || "http://localhost:8080").replace(/\/$/, "");
 const BENCHMARK_FILE = process.env.BENCHMARK_FILE || path.join(process.cwd(), "docs", "evals", "dvdrental-mvp-benchmark.json");
@@ -32,18 +33,61 @@ const BLOCKED_SQL_KEYWORDS = [
   "MERGE"
 ];
 
-async function sleep(ms) {
+interface BenchmarkCase {
+  id: string;
+  nl_question: string;
+  oracle_sql: string;
+  result_assertion?: string;
+}
+
+interface RequestJsonResult<T = unknown> {
+  ok: boolean;
+  status: number;
+  payload: T | null;
+}
+
+interface AssertionOutcome {
+  ok: boolean;
+  reason: string | null;
+}
+
+interface CaseResult {
+  id: string;
+  question: string;
+  run_status: number;
+  error: string | null;
+  correct: boolean;
+  mismatch_reason?: string | null;
+  critical_safety_violation: boolean;
+  e2e_latency_ms: number | null;
+  generated_sql?: string | null;
+  provider?: string | null;
+  row_count_generated?: number;
+  row_count_oracle?: number;
+}
+
+interface RunContext {
+  dataSourceId: string;
+  targetClient: Client;
+}
+
+async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function readCases(filePath) {
+async function readCases(filePath: string): Promise<BenchmarkCase[]> {
   const raw = await fs.readFile(filePath, "utf8");
-  const parsed = JSON.parse(raw);
+  const parsed: unknown = JSON.parse(raw);
   if (!Array.isArray(parsed) || parsed.length === 0) {
     throw new Error("Benchmark dataset must be a non-empty JSON array");
   }
 
-  const valid = parsed.filter((item) => item && item.id && item.nl_question && item.oracle_sql);
+  const valid = parsed.filter((item): item is BenchmarkCase => (
+    Boolean(item) && typeof item === "object"
+    && typeof (item as BenchmarkCase).id === "string"
+    && typeof (item as BenchmarkCase).nl_question === "string"
+    && typeof (item as BenchmarkCase).oracle_sql === "string"
+  ));
   if (valid.length === 0) {
     throw new Error("Benchmark dataset does not include valid cases");
   }
@@ -51,9 +95,9 @@ async function readCases(filePath) {
   return BENCHMARK_MAX_CASES > 0 ? valid.slice(0, BENCHMARK_MAX_CASES) : valid;
 }
 
-async function requestJson(method, pathname, body) {
+async function requestJson<T = unknown>(method: string, pathname: string, body?: unknown): Promise<RequestJsonResult<T>> {
   const url = `${APP_BASE_URL}${pathname}`;
-  const init = {
+  const init: RequestInit = {
     method,
     headers: {
       "Content-Type": "application/json"
@@ -67,12 +111,12 @@ async function requestJson(method, pathname, body) {
   const response = await fetch(url, init);
   const text = await response.text();
 
-  let payload = null;
+  let payload: T | null = null;
   if (text) {
     try {
-      payload = JSON.parse(text);
+      payload = JSON.parse(text) as T;
     } catch {
-      payload = { raw: text };
+      payload = { raw: text } as unknown as T;
     }
   }
 
@@ -83,33 +127,44 @@ async function requestJson(method, pathname, body) {
   };
 }
 
-async function ensureDataSourceId() {
+interface DataSourceListItem {
+  id: string;
+  name: string;
+}
+
+async function ensureDataSourceId(): Promise<string> {
   if (BENCHMARK_DATA_SOURCE_ID) {
     return BENCHMARK_DATA_SOURCE_ID;
   }
 
-  const listResponse = await requestJson("GET", "/v1/data-sources");
+  const listResponse = await requestJson<{ items?: DataSourceListItem[] }>("GET", "/v1/data-sources");
   if (listResponse.ok && Array.isArray(listResponse.payload?.items)) {
-    const found = listResponse.payload.items.find((item) => item.name === BENCHMARK_DATA_SOURCE_NAME);
+    const found = listResponse.payload!.items!.find((item) => item.name === BENCHMARK_DATA_SOURCE_NAME);
     if (found?.id) {
       return found.id;
     }
   }
 
-  const createResponse = await requestJson("POST", "/v1/data-sources", {
+  const createResponse = await requestJson<{ id: string }>("POST", "/v1/data-sources", {
     name: BENCHMARK_DATA_SOURCE_NAME,
     db_type: "postgres",
     connection_ref: BENCHMARK_CONNECTION_REF
   });
 
-  if (!createResponse.ok) {
+  if (!createResponse.ok || !createResponse.payload) {
     throw new Error(`Failed to create data source: HTTP ${createResponse.status} ${stringifyPayload(createResponse.payload)}`);
   }
 
   return createResponse.payload.id;
 }
 
-async function ensureIntrospectionReady(dataSourceId) {
+interface SchemaObjectListItem {
+  id: string;
+  schema_name: string;
+  object_name: string;
+}
+
+async function ensureIntrospectionReady(dataSourceId: string): Promise<SchemaObjectListItem[]> {
   const introspectResponse = await requestJson("POST", `/v1/data-sources/${encodeURIComponent(dataSourceId)}/introspect`);
   if (![200, 202].includes(introspectResponse.status)) {
     throw new Error(
@@ -119,13 +174,17 @@ async function ensureIntrospectionReady(dataSourceId) {
 
   const startedAt = Date.now();
   while (Date.now() - startedAt < BENCHMARK_INTROSPECTION_TIMEOUT_MS) {
-    const listObjectsResponse = await requestJson(
+    const listObjectsResponse = await requestJson<{ items?: SchemaObjectListItem[] }>(
       "GET",
       `/v1/schema-objects?data_source_id=${encodeURIComponent(dataSourceId)}`
     );
 
-    if (listObjectsResponse.ok && Array.isArray(listObjectsResponse.payload?.items) && listObjectsResponse.payload.items.length > 0) {
-      return listObjectsResponse.payload.items;
+    if (
+      listObjectsResponse.ok
+      && Array.isArray(listObjectsResponse.payload?.items)
+      && listObjectsResponse.payload!.items!.length > 0
+    ) {
+      return listObjectsResponse.payload!.items!;
     }
 
     await sleep(2000);
@@ -134,8 +193,25 @@ async function ensureIntrospectionReady(dataSourceId) {
   throw new Error(`Timed out waiting for schema introspection after ${BENCHMARK_INTROSPECTION_TIMEOUT_MS}ms`);
 }
 
-async function runCase(caseDef, context) {
-  const sessionResponse = await requestJson("POST", "/v1/query/sessions", {
+interface SessionResponse {
+  session_id?: string;
+}
+
+interface RunResponse {
+  sql?: string;
+  rows?: Array<Record<string, unknown>>;
+  provider?: string;
+}
+
+interface RunBody {
+  max_rows: number;
+  timeout_ms: number;
+  llm_provider?: string;
+  model?: string;
+}
+
+async function runCase(caseDef: BenchmarkCase, context: RunContext): Promise<CaseResult> {
+  const sessionResponse = await requestJson<SessionResponse>("POST", "/v1/query/sessions", {
     data_source_id: context.dataSourceId,
     question: caseDef.nl_question
   });
@@ -165,7 +241,7 @@ async function runCase(caseDef, context) {
     };
   }
 
-  const runBody = {
+  const runBody: RunBody = {
     max_rows: Number.isFinite(BENCHMARK_MAX_ROWS) ? BENCHMARK_MAX_ROWS : 2000,
     timeout_ms: Number.isFinite(BENCHMARK_TIMEOUT_MS) ? BENCHMARK_TIMEOUT_MS : 30000
   };
@@ -177,7 +253,7 @@ async function runCase(caseDef, context) {
   }
 
   const runStartedAt = Date.now();
-  const runResponse = await requestJson("POST", `/v1/query/sessions/${encodeURIComponent(sessionId)}/run`, runBody);
+  const runResponse = await requestJson<RunResponse>("POST", `/v1/query/sessions/${encodeURIComponent(sessionId)}/run`, runBody);
   const e2eLatencyMs = Date.now() - runStartedAt;
 
   if (!runResponse.ok) {
@@ -194,9 +270,9 @@ async function runCase(caseDef, context) {
   }
 
   const generatedSql = String(runResponse.payload?.sql || "");
-  const generatedRows = Array.isArray(runResponse.payload?.rows) ? runResponse.payload.rows : [];
+  const generatedRows = Array.isArray(runResponse.payload?.rows) ? runResponse.payload!.rows! : [];
 
-  let oracleRows;
+  let oracleRows: Array<Record<string, unknown>>;
   try {
     const oracleResult = await context.targetClient.query(caseDef.oracle_sql);
     oracleRows = Array.isArray(oracleResult.rows) ? oracleResult.rows : [];
@@ -205,7 +281,7 @@ async function runCase(caseDef, context) {
       id: caseDef.id,
       question: caseDef.nl_question,
       run_status: 500,
-      error: `oracle_sql_failed: ${err.message}`,
+      error: `oracle_sql_failed: ${errorMessage(err)}`,
       correct: false,
       critical_safety_violation: false,
       e2e_latency_ms: e2eLatencyMs,
@@ -232,7 +308,11 @@ async function runCase(caseDef, context) {
   };
 }
 
-function evaluateAssertion(assertion, generatedRows, oracleRows) {
+function evaluateAssertion(
+  assertion: string,
+  generatedRows: Array<Record<string, unknown>>,
+  oracleRows: Array<Record<string, unknown>>
+): AssertionOutcome {
   if (assertion === "single_value_equal") {
     const generatedValue = firstScalar(generatedRows);
     const oracleValue = firstScalar(oracleRows);
@@ -274,7 +354,7 @@ function evaluateAssertion(assertion, generatedRows, oracleRows) {
   return { ok: true, reason: null };
 }
 
-function firstScalar(rows) {
+function firstScalar(rows: Array<Record<string, unknown>>): unknown {
   if (!Array.isArray(rows) || rows.length === 0) {
     return null;
   }
@@ -286,14 +366,14 @@ function firstScalar(rows) {
   return values.length > 0 ? normalizeScalar(values[0]) : null;
 }
 
-function valuesEqual(a, b) {
+function valuesEqual(a: unknown, b: unknown): boolean {
   if (typeof a === "number" && typeof b === "number") {
     return Math.abs(a - b) <= 0.000001;
   }
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
-function canonicalizeRows(rows) {
+function canonicalizeRows(rows: Array<Record<string, unknown>>): string[] {
   if (!Array.isArray(rows)) {
     return [];
   }
@@ -306,7 +386,7 @@ function canonicalizeRows(rows) {
     .sort();
 }
 
-function normalizeScalar(value) {
+function normalizeScalar(value: unknown): unknown {
   if (value === null || value === undefined) {
     return null;
   }
@@ -330,17 +410,17 @@ function normalizeScalar(value) {
     return trimmed;
   }
   if (typeof value === "object") {
-    const keys = Object.keys(value).sort();
-    const obj = {};
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    const obj: Record<string, unknown> = {};
     for (const key of keys) {
-      obj[key] = normalizeScalar(value[key]);
+      obj[key] = normalizeScalar((value as Record<string, unknown>)[key]);
     }
     return obj;
   }
   return value;
 }
 
-function detectCriticalSafetyViolation(sql) {
+function detectCriticalSafetyViolation(sql: string): boolean {
   const source = String(sql || "").toUpperCase();
   return BLOCKED_SQL_KEYWORDS.some((keyword) => {
     const pattern = new RegExp(`\\b${keyword}\\b`, "i");
@@ -348,18 +428,38 @@ function detectCriticalSafetyViolation(sql) {
   });
 }
 
-function summarizeResults(results) {
+interface BenchmarkSummary {
+  total_cases: number;
+  sql_valid_cases: number;
+  correct_cases: number;
+  critical_safety_violations: number;
+  correctness_rate: number;
+  sql_validation_pass_rate: number;
+  p95_latency_ms: number | null;
+  p50_latency_ms: number | null;
+  average_latency_ms: number | null;
+  release_gates: {
+    correctness_ge_85pct: boolean;
+    critical_safety_violations_eq_0: boolean;
+    p95_latency_le_8s: boolean;
+    sql_validation_pass_rate_ge_98pct: boolean;
+    all_passed: boolean;
+  };
+}
+
+function summarizeResults(results: CaseResult[]): BenchmarkSummary {
   const total = results.length;
   const sqlValid = results.filter((item) => item.run_status === 200).length;
   const correct = results.filter((item) => item.correct).length;
   const safetyViolations = results.filter((item) => item.critical_safety_violation).length;
   const latencies = results
     .map((item) => item.e2e_latency_ms)
-    .filter((value) => Number.isFinite(value));
+    .filter((value): value is number => Number.isFinite(value));
 
   const correctnessRate = ratio(correct, total);
   const sqlValidityRate = ratio(sqlValid, total);
   const p95Latency = percentile(latencies, 0.95);
+  const p50Latency = percentile(latencies, 0.5);
 
   const gates = {
     correctness_ge_85pct: correctnessRate >= 0.85,
@@ -376,7 +476,7 @@ function summarizeResults(results) {
     correctness_rate: round4(correctnessRate),
     sql_validation_pass_rate: round4(sqlValidityRate),
     p95_latency_ms: Number.isFinite(p95Latency) ? Math.round(p95Latency) : null,
-    p50_latency_ms: Number.isFinite(percentile(latencies, 0.5)) ? Math.round(percentile(latencies, 0.5)) : null,
+    p50_latency_ms: Number.isFinite(p50Latency) ? Math.round(p50Latency) : null,
     average_latency_ms: latencies.length > 0 ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : null,
     release_gates: {
       ...gates,
@@ -385,18 +485,18 @@ function summarizeResults(results) {
   };
 }
 
-function ratio(numerator, denominator) {
+function ratio(numerator: number, denominator: number): number {
   if (!denominator) {
     return 0;
   }
   return numerator / denominator;
 }
 
-function round4(value) {
+function round4(value: number): number {
   return Number(Number(value || 0).toFixed(4));
 }
 
-function percentile(values, p) {
+function percentile(values: number[], p: number): number {
   if (!Array.isArray(values) || values.length === 0) {
     return NaN;
   }
@@ -407,7 +507,7 @@ function percentile(values, p) {
   return sorted[idx];
 }
 
-async function fetchObservabilityMetrics() {
+async function fetchObservabilityMetrics(): Promise<unknown> {
   const response = await requestJson("GET", "/v1/observability/metrics");
   if (!response.ok) {
     return {
@@ -417,8 +517,26 @@ async function fetchObservabilityMetrics() {
   return response.payload;
 }
 
-async function publishBenchmarkReport(report) {
-  const response = await requestJson("POST", "/v1/observability/release-gates/report", report);
+interface BenchmarkReport {
+  run_date: string;
+  dataset_file: string;
+  data_source_id: string;
+  provider: string | null;
+  model: string | null;
+  summary: BenchmarkSummary;
+  observability: unknown;
+  cases: CaseResult[];
+}
+
+interface PublishResult {
+  ok: boolean;
+  status?: number;
+  payload?: unknown;
+  error?: string;
+}
+
+async function publishBenchmarkReport(report: BenchmarkReport): Promise<PublishResult> {
+  const response = await requestJson<{ id: string }>("POST", "/v1/observability/release-gates/report", report);
   if (!response.ok) {
     return {
       ok: false,
@@ -432,7 +550,7 @@ async function publishBenchmarkReport(report) {
   };
 }
 
-function buildMarkdownReport(payload) {
+function buildMarkdownReport(payload: BenchmarkReport): string {
   const summary = payload.summary;
   const gates = summary.release_gates;
   const topFailures = payload.cases
@@ -474,11 +592,11 @@ function buildMarkdownReport(payload) {
   ].join("\n");
 }
 
-function gateMark(ok) {
+function gateMark(ok: boolean): string {
   return ok ? "PASS" : "FAIL";
 }
 
-function stringifyPayload(payload) {
+function stringifyPayload(payload: unknown): string {
   if (payload === null || payload === undefined) {
     return "";
   }
@@ -489,14 +607,14 @@ function stringifyPayload(payload) {
   }
 }
 
-function timestampForFile(date = new Date()) {
-  const pad = (n) => String(n).padStart(2, "0");
+function timestampForFile(date: Date = new Date()): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
   return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}-${pad(date.getUTCHours())}${pad(
     date.getUTCMinutes()
   )}${pad(date.getUTCSeconds())}`;
 }
 
-async function main() {
+async function main(): Promise<void> {
   const cases = await readCases(BENCHMARK_FILE);
   const dataSourceId = await ensureDataSourceId();
   await ensureIntrospectionReady(dataSourceId);
@@ -504,21 +622,19 @@ async function main() {
   const targetClient = new Client({ connectionString: BENCHMARK_ORACLE_CONN });
   await targetClient.connect();
 
-  const context = {
+  const context: RunContext = {
     dataSourceId,
     targetClient
   };
 
   const runDate = new Date().toISOString();
-  const results = [];
+  const results: CaseResult[] = [];
 
   try {
     for (const caseDef of cases) {
-      // eslint-disable-next-line no-console
       console.log(`[benchmark] Running ${caseDef.id}: ${caseDef.nl_question}`);
       const result = await runCase(caseDef, context);
       results.push(result);
-      // eslint-disable-next-line no-console
       console.log(
         `[benchmark] ${caseDef.id} status=${result.run_status} correct=${result.correct} latency_ms=${result.e2e_latency_ms ?? "n/a"}`
       );
@@ -528,9 +644,9 @@ async function main() {
   }
 
   const summary = summarizeResults(results);
-  const observability = await fetchObservabilityMetrics().catch((err) => ({ error: err.message }));
+  const observability = await fetchObservabilityMetrics().catch((err: unknown) => ({ error: errorMessage(err) }));
 
-  const report = {
+  const report: BenchmarkReport = {
     run_date: runDate,
     dataset_file: BENCHMARK_FILE,
     data_source_id: dataSourceId,
@@ -549,22 +665,17 @@ async function main() {
   await fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
   await fs.writeFile(markdownPath, `${buildMarkdownReport(report)}\n`, "utf8");
 
-  const publishResult = await publishBenchmarkReport(report).catch((err) => ({ ok: false, error: err.message }));
+  const publishResult = await publishBenchmarkReport(report).catch((err: unknown) => ({ ok: false, error: errorMessage(err) } as PublishResult));
   if (!publishResult.ok) {
-    // eslint-disable-next-line no-console
     console.warn(
       `[benchmark] Could not publish report to API: ${stringifyPayload(publishResult.error || publishResult.payload)}`
     );
   } else {
-    // eslint-disable-next-line no-console
-    console.log(`[benchmark] Published report to API with id=${publishResult.payload.id}`);
+    console.log(`[benchmark] Published report to API with id=${(publishResult.payload as { id?: string } | undefined)?.id}`);
   }
 
-  // eslint-disable-next-line no-console
   console.log(`[benchmark] Report written to ${jsonPath}`);
-  // eslint-disable-next-line no-console
   console.log(`[benchmark] Report written to ${markdownPath}`);
-  // eslint-disable-next-line no-console
   console.log(`[benchmark] Release gates all passed: ${summary.release_gates.all_passed}`);
 
   if (!summary.release_gates.all_passed) {
@@ -572,8 +683,8 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  // eslint-disable-next-line no-console
-  console.error(`[benchmark] Failed: ${err.stack || err.message}`);
+main().catch((err: unknown) => {
+  const e = err as { stack?: string; message?: string };
+  console.error(`[benchmark] Failed: ${e.stack || errorMessage(err)}`);
   process.exit(1);
 });

--- a/app/src/migrate.ts
+++ b/app/src/migrate.ts
@@ -1,20 +1,26 @@
-const fs = require("fs/promises");
-const path = require("path");
-const { Client } = require("pg");
+import * as fs from "fs/promises";
+import * as path from "path";
+import { Client } from "pg";
+import { errorMessage } from "./lib/http";
 
 const MIGRATIONS_DIR = process.env.MIGRATIONS_DIR || path.join(process.cwd(), "db", "migrations");
 const DATABASE_URL = process.env.DATABASE_URL;
 
-async function sleep(ms) {
+export interface RunMigrationsOptions {
+  maxRetries?: number;
+  delayMs?: number;
+}
+
+async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function connectWithRetry(maxRetries = 20, delayMs = 2000) {
+async function connectWithRetry(maxRetries = 20, delayMs = 2000): Promise<Client> {
   if (!DATABASE_URL) {
     throw new Error("DATABASE_URL is not set");
   }
 
-  let lastError;
+  let lastError: unknown;
   for (let attempt = 1; attempt <= maxRetries; attempt += 1) {
     const client = new Client({ connectionString: DATABASE_URL });
     try {
@@ -22,15 +28,15 @@ async function connectWithRetry(maxRetries = 20, delayMs = 2000) {
       return client;
     } catch (err) {
       lastError = err;
-      console.error(`[migrate] DB connection attempt ${attempt}/${maxRetries} failed: ${err.message}`);
+      console.error(`[migrate] DB connection attempt ${attempt}/${maxRetries} failed: ${errorMessage(err)}`);
       await sleep(delayMs);
     }
   }
 
-  throw new Error(`[migrate] Could not connect to database after retries: ${lastError?.message}`);
+  throw new Error(`[migrate] Could not connect to database after retries: ${errorMessage(lastError)}`);
 }
 
-async function ensureMigrationsTable(client) {
+async function ensureMigrationsTable(client: Client): Promise<void> {
   await client.query(`
     CREATE TABLE IF NOT EXISTS schema_migrations (
       name TEXT PRIMARY KEY,
@@ -39,7 +45,7 @@ async function ensureMigrationsTable(client) {
   `);
 }
 
-async function listMigrationFiles() {
+async function listMigrationFiles(): Promise<string[]> {
   const entries = await fs.readdir(MIGRATIONS_DIR, { withFileTypes: true });
   return entries
     .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
@@ -47,12 +53,12 @@ async function listMigrationFiles() {
     .sort();
 }
 
-async function isApplied(client, migrationName) {
+async function isApplied(client: Client, migrationName: string): Promise<boolean> {
   const result = await client.query("SELECT 1 FROM schema_migrations WHERE name = $1", [migrationName]);
-  return result.rowCount > 0;
+  return (result.rowCount ?? 0) > 0;
 }
 
-async function applyMigration(client, migrationName) {
+async function applyMigration(client: Client, migrationName: string): Promise<void> {
   const migrationPath = path.join(MIGRATIONS_DIR, migrationName);
   const sql = await fs.readFile(migrationPath, "utf8");
 
@@ -68,7 +74,7 @@ async function applyMigration(client, migrationName) {
   }
 }
 
-async function runMigrations(options = {}) {
+export async function runMigrations(options: RunMigrationsOptions = {}): Promise<void> {
   const maxRetries = options.maxRetries ?? 20;
   const delayMs = options.delayMs ?? 2000;
   const client = await connectWithRetry(maxRetries, delayMs);
@@ -98,10 +104,8 @@ async function runMigrations(options = {}) {
 }
 
 if (require.main === module) {
-  runMigrations().catch((err) => {
-    console.error(`[migrate] Failed: ${err.message}`);
+  runMigrations().catch((err: unknown) => {
+    console.error(`[migrate] Failed: ${errorMessage(err)}`);
     process.exit(1);
   });
 }
-
-module.exports = { runMigrations };

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -1,50 +1,51 @@
-const http = require("http");
-const { createRequestId, logEvent } = require("./lib/observability");
-const { json, notFound, badRequest, internalError } = require("./lib/http");
-const { PORT } = require("./lib/constants");
-const {
+import * as http from "http";
+import type { IncomingMessage, ServerResponse } from "http";
+import { createRequestId, logEvent } from "./lib/observability";
+import { json, notFound, badRequest, internalError, errorMessage } from "./lib/http";
+import { PORT } from "./lib/constants";
+import {
   serveSwaggerDocs,
   serveOpenApiSpec,
   serveFrontendIndex,
   serveFrontendAsset,
   shouldServeFrontendApp,
   checkDatabase
-} = require("./lib/staticServing");
+} from "./lib/staticServing";
 
 // Route modules
-const {
+import {
   handleCreateDataSource,
   handleListDataSources,
   handleDeleteDataSource,
   handleIntrospect,
   handleImportSchema
-} = require("./routes/dataSources");
-const {
+} from "./routes/dataSources";
+import {
   handleExportDataSource,
   handleImportDataSource
-} = require("./routes/dataSourceExportImport");
-const {
+} from "./routes/dataSourceExportImport";
+import {
   handleListSchemaObjects,
   handlePatchSchemaObject
-} = require("./routes/schema");
-const {
+} from "./routes/schema";
+import {
   handleUpsertSemanticEntity,
   handleUpsertMetricDefinition,
   handleUpsertJoinPolicy
-} = require("./routes/semantic");
-const {
+} from "./routes/semantic";
+import {
   handleListRagNotes,
   handleUpsertRagNote,
   handleDeleteRagNote,
   handleRagReindex
-} = require("./routes/rag");
-const {
+} from "./routes/rag";
+import {
   handleCreateSession,
   handlePromptHistory,
   handleRunSession,
   handleFeedback
-} = require("./routes/query");
-const {
+} from "./routes/query";
+import {
   handleCreateSavedQuery,
   handleListSavedQueries,
   handleGetSavedQuery,
@@ -56,44 +57,44 @@ const {
   handleGetSavedQueryAccess,
   handleListSavedQueryVersions,
   handleRestoreSavedQueryVersion
-} = require("./routes/savedQueries");
-const {
+} from "./routes/savedQueries";
+import {
   handleCreateSavedQueryFolder,
   handleListSavedQueryFolders,
   handleUpdateSavedQueryFolder,
   handleDeleteSavedQueryFolder,
   handleMoveSavedQuery
-} = require("./routes/savedQueryFolders");
-const {
+} from "./routes/savedQueryFolders";
+import {
   handleCreateSchedule,
   handleListSchedules,
   handleUpdateSchedule,
   handleDeleteSchedule,
   handleRetrySchedule
-} = require("./routes/savedQuerySchedules");
-const {
+} from "./routes/savedQuerySchedules";
+import {
   handleExportSession,
   handleExportDeliver,
   handleExportStatus
-} = require("./routes/exportDelivery");
-const {
+} from "./routes/exportDelivery";
+import {
   handleProviderList,
   handleProviderUpsert,
   handleRoutingRuleUpsert,
   handleProviderHealth
-} = require("./routes/providers");
-const {
+} from "./routes/providers";
+import {
   handleObservabilityMetrics,
   handleReleaseGates,
   handleBenchmarkCommand,
   handleCreateBenchmarkReport
-} = require("./routes/observability");
-const {
+} from "./routes/observability";
+import {
   handleLogin,
   handleLogout,
   handleMe
-} = require("./routes/auth");
-const {
+} from "./routes/auth";
+import {
   handleListUsers,
   handleCreateUser,
   handleUpdateUserRoles,
@@ -112,41 +113,54 @@ const {
   handleIssueScimToken,
   handleRevokeScimToken,
   handleListAuditEvents
-} = require("./routes/admin");
-const {
+} from "./routes/admin";
+import {
   handleListEnabledProviders,
   handleStartLogin,
   handleCallback
-} = require("./routes/oidc");
-const {
-  handleGetConfig: handleGetUserConfig,
-  handlePutConfig: handlePutUserConfig
-} = require("./routes/userConfig");
-const {
-  handleList: handleListPromptPresets,
-  handleCreate: handleCreatePromptPreset,
-  handleUpdate: handleUpdatePromptPreset,
-  handleDelete: handleDeletePromptPreset
-} = require("./routes/promptPresets");
-const {
+} from "./routes/oidc";
+import {
+  handleGetConfig as handleGetUserConfig,
+  handlePutConfig as handlePutUserConfig
+} from "./routes/userConfig";
+import {
+  handleList as handleListPromptPresets,
+  handleCreate as handleCreatePromptPreset,
+  handleUpdate as handleUpdatePromptPreset,
+  handleDelete as handleDeletePromptPreset
+} from "./routes/promptPresets";
+import {
   handleServiceProviderConfig,
   handleResourceTypes,
   handleSchemas,
-  handleListUsers: handleScimListUsers,
-  handleCreateUser: handleScimCreateUser,
-  handleGetUser: handleScimGetUser,
-  handleReplaceUser: handleScimReplaceUser,
-  handlePatchUser: handleScimPatchUser,
-  handleDeleteUser: handleScimDeleteUser,
-  handleListGroups: handleScimListGroups,
-  handleCreateOrReplaceGroup: handleScimCreateGroup,
-  handlePatchGroup: handleScimPatchGroup
-} = require("./routes/scim");
-const { findPolicy } = require("./lib/routePolicy");
-const { enforcePolicy } = require("./lib/authGate");
+  handleListUsers as handleScimListUsers,
+  handleCreateUser as handleScimCreateUser,
+  handleGetUser as handleScimGetUser,
+  handleReplaceUser as handleScimReplaceUser,
+  handlePatchUser as handleScimPatchUser,
+  handleDeleteUser as handleScimDeleteUser,
+  handleListGroups as handleScimListGroups,
+  handleCreateOrReplaceGroup as handleScimCreateGroup,
+  handlePatchGroup as handleScimPatchGroup
+} from "./routes/scim";
+import { findPolicy } from "./lib/routePolicy";
+import { enforcePolicy, type AuthedRequest } from "./lib/authGate";
 
-async function routeRequest(req, res) {
-  const requestUrl = new URL(req.url, "http://localhost");
+interface HttpishError {
+  statusCode?: number;
+  message?: string;
+  stack?: string;
+}
+
+function statusCodeFromError(err: unknown): number | null {
+  if (err && typeof err === "object" && typeof (err as HttpishError).statusCode === "number") {
+    return (err as HttpishError).statusCode!;
+  }
+  return null;
+}
+
+async function routeRequest(req: AuthedRequest, res: ServerResponse): Promise<void> {
+  const requestUrl = new URL(req.url ?? "/", "http://localhost");
   const { pathname } = requestUrl;
 
   // AUTH-013: SCIM routes carry their own bearer-token auth gate and do
@@ -159,7 +173,7 @@ async function routeRequest(req, res) {
   // /v1 is handled by the static-asset and frontend-fallback branches.
   if (!isScimPath) {
     if (pathname.startsWith("/v1/")) {
-      const policy = findPolicy(req.method, pathname);
+      const policy = findPolicy(req.method ?? "", pathname);
       if (!policy) {
         return notFound(res);
       }
@@ -171,7 +185,7 @@ async function routeRequest(req, res) {
       // Public surfaces — apply the policy table where one exists (records an
       // audit event for transparency) and otherwise fall through to the static
       // routing below.
-      const policy = findPolicy(req.method, pathname);
+      const policy = findPolicy(req.method ?? "", pathname);
       if (policy && policy.public) {
         await enforcePolicy(req, res, policy);
       }
@@ -616,21 +630,23 @@ async function routeRequest(req, res) {
   }
 
   if (shouldServeFrontendApp(req, pathname)) {
-    return serveFrontendIndex(res);
+    serveFrontendIndex(res);
+    return;
   }
 
   return notFound(res);
 }
 
-function startServer() {
-  const server = http.createServer(async (req, res) => {
+export function startServer(): Promise<http.Server> {
+  const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const authedReq = req as AuthedRequest;
     const startedAt = Date.now();
     const requestId = createRequestId();
-    req.requestId = requestId;
+    authedReq.requestId = requestId;
     res.setHeader("x-request-id", requestId);
 
     // CORS
-    const origin = req.headers.origin || "*";
+    const origin = (req.headers.origin as string | undefined) || "*";
     res.setHeader("Access-Control-Allow-Origin", origin);
     res.setHeader("Access-Control-Allow-Credentials", "true");
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
@@ -670,10 +686,10 @@ function startServer() {
     });
 
     try {
-      await routeRequest(req, res);
+      await routeRequest(authedReq, res);
     } catch (err) {
-      if (err.statusCode === 400) {
-        return badRequest(res, err.message);
+      if (statusCodeFromError(err) === 400) {
+        return badRequest(res, (err as HttpishError).message);
       }
       logEvent(
         "http_error",
@@ -681,8 +697,8 @@ function startServer() {
           request_id: requestId,
           method: req.method,
           path: req.url,
-          error: err.message,
-          stack: err.stack || null
+          error: errorMessage(err),
+          stack: (err as HttpishError).stack || null
         },
         "error"
       );
@@ -698,5 +714,3 @@ function startServer() {
     });
   });
 }
-
-module.exports = { startServer };

--- a/app/src/start.ts
+++ b/app/src/start.ts
@@ -1,8 +1,9 @@
-const { runMigrations } = require("./migrate");
-const { startServer } = require("./server");
-const scheduleDispatcher = require("./services/scheduleDispatcher");
+import { runMigrations } from "./migrate";
+import { startServer } from "./server";
+import * as scheduleDispatcher from "./services/scheduleDispatcher";
+import { errorMessage } from "./lib/http";
 
-async function start() {
+async function start(): Promise<void> {
   console.log("[boot] Running migrations...");
   await runMigrations({ maxRetries: 30, delayMs: 2000 });
 
@@ -19,7 +20,7 @@ async function start() {
   }
 }
 
-start().catch((err) => {
-  console.error(`[boot] Startup failed: ${err.message}`);
+start().catch((err: unknown) => {
+  console.error(`[boot] Startup failed: ${errorMessage(err)}`);
   process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -6,17 +6,18 @@
   "description": "Report Pilot NL to SQL backend (bootstrap runtime)",
   "scripts": {
     "dev:fe": "npm --prefix frontend run dev",
-    "dev:be": "tsx watch app/src/start.js",
+    "dev:be": "tsx watch app/src/start.ts",
     "setup": "npm ci && npm --prefix frontend ci",
     "build:fe": "npm --prefix frontend run build",
     "build:be": "tsc",
     "dev": "concurrently \"npm run dev:fe\" \"npm run dev:be\"",
     "build": "npm run build:fe && npm run build:be",
     "start": "node dist/src/start.js",
-    "migrate": "node app/src/migrate.js",
-    "benchmark:mvp": "node app/src/benchmark/runMvpBenchmark.js",
+    "migrate": "tsx app/src/migrate.ts",
+    "benchmark:mvp": "tsx app/src/benchmark/runMvpBenchmark.ts",
+    "create-user": "tsx scripts/create-user.ts",
     "test": "node --import tsx --test app/test/**/*.test.{js,ts}",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json",
     "types:openapi": "openapi-typescript docs/api/openapi.yaml -o app/src/types/openapi.ts"
   },
   "engines": {

--- a/scripts/create-user.ts
+++ b/scripts/create-user.ts
@@ -2,10 +2,10 @@
 // AUTH-001/AUTH-002: bootstrap a user account (e.g. the initial admin) without
 // going through the admin API. Reads DATABASE_URL from the env.
 //
-// Usage:
-//   node scripts/create-user.js --email alice@example.com --password 'hunter22ok'
-//   node scripts/create-user.js --email alice@example.com --password '...' --display-name 'Alice' --update-if-exists
-//   node scripts/create-user.js --email alice@example.com --password '...' --role analyst --role viewer
+// Usage (run via tsx since this file lives outside the compiled `dist/`):
+//   npx tsx scripts/create-user.ts --email alice@example.com --password 'hunter22ok'
+//   npx tsx scripts/create-user.ts --email alice@example.com --password '...' --display-name 'Alice' --update-if-exists
+//   npx tsx scripts/create-user.ts --email alice@example.com --password '...' --role analyst --role viewer
 //
 // Default role behavior:
 //   * If --role is supplied (one or more), exactly those roles are assigned.
@@ -13,15 +13,23 @@
 //     `admin` role so the system has an initial administrator.
 //   * Otherwise the new user gets the standard default role (`viewer`).
 
-const path = require("path");
-const readline = require("readline");
+import * as readline from "readline";
+import * as authService from "../app/src/services/authService";
+import * as roleService from "../app/src/services/roleService";
+import appDb = require("../app/src/lib/appDb");
+import { errorMessage } from "../app/src/lib/http";
 
-const authService = require(path.resolve(__dirname, "../app/src/services/authService"));
-const roleService = require(path.resolve(__dirname, "../app/src/services/roleService"));
-const appDb = require(path.resolve(__dirname, "../app/src/lib/appDb"));
+interface CliOptions {
+  email?: string;
+  password?: string;
+  displayName?: string;
+  roles: string[];
+  updateIfExists: boolean;
+  help?: boolean;
+}
 
-function parseArgs(argv) {
-  const opts = { updateIfExists: false, roles: [] };
+function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = { updateIfExists: false, roles: [] };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     switch (arg) {
@@ -51,8 +59,8 @@ function parseArgs(argv) {
   return opts;
 }
 
-function printHelp() {
-  process.stdout.write(`Usage: node scripts/create-user.js --email <email> [options]\n\n`
+function printHelp(): void {
+  process.stdout.write(`Usage: npx tsx scripts/create-user.ts --email <email> [options]\n\n`
     + `Options:\n`
     + `  --email <email>        Email address (required)\n`
     + `  --password <pw>        Password. If omitted, you'll be prompted.\n`
@@ -64,12 +72,12 @@ function printHelp() {
     + `  -h, --help             Show this help\n`);
 }
 
-function promptHidden(prompt) {
+function promptHidden(prompt: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    const onData = (char) => {
+    const onData = (char: Buffer | string) => {
       const c = String(char);
-      if (c === "\n" || c === "\r" || c === "") {
+      if (c === "\n" || c === "\r" || c === "") {
         process.stdin.removeListener("data", onData);
         return;
       }
@@ -91,7 +99,38 @@ function promptHidden(prompt) {
   });
 }
 
-async function main() {
+interface ApplyRolesInput {
+  userId: string;
+  roleNames: string[];
+}
+
+async function applyRoles({ userId, roleNames }: ApplyRolesInput): Promise<void> {
+  const currentRoles = await roleService.listRoleNamesForUser(userId);
+  const desired = roleService.uniqueRoleNames(roleNames) || [];
+  const toAssign = desired.filter((name) => !currentRoles.includes(name));
+  const toRevoke = currentRoles.filter((name) => !desired.includes(name));
+  if (toAssign.length === 0 && toRevoke.length === 0) {
+    return;
+  }
+  await appDb.withTransaction(async (client) => {
+    if (toAssign.length > 0) {
+      await roleService.assignRolesByName(client, {
+        userId,
+        roleNames: toAssign,
+        actorUserId: null
+      });
+    }
+    if (toRevoke.length > 0) {
+      await roleService.revokeRolesByName(client, {
+        userId,
+        roleNames: toRevoke,
+        actorUserId: null
+      });
+    }
+  });
+}
+
+async function main(): Promise<void> {
   const opts = parseArgs(process.argv.slice(2));
   if (opts.help) {
     printHelp();
@@ -119,7 +158,7 @@ async function main() {
 
   if (existing) {
     const passwordHash = authService.hashPassword(opts.password);
-    const result = await appDb.query(
+    const result = await appDb.query<{ id: string; email: string }>(
       `
         UPDATE users
         SET password_hash = $1,
@@ -137,27 +176,27 @@ async function main() {
     return;
   }
 
-  const userCountResult = await appDb.query("SELECT COUNT(*)::int AS count FROM users");
+  const userCountResult = await appDb.query<{ count: number }>("SELECT COUNT(*)::int AS count FROM users");
   const hasExistingUsers = userCountResult.rows[0].count > 0;
   const rolesToAssign = opts.roles.length > 0
     ? opts.roles
     : [hasExistingUsers ? roleService.DEFAULT_ROLE : "admin"];
 
   const created = await appDb.withTransaction(async (client) => {
-    const insert = await client.query(
+    const insert = await client.query<{ id: string; email: string }>(
       `
         INSERT INTO users (email, password_hash, display_name)
         VALUES ($1, $2, $3)
         RETURNING id, email
       `,
-      [normalized, authService.hashPassword(opts.password), opts.displayName || null]
+      [normalized, authService.hashPassword(opts.password as string), opts.displayName || null]
     );
     const user = insert.rows[0];
     await roleService.writeAuditEntry(client, {
       actorUserId: null,
       targetUserId: user.id,
       action: "user.created",
-      details: { email: user.email, via: "scripts/create-user.js" }
+      details: { email: user.email, via: "scripts/create-user.ts" }
     });
     await roleService.assignRolesByName(client, {
       userId: user.id,
@@ -170,35 +209,9 @@ async function main() {
   process.stdout.write(`Created user ${created.email} (id=${created.id}) with roles: ${rolesToAssign.join(", ")}.\n`);
 }
 
-async function applyRoles({ userId, roleNames }) {
-  const currentRoles = await roleService.listRoleNamesForUser(userId);
-  const desired = roleService.uniqueRoleNames(roleNames) || [];
-  const toAssign = desired.filter((name) => !currentRoles.includes(name));
-  const toRevoke = currentRoles.filter((name) => !desired.includes(name));
-  if (toAssign.length === 0 && toRevoke.length === 0) {
-    return;
-  }
-  await appDb.withTransaction(async (client) => {
-    if (toAssign.length > 0) {
-      await roleService.assignRolesByName(client, {
-        userId,
-        roleNames: toAssign,
-        actorUserId: null
-      });
-    }
-    if (toRevoke.length > 0) {
-      await roleService.revokeRolesByName(client, {
-        userId,
-        roleNames: toRevoke,
-        actorUserId: null
-      });
-    }
-  });
-}
-
 main()
-  .catch((err) => {
-    process.stderr.write(`[create-user] ${err.message}\n`);
+  .catch((err: unknown) => {
+    process.stderr.write(`[create-user] ${errorMessage(err)}\n`);
     process.exitCode = 1;
   })
   .finally(async () => {

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["scripts/**/*.ts", "app/src/**/*"],
+  "exclude": ["node_modules", "dist", "frontend"]
+}


### PR DESCRIPTION
Closes #146.

## Summary

Migrates the remaining `.js` sources outside services/routes to TypeScript:

- `app/src/migrate.ts` — typed migration runner; preserves `maxRetries` / `delayMs` retry semantics and the `require.main === module` CLI guard.
- `app/src/start.ts` — typed boot sequence; preserves the QUERY-007 `scheduleDispatcher` gate.
- `app/src/server.ts` — typed HTTP dispatcher; threads `IncomingMessage` through `AuthedRequest` and uses `errorMessage()` for the catch handler instead of reading `err.message` directly.
- `app/src/benchmark/runMvpBenchmark.ts` — typed benchmark runner; case / summary / report shapes are now explicit.
- `scripts/create-user.ts` — typed CLI; bare `require(path.resolve(...))` calls replaced with ES imports.

## Build + tsconfig wiring

- `tsconfig.json` keeps `rootDir: "app"` so compiled output stays under `dist/src/...` — the path the Dockerfile `CMD` and the `start` script already point to. No path churn.
- New `tsconfig.scripts.json` typechecks `scripts/` (with `noEmit`) without forcing the layout to change. `npm run typecheck` runs both.
- `package.json`:
  - `dev:be` now points at `start.ts`
  - `migrate`, `benchmark:mvp`, and new `create-user` now go through `tsx` so they work without a build step
  - `start` still uses `node dist/src/start.js` so Docker is unaffected

## Verification

- `npm run typecheck` (both configs) — passes
- `npm run build:be` — succeeds, emits `dist/src/{start,migrate,server}.js` and `dist/src/benchmark/runMvpBenchmark.js`
- `npm test` — 219/219 pass
- `find app/src -name '*.js'` and `find scripts -name '*.js'` — no results

## Smoke test

Booted `dist/src/start.js` against a throwaway Postgres:

- Applied all 27 migrations
- Served `GET /health` → `{"status":"ok"}`
- Served `GET /ready` → `{"status":"ready"}`

Verified `npx tsx scripts/create-user.ts --help` renders the help text correctly.

## Out of scope

- Tests (TS-016)
- Strict mode (TS-017)

## Unblocks

- TS-017 (the migration is content-complete once tests are migrated in TS-016)