### PR TITLE
Replace vulnerable XLSX dependency

### DIFF
--- a/app/test/exportService.test.ts
+++ b/app/test/exportService.test.ts
@@ -4,7 +4,74 @@ import assert from "node:assert/strict";
 
 process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
 
-import { __private } from "../src/services/exportService";
+import appDb = require("../src/lib/appDb");
+import dbAdapterFactory = require("../src/adapters/dbAdapterFactory");
+import * as xlsx from "xlsx";
+import { __private, exportQueryResult } from "../src/services/exportService";
+
+test("exportQueryResult writes a readable XLSX workbook in adapter column order", async () => {
+  const originalQuery = appDb.query;
+  const originalCreateDatabaseAdapter = dbAdapterFactory.createDatabaseAdapter;
+  let queryNumber = 0;
+  let adapterClosed = false;
+
+  appDb.query = (async () => {
+    queryNumber += 1;
+    if (queryNumber === 1) {
+      return {
+        rowCount: 1,
+        rows: [{
+          id: "00000000-0000-4000-8000-000000000001",
+          data_source_id: "00000000-0000-4000-8000-000000000111",
+          question: "Quarterly sales",
+          connection_ref: "postgresql://example.invalid/reporting",
+          db_type: "postgres"
+        }]
+      };
+    }
+    if (queryNumber === 2) {
+      return { rowCount: 1, rows: [{ generated_sql: "SELECT 2 AS second, 1 AS first" }] };
+    }
+    throw new Error(`Unexpected app database query #${queryNumber}`);
+  }) as unknown as typeof appDb.query;
+
+  (dbAdapterFactory as { createDatabaseAdapter: typeof dbAdapterFactory.createDatabaseAdapter }).createDatabaseAdapter = (() => ({
+    async executeReadOnly() {
+      return {
+        columns: ["second", "first"],
+        rows: [{ first: 1, second: 2 }],
+        rowCount: 1,
+        originalRowCount: 1,
+        truncated: false,
+        durationMs: 1
+      };
+    },
+    async close() {
+      adapterClosed = true;
+    }
+  })) as unknown as typeof dbAdapterFactory.createDatabaseAdapter;
+
+  try {
+    const exported = await exportQueryResult("00000000-0000-4000-8000-000000000001", "xlsx");
+
+    assert.equal(exported.contentType, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    assert.match(exported.filename, /^Quarterly_sales_.*\.xlsx$/);
+    assert.ok(exported.buffer.length > 0);
+
+    const workbook = xlsx.read(exported.buffer, { type: "buffer" });
+    assert.deepEqual(workbook.SheetNames, ["Results"]);
+    const resultsSheet = workbook.Sheets.Results;
+    assert.ok(resultsSheet);
+    assert.deepEqual(xlsx.utils.sheet_to_json(resultsSheet, { header: 1 }), [
+      ["second", "first"],
+      [2, 1]
+    ]);
+    assert.equal(adapterClosed, true);
+  } finally {
+    appDb.query = originalQuery;
+    (dbAdapterFactory as { createDatabaseAdapter: typeof dbAdapterFactory.createDatabaseAdapter }).createDatabaseAdapter = originalCreateDatabaseAdapter;
+  }
+});
 
 test("getColumnOrder prefers adapter columns", () => {
   const actual = __private.getColumnOrder(["b", "a"], [{ a: 1, b: 2 }]);

--- a/app/test/savedQuerySchedulesApi.test.ts
+++ b/app/test/savedQuerySchedulesApi.test.ts
@@ -9,6 +9,7 @@ process.env.AUTH_COOKIE_SECURE = "false";
 import appDb = require("../src/lib/appDb");
 import dbAdapterFactory = require("../src/adapters/dbAdapterFactory");
 import emailService = require("../src/services/emailService");
+import * as xlsx from "xlsx";
 import { createAuthTestStub } from "./helpers/authTestStub";
 
 const DATA_SOURCE_ID = "00000000-0000-4000-8000-000000000111";
@@ -132,8 +133,8 @@ before(async () => {
     },
     async executeParameterizedReadOnly() {
       return {
-        columns: ["value"],
-        rows: [{ value: 1 }],
+        columns: ["second", "first"],
+        rows: [{ first: "A", second: "B" }],
         rowCount: 1,
         durationMs: 4
       };
@@ -152,7 +153,9 @@ before(async () => {
       recipients: [...opts.recipients],
       subject: opts.subject,
       fileName: opts.fileName,
-      bytes: opts.fileBuffer.length
+      bytes: opts.fileBuffer.length,
+      fileBuffer: Buffer.from(opts.fileBuffer),
+      contentType: opts.contentType
     });
     return { messageId: `stub-${sentEmails.length}` };
   };
@@ -638,7 +641,7 @@ test("QUERY-007 dispatch failure records error_message and exposes it via list e
   assert.equal(finalList.payload.items[0].recent_runs[0].status, "succeeded");
 });
 
-test("QUERY-007 successful email dispatch sends to recipients and records file size", async () => {
+test("QUERY-007 successful XLSX email dispatch sends a valid ordered workbook", async () => {
   const savedQueryId = await seedSavedQuery({ ownerLabel: "owner" });
 
   const created = await api("POST", `/v1/saved-queries/${savedQueryId}/schedules`, {
@@ -658,7 +661,18 @@ test("QUERY-007 successful email dispatch sends to recipients and records file s
   assert.deepEqual(sentEmails[0].recipients.sort(), ["lead@example.com", "ops@example.com"]);
   assert.match(sentEmails[0].subject, /Monday digest/);
   assert.match(sentEmails[0].fileName, /\.xlsx$/);
+  assert.equal(sentEmails[0].contentType, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
   assert.ok(sentEmails[0].bytes > 0);
+  assert.equal(xlsx.version, "0.20.3");
+
+  const workbook = xlsx.read(sentEmails[0].fileBuffer, { type: "buffer" });
+  assert.deepEqual(workbook.SheetNames, ["Results"]);
+  const resultsSheet = workbook.Sheets.Results;
+  assert.ok(resultsSheet);
+  assert.deepEqual(xlsx.utils.sheet_to_json(resultsSheet, { header: 1 }), [
+    ["second", "first"],
+    ["B", "A"]
+  ]);
 
   const runs = [...scheduleRuns.values()];
   assert.equal(runs.length, 1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "openid-client": "^6.8.4",
         "parquetjs-lite": "^0.8.7",
         "pg": "^8.13.1",
-        "xlsx": "^0.18.5"
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
       "devDependencies": {
         "@types/mssql": "^12.3.0",
@@ -900,15 +900,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1064,19 +1055,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1127,15 +1105,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -1197,18 +1166,6 @@
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/csv-stringify": {
@@ -1366,15 +1323,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2169,18 +2117,6 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2345,24 +2281,6 @@
       "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
       "license": "MIT"
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -2397,19 +2315,10 @@
       }
     },
     "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "version": "0.20.3",
+      "resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+      "integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
       "bin": {
         "xlsx": "bin/xlsx.njs"
       },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "openid-client": "^6.8.4",
     "parquetjs-lite": "^0.8.7",
     "pg": "^8.13.1",
-    "xlsx": "^0.18.5"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
   "devDependencies": {
     "@types/mssql": "^12.3.0",


### PR DESCRIPTION
## Summary

- replace vulnerable `xlsx@0.18.5` with the pinned official SheetJS 0.20.3 distribution
- add workbook round-trip regressions for both interactive query exports and scheduled XLSX attachments
- verify ordered columns, workbook structure, filenames, MIME type, and adapter cleanup
- keep workbook parsing test-only and limited to trusted generated buffers

## Verification

- `npm ci`
- `npm test` (220 passed)
- `npm run typecheck`
- `npm run build`
- `npm --prefix frontend run lint`
- `npm audit --json` (0 vulnerabilities)
- `npm audit --omit=dev --json` (0 vulnerabilities)

The dependency URL follows the official SheetJS Node installation guidance: https://docs.sheetjs.com/docs/getting-started/installation/nodejs/

Closes #168