### PR TITLE
Add large-schema table retrieval foundation

### DIFF
--- a/app/src/services/queryOrchestrationStore.ts
+++ b/app/src/services/queryOrchestrationStore.ts
@@ -75,6 +75,29 @@ export async function resolveSession({ sessionId, question, dataSourceId, connec
 }
 
 export async function loadQueryContext(dataSourceId: string): Promise<QueryContext> {
+  return loadQueryContextForObjects(dataSourceId, null);
+}
+
+export async function loadScopedQueryContext(dataSourceId: string, schemaObjectIds: string[]): Promise<QueryContext> {
+  const ids = [...new Set(schemaObjectIds.map((id) => String(id).trim()).filter(Boolean))];
+  if (ids.length === 0) {
+    return {
+      schemaObjects: [],
+      columns: [],
+      semanticEntities: [],
+      metricDefinitions: [],
+      joinPolicies: [],
+      ragNotes: []
+    };
+  }
+  return loadQueryContextForObjects(dataSourceId, ids);
+}
+
+async function loadQueryContextForObjects(dataSourceId: string, schemaObjectIds: string[] | null): Promise<QueryContext> {
+  const scoped = Array.isArray(schemaObjectIds);
+  const params = scoped ? [dataSourceId, schemaObjectIds] : [dataSourceId];
+  const objectScopeSql = scoped ? "AND id = ANY($2::uuid[])" : "";
+  const columnScopeSql = scoped ? "AND so.id = ANY($2::uuid[])" : "";
   const [
     schemaObjectsResult,
     columnsResult,
@@ -90,9 +113,10 @@ export async function loadQueryContext(dataSourceId: string): Promise<QueryConte
         WHERE data_source_id = $1
           AND is_ignored = FALSE
           AND object_type IN ('table', 'view', 'materialized_view')
+          ${objectScopeSql}
         ORDER BY schema_name, object_name
       `,
-      [dataSourceId]
+      params
     ),
     appDb.query<{ schema_name: string; object_name: string; column_name: string; data_type: string }>(
       `
@@ -105,9 +129,10 @@ export async function loadQueryContext(dataSourceId: string): Promise<QueryConte
         JOIN schema_objects so ON so.id = c.schema_object_id
         WHERE so.data_source_id = $1
           AND so.is_ignored = FALSE
+          ${columnScopeSql}
         ORDER BY so.schema_name, so.object_name, c.ordinal_position
       `,
-      [dataSourceId]
+      params
     ),
     appDb.query<{ id: string; entity_type: string; target_ref: string; business_name: string }>(
       `
@@ -153,14 +178,40 @@ export async function loadQueryContext(dataSourceId: string): Promise<QueryConte
     )
   ]);
 
+  const selectedObjects = schemaObjectsResult.rows;
+  const selectedSemantics = scoped
+    ? semanticEntitiesResult.rows.filter((entity) => selectedObjects.some((object) => refTargetsObject(entity.target_ref, object)))
+    : semanticEntitiesResult.rows;
+  const selectedSemanticIds = new Set(selectedSemantics.map((entity) => entity.id));
+  const selectedJoins = scoped
+    ? joinPoliciesResult.rows.filter((join) =>
+      selectedObjects.some((object) => refTargetsObject(join.left_ref, object))
+      && selectedObjects.some((object) => refTargetsObject(join.right_ref, object)))
+    : joinPoliciesResult.rows;
+
   return {
-    schemaObjects: schemaObjectsResult.rows,
+    schemaObjects: selectedObjects,
     columns: columnsResult.rows,
-    semanticEntities: semanticEntitiesResult.rows,
-    metricDefinitions: metricDefinitionsResult.rows,
-    joinPolicies: joinPoliciesResult.rows,
+    semanticEntities: selectedSemantics,
+    metricDefinitions: scoped
+      ? metricDefinitionsResult.rows.filter((metric) => selectedSemanticIds.has(metric.semantic_entity_id))
+      : metricDefinitionsResult.rows,
+    joinPolicies: selectedJoins,
     ragNotes: ragNotesResult.rows
   };
+}
+
+function refTargetsObject(
+  ref: string,
+  object: { schema_name: string; object_name: string }
+): boolean {
+  const normalized = String(ref || "").toLowerCase().replace(/["'`\[\]\s]/g, "");
+  const qualified = `${object.schema_name}.${object.object_name}`.toLowerCase();
+  const unqualified = object.object_name.toLowerCase();
+  return normalized === qualified
+    || normalized.startsWith(`${qualified}.`)
+    || normalized === unqualified
+    || normalized.startsWith(`${unqualified}.`);
 }
 
 export async function validateRequestedProvider(requestedProvider: string | null | undefined): Promise<boolean> {

--- a/app/src/services/schemaLinkingService.ts
+++ b/app/src/services/schemaLinkingService.ts
@@ -1,0 +1,408 @@
+import appDb = require("../lib/appDb");
+import ragRetrieval = require("./ragRetrieval");
+import type { RagRetrievalDoc } from "./ragRetrieval";
+
+const { retrieveRagContext } = ragRetrieval;
+
+export interface TableCardRelationship {
+  column: string;
+  related_ref: string;
+  related_column: string;
+  direction: "outbound" | "inbound";
+  relationship_type: string;
+}
+
+export interface TableCard {
+  id: string;
+  schema_name: string;
+  object_name: string;
+  object_type: string;
+  description: string | null;
+  primary_keys: string[];
+  join_columns: string[];
+  relationships: TableCardRelationship[];
+  approved_join_refs: string[];
+  semantic_aliases: string[];
+  synonyms: Array<{ term: string; weight: number }>;
+}
+
+export interface TableCandidate extends TableCard {
+  score: number;
+  lexical_score: number;
+  rag_score: number;
+  matched_terms: string[];
+}
+
+export interface RetrieveTableCandidatesOptions {
+  limit?: number;
+  ragLimit?: number;
+}
+
+interface SchemaObjectRow {
+  id: string;
+  schema_name: string;
+  object_name: string;
+  object_type: string;
+  description: string | null;
+}
+
+interface KeyColumnRow {
+  schema_object_id: string;
+  column_name: string;
+}
+
+interface RelationshipRow {
+  from_object_id: string;
+  from_column: string;
+  from_schema: string;
+  from_object: string;
+  to_object_id: string;
+  to_column: string;
+  to_schema: string;
+  to_object: string;
+  relationship_type: string;
+}
+
+interface SemanticRow {
+  target_ref: string;
+  business_name: string;
+}
+
+interface SynonymRow {
+  term: string;
+  maps_to_ref: string;
+  weight: number | string;
+}
+
+interface JoinPolicyRow {
+  left_ref: string;
+  right_ref: string;
+}
+
+export async function retrieveTableCandidates(
+  dataSourceId: string,
+  question: string,
+  opts: RetrieveTableCandidatesOptions = {}
+): Promise<TableCandidate[]> {
+  const q = String(question || "").trim();
+  if (!q) {
+    return [];
+  }
+
+  const limit = positiveInteger(opts.limit, 15);
+  const ragLimit = positiveInteger(opts.ragLimit, Math.max(limit * 3, 30));
+  const [cards, ragDocuments] = await Promise.all([
+    loadTableCards(dataSourceId),
+    retrieveRagContext(dataSourceId, q, { limit: ragLimit })
+  ]);
+
+  return rankTableCards(q, cards, ragDocuments, limit);
+}
+
+export async function loadTableCards(dataSourceId: string): Promise<TableCard[]> {
+  const [objectsResult, primaryKeysResult, relationshipsResult, semanticResult, synonymsResult, joinsResult] =
+    await Promise.all([
+      appDb.query<SchemaObjectRow>(
+        `
+          SELECT id, schema_name, object_name, object_type, description
+          FROM schema_objects
+          WHERE data_source_id = $1
+            AND is_ignored = FALSE
+            AND object_type IN ('table', 'view', 'materialized_view')
+          ORDER BY schema_name, object_name
+        `,
+        [dataSourceId]
+      ),
+      appDb.query<KeyColumnRow>(
+        `
+          SELECT c.schema_object_id, c.column_name
+          FROM columns c
+          JOIN schema_objects so ON so.id = c.schema_object_id
+          WHERE so.data_source_id = $1
+            AND so.is_ignored = FALSE
+            AND c.is_pk = TRUE
+          ORDER BY c.schema_object_id, c.ordinal_position
+        `,
+        [dataSourceId]
+      ),
+      appDb.query<RelationshipRow>(
+        `
+          SELECT
+            r.from_object_id,
+            r.from_column,
+            source.schema_name AS from_schema,
+            source.object_name AS from_object,
+            r.to_object_id,
+            r.to_column,
+            target.schema_name AS to_schema,
+            target.object_name AS to_object,
+            r.relationship_type
+          FROM relationships r
+          JOIN schema_objects source ON source.id = r.from_object_id
+          JOIN schema_objects target ON target.id = r.to_object_id
+          WHERE source.data_source_id = $1
+            AND target.data_source_id = $1
+            AND source.is_ignored = FALSE
+            AND target.is_ignored = FALSE
+        `,
+        [dataSourceId]
+      ),
+      appDb.query<SemanticRow>(
+        `
+          SELECT target_ref, business_name
+          FROM semantic_entities
+          WHERE data_source_id = $1 AND active = TRUE
+          ORDER BY business_name
+        `,
+        [dataSourceId]
+      ),
+      appDb.query<SynonymRow>(
+        `
+          SELECT term, maps_to_ref, weight
+          FROM synonyms
+          WHERE data_source_id = $1
+          ORDER BY term
+        `,
+        [dataSourceId]
+      ),
+      appDb.query<JoinPolicyRow>(
+        `
+          SELECT left_ref, right_ref
+          FROM join_policies
+          WHERE data_source_id = $1 AND approved = TRUE
+          ORDER BY left_ref, right_ref
+        `,
+        [dataSourceId]
+      )
+    ]);
+
+  const cards = objectsResult.rows.map<TableCard>((row) => ({
+    ...row,
+    primary_keys: [],
+    join_columns: [],
+    relationships: [],
+    approved_join_refs: [],
+    semantic_aliases: [],
+    synonyms: []
+  }));
+  const cardsById = new Map(cards.map((card) => [card.id, card]));
+  const resolveCard = buildCardResolver(cards);
+
+  for (const key of primaryKeysResult.rows) {
+    cardsById.get(key.schema_object_id)?.primary_keys.push(key.column_name);
+  }
+
+  for (const relationship of relationshipsResult.rows) {
+    const from = cardsById.get(relationship.from_object_id);
+    const to = cardsById.get(relationship.to_object_id);
+    if (from) {
+      from.join_columns.push(relationship.from_column);
+      from.relationships.push({
+        column: relationship.from_column,
+        related_ref: `${relationship.to_schema}.${relationship.to_object}`,
+        related_column: relationship.to_column,
+        direction: "outbound",
+        relationship_type: relationship.relationship_type
+      });
+    }
+    if (to) {
+      to.join_columns.push(relationship.to_column);
+      to.relationships.push({
+        column: relationship.to_column,
+        related_ref: `${relationship.from_schema}.${relationship.from_object}`,
+        related_column: relationship.from_column,
+        direction: "inbound",
+        relationship_type: relationship.relationship_type
+      });
+    }
+  }
+
+  for (const semantic of semanticResult.rows) {
+    const card = resolveCard(semantic.target_ref);
+    if (card) {
+      card.semantic_aliases.push(semantic.business_name);
+    }
+  }
+
+  for (const synonym of synonymsResult.rows) {
+    const card = resolveCard(synonym.maps_to_ref);
+    if (card) {
+      card.synonyms.push({ term: synonym.term, weight: finiteNumber(synonym.weight, 1) });
+    }
+  }
+
+  for (const join of joinsResult.rows) {
+    const left = resolveCard(join.left_ref);
+    const right = resolveCard(join.right_ref);
+    if (left && right) {
+      left.approved_join_refs.push(qualifiedRef(right));
+      right.approved_join_refs.push(qualifiedRef(left));
+    }
+  }
+
+  for (const card of cards) {
+    card.primary_keys = uniqueSorted(card.primary_keys);
+    card.join_columns = uniqueSorted(card.join_columns);
+    card.approved_join_refs = uniqueSorted(card.approved_join_refs);
+    card.semantic_aliases = uniqueSorted(card.semantic_aliases);
+    card.synonyms = uniqueBy(card.synonyms, (entry) => normalizeText(entry.term));
+  }
+
+  return cards;
+}
+
+export function rankTableCards(
+  question: string,
+  cards: TableCard[],
+  ragDocuments: RagRetrievalDoc[] = [],
+  limit = 15
+): TableCandidate[] {
+  const q = normalizeText(question);
+  if (!q) {
+    return [];
+  }
+
+  const questionTerms = tokenize(question);
+  const ragScores = new Map<string, number>();
+  for (const doc of ragDocuments) {
+    if (doc.doc_type !== "schema") {
+      continue;
+    }
+    const score = finiteNumber(doc.rerank_score, finiteNumber(doc.score, 0));
+    ragScores.set(String(doc.ref_id), Math.max(ragScores.get(String(doc.ref_id)) || 0, score));
+  }
+
+  return cards
+    .map<TableCandidate>((card) => {
+      const objectRef = qualifiedRef(card);
+      const objectTerms = new Set(tokenize(`${card.schema_name} ${card.object_name}`));
+      const descriptiveTerms = new Set(tokenize([
+        card.description,
+        ...card.semantic_aliases,
+        ...card.synonyms.map((entry) => entry.term)
+      ].join(" ")));
+      const matchedTerms = questionTerms.filter((term) => objectTerms.has(term) || descriptiveTerms.has(term));
+
+      let lexicalScore = 0;
+      if (q.includes(normalizeText(objectRef))) {
+        lexicalScore += 8;
+      } else if (q.includes(normalizeText(card.object_name))) {
+        lexicalScore += 5;
+      }
+      for (const term of new Set(questionTerms)) {
+        if (objectTerms.has(term)) {
+          lexicalScore += 2;
+        } else if (descriptiveTerms.has(term)) {
+          lexicalScore += 1;
+        }
+      }
+      for (const synonym of card.synonyms) {
+        if (phraseMatches(q, synonym.term)) {
+          lexicalScore += Math.max(0, synonym.weight) * 2;
+        }
+      }
+      for (const alias of card.semantic_aliases) {
+        if (phraseMatches(q, alias)) {
+          lexicalScore += 2;
+        }
+      }
+
+      const ragScore = ragScores.get(card.id) || 0;
+      return {
+        ...card,
+        score: roundScore(lexicalScore + ragScore),
+        lexical_score: roundScore(lexicalScore),
+        rag_score: roundScore(ragScore),
+        matched_terms: uniqueSorted(matchedTerms)
+      };
+    })
+    .filter((candidate) => candidate.score > 0)
+    .sort((a, b) => b.score - a.score || a.schema_name.localeCompare(b.schema_name) || a.object_name.localeCompare(b.object_name))
+    .slice(0, positiveInteger(limit, 15));
+}
+
+export function refMatchesCard(ref: string, card: Pick<TableCard, "schema_name" | "object_name">): boolean {
+  const normalized = normalizeRef(ref);
+  const qualified = normalizeRef(qualifiedRef(card));
+  const object = normalizeRef(card.object_name);
+  return normalized === qualified
+    || normalized.startsWith(`${qualified}.`)
+    || normalized === object
+    || normalized.startsWith(`${object}.`);
+}
+
+function buildCardResolver(cards: TableCard[]): (ref: string) => TableCard | undefined {
+  const qualified = new Map(cards.map((card) => [normalizeRef(qualifiedRef(card)), card]));
+  const unqualified = new Map<string, TableCard | null>();
+  for (const card of cards) {
+    const key = normalizeRef(card.object_name);
+    unqualified.set(key, unqualified.has(key) ? null : card);
+  }
+
+  return (ref: string) => {
+    const normalized = normalizeRef(ref);
+    const parts = normalized.split(".").filter(Boolean);
+    for (let end = parts.length; end > 0; end -= 1) {
+      const direct = qualified.get(parts.slice(0, end).join("."));
+      if (direct) {
+        return direct;
+      }
+    }
+    const byObjectName = unqualified.get(parts[0] || normalized);
+    return byObjectName || undefined;
+  };
+}
+
+function qualifiedRef(card: Pick<TableCard, "schema_name" | "object_name">): string {
+  return `${card.schema_name}.${card.object_name}`;
+}
+
+function phraseMatches(normalizedQuestion: string, phrase: string): boolean {
+  const normalizedPhrase = normalizeText(phrase);
+  return Boolean(normalizedPhrase) && normalizedQuestion.includes(normalizedPhrase);
+}
+
+function tokenize(value: unknown): string[] {
+  return normalizeText(String(value || "").replace(/([a-z0-9])([A-Z])/g, "$1 $2"))
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(/\s+/)
+    .filter((term) => term.length >= 2);
+}
+
+function normalizeText(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function normalizeRef(value: unknown): string {
+  return normalizeText(value).replace(/["'`\[\]]/g, "").replace(/\s+/g, "");
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : fallback;
+}
+
+function finiteNumber(value: unknown, fallback: number): number {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function roundScore(value: number): number {
+  return Number(value.toFixed(4));
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function uniqueBy<T>(values: T[], key: (value: T) => string): T[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const identifier = key(value);
+    if (seen.has(identifier)) {
+      return false;
+    }
+    seen.add(identifier);
+    return true;
+  });
+}

--- a/app/test/schemaLinkingService.test.ts
+++ b/app/test/schemaLinkingService.test.ts
@@ -1,0 +1,230 @@
+import "./helpers/setupEnv";
+import { after, before, test } from "node:test";
+import assert from "node:assert/strict";
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+
+import appDb = require("../src/lib/appDb");
+import {
+  loadTableCards,
+  rankTableCards,
+  type TableCard
+} from "../src/services/schemaLinkingService";
+import { loadScopedQueryContext } from "../src/services/queryOrchestrationStore";
+import type { RagRetrievalDoc } from "../src/services/ragRetrieval";
+
+const DATA_SOURCE_ID = "00000000-0000-4000-8000-000000000111";
+const PAYMENT_ID = "00000000-0000-4000-8000-000000000201";
+const CUSTOMER_ID = "00000000-0000-4000-8000-000000000202";
+
+let originalQuery: typeof appDb.query;
+
+before(() => {
+  originalQuery = appDb.query;
+});
+
+after(() => {
+  appDb.query = originalQuery;
+});
+
+test("rankTableCards finds a semantic match among a large distractor schema", () => {
+  const distractors = Array.from({ length: 1000 }, (_, index) =>
+    card(`table-${index}`, `archive_${String(index).padStart(4, "0")}`));
+  const payment = card(PAYMENT_ID, "payment", {
+    description: "Transactions received from customers",
+    semantic_aliases: ["Revenue"],
+    synonyms: [{ term: "sales", weight: 1.5 }]
+  });
+
+  const candidates = rankTableCards("Show revenue by month", [...distractors, payment], [], 5);
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].id, PAYMENT_ID);
+  assert.ok(candidates[0].score > 0);
+  assert.deepEqual(candidates[0].matched_terms, ["revenue"]);
+});
+
+test("rankTableCards uses schema RAG scores and applies a deterministic limit", () => {
+  const cards = [card("b", "beta"), card("a", "alpha"), card("c", "gamma")];
+  const ragDocuments = [
+    ragDoc("b", 0.7),
+    ragDoc("a", 0.7),
+    ragDoc("c", 0.2)
+  ];
+
+  const candidates = rankTableCards("business concept with no lexical match", cards, ragDocuments, 2);
+
+  assert.deepEqual(candidates.map((candidate) => candidate.id), ["a", "b"]);
+  assert.deepEqual(candidates.map((candidate) => candidate.rag_score), [0.7, 0.7]);
+});
+
+test("rankTableCards returns no weak fill candidates for an empty or unmatched question", () => {
+  const cards = [card(PAYMENT_ID, "payment")];
+
+  assert.deepEqual(rankTableCards("", cards), []);
+  assert.deepEqual(rankTableCards("weather forecast", cards), []);
+});
+
+test("loadTableCards retains keys, both relationship directions, aliases, synonyms, and approved endpoints", async () => {
+  appDb.query = (async (sql: string) => {
+    const normalized = normalizeSql(sql);
+    if (normalized.includes("from schema_objects") && normalized.includes("object_type in")) {
+      return result([
+        {
+          id: PAYMENT_ID,
+          schema_name: "public",
+          object_name: "payment",
+          object_type: "table",
+          description: "Customer payments"
+        },
+        {
+          id: CUSTOMER_ID,
+          schema_name: "public",
+          object_name: "customer",
+          object_type: "table",
+          description: "Customers"
+        }
+      ]);
+    }
+    if (normalized.includes("c.is_pk = true")) {
+      return result([{ schema_object_id: PAYMENT_ID, column_name: "payment_id" }]);
+    }
+    if (normalized.includes("from relationships")) {
+      return result([{
+        from_object_id: PAYMENT_ID,
+        from_column: "customer_id",
+        from_schema: "public",
+        from_object: "payment",
+        to_object_id: CUSTOMER_ID,
+        to_column: "customer_id",
+        to_schema: "public",
+        to_object: "customer",
+        relationship_type: "fk"
+      }]);
+    }
+    if (normalized.includes("from semantic_entities")) {
+      return result([{ target_ref: "public.payment", business_name: "Revenue" }]);
+    }
+    if (normalized.includes("from synonyms")) {
+      return result([{ term: "sales", maps_to_ref: "public.payment.amount", weight: "1.5" }]);
+    }
+    if (normalized.includes("from join_policies")) {
+      return result([{ left_ref: "public.payment", right_ref: "public.customer" }]);
+    }
+    throw new Error(`Unexpected SQL: ${normalized}`);
+  }) as typeof appDb.query;
+
+  const cards = await loadTableCards(DATA_SOURCE_ID);
+  const payment = cards.find((candidate) => candidate.id === PAYMENT_ID);
+  const customer = cards.find((candidate) => candidate.id === CUSTOMER_ID);
+
+  assert.deepEqual(payment?.primary_keys, ["payment_id"]);
+  assert.deepEqual(payment?.join_columns, ["customer_id"]);
+  assert.deepEqual(payment?.semantic_aliases, ["Revenue"]);
+  assert.deepEqual(payment?.synonyms, [{ term: "sales", weight: 1.5 }]);
+  assert.deepEqual(payment?.approved_join_refs, ["public.customer"]);
+  assert.deepEqual(payment?.relationships, [{
+    column: "customer_id",
+    related_ref: "public.customer",
+    related_column: "customer_id",
+    direction: "outbound",
+    relationship_type: "fk"
+  }]);
+  assert.deepEqual(customer?.relationships[0]?.direction, "inbound");
+});
+
+test("loadScopedQueryContext loads every column for selected objects and filters semantic context", async () => {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
+    const normalized = normalizeSql(sql);
+    calls.push({ sql: normalized, params });
+    if (normalized.includes("from schema_objects") && normalized.includes("object_type in")) {
+      return result([{
+        id: PAYMENT_ID,
+        schema_name: "public",
+        object_name: "payment",
+        object_type: "table"
+      }]);
+    }
+    if (normalized.includes("from columns c")) {
+      return result(Array.from({ length: 250 }, (_, ordinal) => ({
+        schema_name: "public",
+        object_name: "payment",
+        column_name: `column_${ordinal}`,
+        data_type: "text"
+      })));
+    }
+    if (normalized.includes("from semantic_entities")) {
+      return result([
+        { id: "semantic-payment", entity_type: "table", target_ref: "public.payment", business_name: "Revenue" },
+        { id: "semantic-customer", entity_type: "table", target_ref: "public.customer", business_name: "Customers" }
+      ]);
+    }
+    if (normalized.includes("from metric_definitions")) {
+      return result([
+        { id: "metric-payment", semantic_entity_id: "semantic-payment", sql_expression: "sum(amount)", grain: null, business_name: "Revenue" },
+        { id: "metric-customer", semantic_entity_id: "semantic-customer", sql_expression: "count(*)", grain: null, business_name: "Customers" }
+      ]);
+    }
+    if (normalized.includes("from join_policies")) {
+      return result([
+        { id: "join-self", left_ref: "public.payment", right_ref: "public.payment", join_type: "inner", on_clause: "true" },
+        { id: "join-other", left_ref: "public.payment", right_ref: "public.customer", join_type: "inner", on_clause: "true" }
+      ]);
+    }
+    if (normalized.includes("from rag_notes")) {
+      return result([{ id: "note", title: "Policy", content: "Exclude tests" }]);
+    }
+    throw new Error(`Unexpected SQL: ${normalized}`);
+  }) as typeof appDb.query;
+
+  const context = await loadScopedQueryContext(DATA_SOURCE_ID, [PAYMENT_ID, PAYMENT_ID]);
+
+  assert.equal(context.schemaObjects.length, 1);
+  assert.equal(context.columns.length, 250);
+  assert.deepEqual(context.semanticEntities.map((entity) => entity.id), ["semantic-payment"]);
+  assert.deepEqual(context.metricDefinitions.map((metric) => metric.id), ["metric-payment"]);
+  assert.deepEqual(context.joinPolicies.map((join) => join.id), ["join-self"]);
+  assert.equal(context.ragNotes.length, 1);
+  assert.ok(calls.slice(0, 2).every((call) => call.sql.includes("any($2::uuid[])")));
+  assert.deepEqual(calls[0].params, [DATA_SOURCE_ID, [PAYMENT_ID]]);
+});
+
+function card(id: string, objectName: string, overrides: Partial<TableCard> = {}): TableCard {
+  return {
+    id,
+    schema_name: "public",
+    object_name: objectName,
+    object_type: "table",
+    description: null,
+    primary_keys: [],
+    join_columns: [],
+    relationships: [],
+    approved_join_refs: [],
+    semantic_aliases: [],
+    synonyms: [],
+    ...overrides
+  };
+}
+
+function ragDoc(refId: string, score: number): RagRetrievalDoc {
+  return {
+    id: `rag-${refId}`,
+    doc_type: "schema",
+    ref_id: refId,
+    content: "schema card",
+    metadata_json: null,
+    vector_json: null,
+    score,
+    rerank_score: score,
+    embedding_model: "test"
+  };
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function result<T>(rows: T[]): { rows: T[]; rowCount: number } {
+  return { rows, rowCount: rows.length };
+}


### PR DESCRIPTION
## Summary

- build compact table cards from schema metadata, PK/FK relationships, approved join endpoints, semantic aliases, and synonyms
- rank table candidates with deterministic lexical signals plus existing schema-RAG scores
- add scoped query-context loading that returns every column for selected objects and filters semantic/join context
- cover large distractor schemas, wide tables, deterministic limits, and relationship metadata

## Why

The current final SQL prompt is built from globally ordered schema context with fixed table and column caps. On large databases, relevant tables can be omitted before generation. This PR provides the retrieval and scoped-loading foundation for the two-stage schema-linking pipeline tracked in #171; it does not switch production generation yet.

## Verification

- `npm run typecheck`
- `npm test` (225 passed)
- `npm --prefix frontend run lint`
- `npm run build`

Closes #172