### PR TITLE
Add large-schema NL-to-SQL quality gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ curl -X POST http://localhost:8080/v1/llm/providers \
 Benchmark assets:
 
 - Dataset: `docs/evals/dvdrental-mvp-benchmark.json` (60 reporting prompts)
+- Large-schema fixture: `docs/evals/large-schema-linking-benchmark.json` (300 distractor tables plus multi-hop, wide-table, paraphrase, and ambiguity cases)
 - Runner: `app/src/benchmark/runMvpBenchmark.ts`
 
 Recommended flow with the dvdrental fixture:
@@ -162,6 +163,12 @@ BENCHMARK_ORACLE_CONN=postgresql://postgres:postgres@localhost:5440/dvdrental \
 npm run benchmark:mvp
 ```
 
+The provider-free schema-linking comparison can be run without databases or API keys:
+
+```bash
+npm run benchmark:large-schema
+```
+
 Note: on first initialization of `test-data`, the restore script shifts all `date`/`timestamp` fields by dynamic offsets so the latest rental and latest payment land around yesterday (relative to system time), then caps shifted values at current system date/time to avoid future-dated rows.
 
 Report outputs:
@@ -169,6 +176,8 @@ Report outputs:
 - JSON and Markdown reports in `docs/evals/reports`
 - Benchmark summary is also persisted to the app DB via `POST /v1/observability/release-gates/report`
 - Runner exits with code `2` when one or more MVP release gates fail.
+- Reports include table recall@15, join-path accuracy, repair rate, prompt size,
+  schema-size/complexity stratification, and a legacy-global versus hierarchical comparison.
 
 Progress tracker:
 

--- a/app/src/benchmark/largeSchemaBenchmark.ts
+++ b/app/src/benchmark/largeSchemaBenchmark.ts
@@ -1,0 +1,372 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { performance } from "perf_hooks";
+import { buildSqlPrompt } from "../services/llmPromptBuilder";
+import { expandSchemaGraph, type SchemaGraph, type SchemaGraphEdge, type SchemaGraphNode } from "../services/schemaGraphService";
+import { rankTableCards, type TableCard } from "../services/schemaLinkingService";
+
+export const DEFAULT_LARGE_SCHEMA_BENCHMARK_FILE = path.join(
+  process.cwd(),
+  "docs",
+  "evals",
+  "large-schema-linking-benchmark.json"
+);
+
+interface LargeSchemaCaseDefinition {
+  id: string;
+  question: string;
+  expected_core_refs: string[];
+  expected_path_refs: string[];
+  expected_status: "complete" | "ambiguous";
+  complexity: string;
+}
+
+interface LargeSchemaFixtureDefinition {
+  version: string;
+  distractor_table_count: number;
+  distractor_columns_per_table: number;
+  candidate_limit: number;
+  legacy_table_limit: number;
+  legacy_column_limit: number;
+  cases: LargeSchemaCaseDefinition[];
+}
+
+interface SyntheticSchema {
+  cards: TableCard[];
+  graph: SchemaGraph;
+  columns: Array<{ schema_name: string; object_name: string; column_name: string; data_type: string }>;
+}
+
+export interface LargeSchemaCaseResult {
+  id: string;
+  complexity: string;
+  expected_status: string;
+  legacy_global: {
+    table_recall_at_40: number;
+    join_path_correct: boolean;
+    prompt_chars: number;
+  };
+  hierarchical: {
+    table_recall_at_15: number;
+    join_path_correct: boolean;
+    expansion_status: string;
+    prompt_chars: number | null;
+    latency_ms: number;
+  };
+}
+
+export interface LargeSchemaBenchmarkResult {
+  version: string;
+  schema: {
+    table_count: number;
+    column_count: number;
+    distractor_table_count: number;
+  };
+  legacy_global: {
+    table_recall_at_40: number;
+    join_path_accuracy: number;
+    average_prompt_chars: number;
+  };
+  hierarchical: {
+    table_recall_at_15: number;
+    join_path_accuracy: number;
+    average_prompt_chars: number;
+    p95_linking_latency_ms: number;
+  };
+  deltas: {
+    table_recall: number;
+    join_path_accuracy: number;
+    average_prompt_chars: number;
+  };
+  release_gates: {
+    table_recall_at_15_ge_95pct: boolean;
+    join_path_accuracy_eq_100pct: boolean;
+    improves_table_recall_over_legacy: boolean;
+    prompt_chars_below_legacy: boolean;
+    all_passed: boolean;
+  };
+  cases: LargeSchemaCaseResult[];
+}
+
+export async function runLargeSchemaBenchmark(
+  filePath: string = DEFAULT_LARGE_SCHEMA_BENCHMARK_FILE
+): Promise<LargeSchemaBenchmarkResult> {
+  const fixture = await readFixture(filePath);
+  const schema = buildSyntheticSchema(fixture);
+  const cardsByRef = new Map(schema.cards.map((card) => [tableRef(card), card]));
+  const nodesByRef = new Map(schema.graph.nodes.map((node) => [node.ref, node]));
+  const legacyObjects = schema.graph.nodes
+    .slice()
+    .sort((a, b) => a.ref.localeCompare(b.ref))
+    .slice(0, fixture.legacy_table_limit);
+  const legacyIds = new Set(legacyObjects.map((node) => node.id));
+  const legacyColumns = schema.columns
+    .slice()
+    .sort(compareColumns)
+    .slice(0, fixture.legacy_column_limit);
+  const results: LargeSchemaCaseResult[] = [];
+
+  for (const caseDef of fixture.cases) {
+    const expectedCoreCards = caseDef.expected_core_refs.map((ref) => required(cardsByRef, ref));
+    const expectedCoreIds = expectedCoreCards.map((card) => card.id);
+    const startedAt = performance.now();
+    const candidates = rankTableCards(caseDef.question, schema.cards, [], fixture.candidate_limit);
+    const expansion = expandSchemaGraph(schema.graph, expectedCoreIds, {
+      maxIntermediateHops: caseDef.complexity === "multi_hop" ? 3 : 2,
+      maxAlternativePaths: 4
+    });
+    const linkingLatency = performance.now() - startedAt;
+    const candidateRefs = new Set(candidates.map(tableRef));
+    const expandedRefs = new Set(expansion.object_ids.map((id) => schema.graph.nodes.find((node) => node.id === id)?.ref).filter(Boolean));
+
+    const legacyPrompt = buildSqlPrompt({
+      question: caseDef.question,
+      maxRows: 1000,
+      schemaObjects: legacyObjects.map(toPromptObject),
+      columns: legacyColumns,
+      joinPolicies: schema.graph.edges
+        .filter((edge) => legacyIds.has(edge.left_object_id) && legacyIds.has(edge.right_object_id))
+        .map(toPromptJoin)
+    });
+
+    let hierarchicalPromptChars: number | null = null;
+    if (expansion.status === "complete") {
+      const selectedIds = new Set(expansion.object_ids);
+      hierarchicalPromptChars = buildSqlPrompt({
+        question: caseDef.question,
+        maxRows: 1000,
+        schemaObjects: schema.graph.nodes.filter((node) => selectedIds.has(node.id)).map(toPromptObject),
+        columns: schema.columns.filter((column) => {
+          const node = nodesByRef.get(`${column.schema_name}.${column.object_name}`);
+          return Boolean(node && selectedIds.has(node.id));
+        }),
+        joinPolicies: expansion.edges.map(toPromptJoin)
+      }).length;
+    }
+
+    const expectedPathPresentInLegacy = caseDef.expected_path_refs.every((ref) => {
+      const node = nodesByRef.get(ref);
+      return Boolean(node && legacyIds.has(node.id));
+    });
+    const hierarchicalPathCorrect = caseDef.expected_status === "ambiguous"
+      ? expansion.status === "ambiguous"
+      : expansion.status === "complete" && caseDef.expected_path_refs.every((ref) => expandedRefs.has(ref));
+
+    results.push({
+      id: caseDef.id,
+      complexity: caseDef.complexity,
+      expected_status: caseDef.expected_status,
+      legacy_global: {
+        table_recall_at_40: recall(caseDef.expected_core_refs, new Set(legacyObjects.map((node) => node.ref))),
+        join_path_correct: caseDef.expected_status === "complete" && expectedPathPresentInLegacy,
+        prompt_chars: legacyPrompt.length
+      },
+      hierarchical: {
+        table_recall_at_15: recall(caseDef.expected_core_refs, candidateRefs),
+        join_path_correct: hierarchicalPathCorrect,
+        expansion_status: expansion.status,
+        prompt_chars: hierarchicalPromptChars,
+        latency_ms: round4(linkingLatency)
+      }
+    });
+  }
+
+  const legacyRecall = average(results.map((result) => result.legacy_global.table_recall_at_40));
+  const hierarchicalRecall = average(results.map((result) => result.hierarchical.table_recall_at_15));
+  const legacyJoinAccuracy = ratio(results.filter((result) => result.legacy_global.join_path_correct).length, results.length);
+  const hierarchicalJoinAccuracy = ratio(results.filter((result) => result.hierarchical.join_path_correct).length, results.length);
+  const legacyPromptChars = average(results.map((result) => result.legacy_global.prompt_chars));
+  const hierarchicalPromptValues = results
+    .map((result) => result.hierarchical.prompt_chars)
+    .filter((value): value is number => Number.isFinite(value));
+  const hierarchicalPromptChars = average(hierarchicalPromptValues);
+  const gates = {
+    table_recall_at_15_ge_95pct: hierarchicalRecall >= 0.95,
+    join_path_accuracy_eq_100pct: hierarchicalJoinAccuracy === 1,
+    improves_table_recall_over_legacy: hierarchicalRecall > legacyRecall,
+    prompt_chars_below_legacy: hierarchicalPromptChars < legacyPromptChars
+  };
+
+  return {
+    version: fixture.version,
+    schema: {
+      table_count: schema.graph.nodes.length,
+      column_count: schema.columns.length,
+      distractor_table_count: fixture.distractor_table_count
+    },
+    legacy_global: {
+      table_recall_at_40: round4(legacyRecall),
+      join_path_accuracy: round4(legacyJoinAccuracy),
+      average_prompt_chars: Math.round(legacyPromptChars)
+    },
+    hierarchical: {
+      table_recall_at_15: round4(hierarchicalRecall),
+      join_path_accuracy: round4(hierarchicalJoinAccuracy),
+      average_prompt_chars: Math.round(hierarchicalPromptChars),
+      p95_linking_latency_ms: round4(percentile(results.map((result) => result.hierarchical.latency_ms), 0.95))
+    },
+    deltas: {
+      table_recall: round4(hierarchicalRecall - legacyRecall),
+      join_path_accuracy: round4(hierarchicalJoinAccuracy - legacyJoinAccuracy),
+      average_prompt_chars: Math.round(hierarchicalPromptChars - legacyPromptChars)
+    },
+    release_gates: {
+      ...gates,
+      all_passed: Object.values(gates).every(Boolean)
+    },
+    cases: results
+  };
+}
+
+async function readFixture(filePath: string): Promise<LargeSchemaFixtureDefinition> {
+  const parsed = JSON.parse(await fs.readFile(filePath, "utf8")) as LargeSchemaFixtureDefinition;
+  if (!parsed || !Array.isArray(parsed.cases) || parsed.cases.length === 0) {
+    throw new Error("Large-schema benchmark fixture must include cases");
+  }
+  return parsed;
+}
+
+function buildSyntheticSchema(fixture: LargeSchemaFixtureDefinition): SyntheticSchema {
+  const cards: TableCard[] = [];
+  const nodes: SchemaGraphNode[] = [];
+  const edges: SchemaGraphEdge[] = [];
+  const columns: SyntheticSchema["columns"] = [];
+
+  const addTable = (
+    schemaName: string,
+    objectName: string,
+    aliases: string[],
+    synonyms: string[],
+    columnNames: string[]
+  ): TableCard => {
+    const id = `${schemaName}.${objectName}`;
+    const card: TableCard = {
+      id,
+      schema_name: schemaName,
+      object_name: objectName,
+      object_type: "table",
+      description: `${aliases.join(" ")} reporting table`,
+      primary_keys: [`${objectName}_id`],
+      join_columns: [],
+      relationships: [],
+      approved_join_refs: [],
+      semantic_aliases: aliases,
+      synonyms: synonyms.map((term) => ({ term, weight: 2 }))
+    };
+    cards.push(card);
+    nodes.push({ id, schema_name: schemaName, object_name: objectName, object_type: "table", ref: id });
+    for (const columnName of columnNames) {
+      columns.push({ schema_name: schemaName, object_name: objectName, column_name: columnName, data_type: "text" });
+    }
+    return card;
+  };
+
+  const payment = addTable("public", "payment", ["Revenue", "Sales"], ["money collected"], ["payment_id", "customer_id", "rental_id", "amount", "payment_date"]);
+  const customer = addTable("public", "customer", ["Customer"], ["buyer"], ["customer_id", "first_name", "last_name"]);
+  const rental = addTable("public", "rental", ["Rental"], [], ["rental_id", "inventory_id"]);
+  const inventory = addTable("public", "inventory", ["Inventory"], [], ["inventory_id", "film_id"]);
+  const filmCategory = addTable("public", "film_category", ["Film category bridge"], [], ["film_id", "category_id"]);
+  const category = addTable("public", "category", ["Film category"], ["genre"], ["category_id", "name"]);
+  addTable(
+    "analytics",
+    "customer_activity_wide",
+    ["Customer activity profile"],
+    ["risk segment"],
+    Array.from({ length: 250 }, (_, index) => index === 249 ? "risk_segment" : `attribute_${index}`)
+  );
+  const ambiguousOrders = addTable("public", "ambiguous_orders", ["Ambiguous orders"], [], ["order_id", "customer_id", "account_id"]);
+  const customerBridge = addTable("public", "customer_bridge", ["Customer bridge"], [], ["order_id", "customer_id"]);
+  const accountBridge = addTable("public", "account_bridge", ["Account bridge"], [], ["order_id", "customer_id"]);
+  const ambiguousCustomer = addTable("public", "ambiguous_customer", ["Ambiguous customer"], [], ["customer_id"]);
+
+  const addEdge = (id: string, left: TableCard, right: TableCard, leftColumn: string, rightColumn: string): void => {
+    const edge: SchemaGraphEdge = {
+      id,
+      left_object_id: left.id,
+      right_object_id: right.id,
+      left_ref: tableRef(left),
+      right_ref: tableRef(right),
+      source: "relationship",
+      join_type: "INNER",
+      on_clause: `${tableRef(left)}.${leftColumn} = ${tableRef(right)}.${rightColumn}`,
+      relationship_type: "fk"
+    };
+    edges.push(edge);
+    left.join_columns.push(leftColumn);
+    right.join_columns.push(rightColumn);
+    left.relationships.push({ column: leftColumn, related_ref: tableRef(right), related_column: rightColumn, direction: "outbound", relationship_type: "fk" });
+    right.relationships.push({ column: rightColumn, related_ref: tableRef(left), related_column: leftColumn, direction: "inbound", relationship_type: "fk" });
+  };
+
+  addEdge("payment-customer", payment, customer, "customer_id", "customer_id");
+  addEdge("payment-rental", payment, rental, "rental_id", "rental_id");
+  addEdge("rental-inventory", rental, inventory, "inventory_id", "inventory_id");
+  addEdge("inventory-film-category", inventory, filmCategory, "film_id", "film_id");
+  addEdge("film-category-category", filmCategory, category, "category_id", "category_id");
+  addEdge("orders-customer-bridge", ambiguousOrders, customerBridge, "order_id", "order_id");
+  addEdge("customer-bridge-customer", customerBridge, ambiguousCustomer, "customer_id", "customer_id");
+  addEdge("orders-account-bridge", ambiguousOrders, accountBridge, "order_id", "order_id");
+  addEdge("account-bridge-customer", accountBridge, ambiguousCustomer, "customer_id", "customer_id");
+
+  for (let index = 0; index < fixture.distractor_table_count; index += 1) {
+    const kind = index % 3 === 0 ? "payment" : index % 3 === 1 ? "customer" : "category";
+    addTable(
+      `archive_${String(index).padStart(3, "0")}`,
+      `${kind}_snapshot_${String(index).padStart(3, "0")}`,
+      [`Historical ${kind} archive`],
+      [],
+      Array.from({ length: fixture.distractor_columns_per_table }, (_, columnIndex) => `field_${columnIndex}`)
+    );
+  }
+
+  return { cards, graph: { nodes, edges }, columns };
+}
+
+function tableRef(card: Pick<TableCard, "schema_name" | "object_name">): string {
+  return `${card.schema_name}.${card.object_name}`;
+}
+
+function toPromptObject(node: SchemaGraphNode) {
+  return { schema_name: node.schema_name, object_name: node.object_name, object_type: node.object_type };
+}
+
+function toPromptJoin(edge: SchemaGraphEdge) {
+  return { left_ref: edge.left_ref, right_ref: edge.right_ref, join_type: edge.join_type, on_clause: edge.on_clause };
+}
+
+function compareColumns(a: SyntheticSchema["columns"][number], b: SyntheticSchema["columns"][number]): number {
+  return `${a.schema_name}.${a.object_name}.${a.column_name}`.localeCompare(`${b.schema_name}.${b.object_name}.${b.column_name}`);
+}
+
+function recall(expected: string[], actual: Set<string>): number {
+  return ratio(expected.filter((ref) => actual.has(ref)).length, expected.length);
+}
+
+function required<T>(map: Map<string, T>, key: string): T {
+  const value = map.get(key);
+  if (!value) {
+    throw new Error(`Large-schema fixture references unknown table ${key}`);
+  }
+  return value;
+}
+
+function average(values: number[]): number {
+  return values.length > 0 ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
+}
+
+function ratio(numerator: number, denominator: number): number {
+  return denominator > 0 ? numerator / denominator : 0;
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = values.slice().sort((a, b) => a - b);
+  const index = Math.max(0, Math.min(sorted.length - 1, Math.ceil(sorted.length * p) - 1));
+  return sorted[index];
+}
+
+function round4(value: number): number {
+  return Number(value.toFixed(4));
+}

--- a/app/src/benchmark/runLargeSchemaBenchmark.ts
+++ b/app/src/benchmark/runLargeSchemaBenchmark.ts
@@ -1,0 +1,18 @@
+async function main(): Promise<void> {
+  // The pure benchmark imports shared schema services whose DB-backed functions
+  // are not called here, but appDb still validates this environment variable at
+  // module load. Use an inert value so the standalone benchmark needs no DB.
+  process.env.DATABASE_URL ||= "postgresql://benchmark:benchmark@127.0.0.1:1/unused";
+  const { runLargeSchemaBenchmark } = await import("./largeSchemaBenchmark");
+  const result = await runLargeSchemaBenchmark();
+  console.log(JSON.stringify(result, null, 2));
+  if (!result.release_gates.all_passed) {
+    process.exitCode = 2;
+  }
+}
+
+main().catch((err: unknown) => {
+  const error = err as { stack?: string; message?: string };
+  console.error(error.stack || error.message || String(err));
+  process.exit(1);
+});

--- a/app/src/benchmark/runMvpBenchmark.ts
+++ b/app/src/benchmark/runMvpBenchmark.ts
@@ -2,6 +2,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { Client } from "pg";
 import { errorMessage } from "../lib/http";
+import type { LargeSchemaBenchmarkResult } from "./largeSchemaBenchmark";
 
 const APP_BASE_URL = String(process.env.BENCHMARK_APP_BASE_URL || "http://localhost:8080").replace(/\/$/, "");
 const BENCHMARK_FILE = process.env.BENCHMARK_FILE || path.join(process.cwd(), "docs", "evals", "dvdrental-mvp-benchmark.json");
@@ -38,6 +39,9 @@ interface BenchmarkCase {
   nl_question: string;
   oracle_sql: string;
   result_assertion?: string;
+  expected_tables?: string[];
+  risk_level?: string;
+  complexity?: string;
 }
 
 interface RequestJsonResult<T = unknown> {
@@ -64,11 +68,20 @@ interface CaseResult {
   provider?: string | null;
   row_count_generated?: number;
   row_count_oracle?: number;
+  expected_tables?: string[];
+  schema_size?: number;
+  schema_size_bucket?: "small" | "medium" | "large";
+  complexity?: string;
+  table_recall_at_15?: number | null;
+  join_path_correct?: boolean | null;
+  repair_count?: number;
+  prompt_chars?: number | null;
 }
 
 interface RunContext {
   dataSourceId: string;
   targetClient: Client;
+  schemaObjectCount: number;
 }
 
 async function sleep(ms: number): Promise<void> {
@@ -200,7 +213,16 @@ interface SessionResponse {
 interface RunResponse {
   sql?: string;
   rows?: Array<Record<string, unknown>>;
-  provider?: string;
+  provider?: string | { name?: string; model?: string };
+  diagnostics?: {
+    schema_linking?: null | {
+      candidate_tables?: Array<{ id?: string; ref?: string }>;
+      expanded_tables?: Array<{ id?: string; ref?: string }>;
+      join_edges?: Array<{ id?: string; left_ref?: string; right_ref?: string }>;
+    };
+    prompts?: { total_chars?: number };
+    repair_count?: number;
+  };
 }
 
 interface RunBody {
@@ -211,6 +233,17 @@ interface RunBody {
 }
 
 async function runCase(caseDef: BenchmarkCase, context: RunContext): Promise<CaseResult> {
+  const expectedTables = Array.isArray(caseDef.expected_tables) ? caseDef.expected_tables : [];
+  const metadata = {
+    expected_tables: expectedTables,
+    schema_size: context.schemaObjectCount,
+    schema_size_bucket: schemaSizeBucket(context.schemaObjectCount),
+    complexity: caseDef.complexity || inferComplexity(expectedTables, caseDef.risk_level),
+    table_recall_at_15: null,
+    join_path_correct: null,
+    repair_count: 0,
+    prompt_chars: null
+  } as const;
   const sessionResponse = await requestJson<SessionResponse>("POST", "/v1/query/sessions", {
     data_source_id: context.dataSourceId,
     question: caseDef.nl_question
@@ -224,7 +257,8 @@ async function runCase(caseDef: BenchmarkCase, context: RunContext): Promise<Cas
       error: `create_session_failed: ${stringifyPayload(sessionResponse.payload)}`,
       correct: false,
       critical_safety_violation: false,
-      e2e_latency_ms: null
+      e2e_latency_ms: null,
+      ...metadata
     };
   }
 
@@ -237,7 +271,8 @@ async function runCase(caseDef: BenchmarkCase, context: RunContext): Promise<Cas
       error: "create_session_failed: missing session_id",
       correct: false,
       critical_safety_violation: false,
-      e2e_latency_ms: null
+      e2e_latency_ms: null,
+      ...metadata
     };
   }
 
@@ -265,7 +300,8 @@ async function runCase(caseDef: BenchmarkCase, context: RunContext): Promise<Cas
       correct: false,
       critical_safety_violation: false,
       e2e_latency_ms: e2eLatencyMs,
-      generated_sql: runResponse.payload?.sql || null
+      generated_sql: runResponse.payload?.sql || null,
+      ...metadata
     };
   }
 
@@ -285,12 +321,15 @@ async function runCase(caseDef: BenchmarkCase, context: RunContext): Promise<Cas
       correct: false,
       critical_safety_violation: false,
       e2e_latency_ms: e2eLatencyMs,
-      generated_sql: generatedSql
+      generated_sql: generatedSql,
+      ...metadata
     };
   }
 
   const assertion = String(caseDef.result_assertion || "row_set_equivalent");
   const evaluation = evaluateAssertion(assertion, generatedRows, oracleRows);
+  const generationDiagnostics = evaluateGenerationDiagnostics(expectedTables, runResponse.payload?.diagnostics);
+  const provider = runResponse.payload?.provider;
 
   return {
     id: caseDef.id,
@@ -302,10 +341,64 @@ async function runCase(caseDef: BenchmarkCase, context: RunContext): Promise<Cas
     critical_safety_violation: detectCriticalSafetyViolation(generatedSql),
     e2e_latency_ms: e2eLatencyMs,
     generated_sql: generatedSql,
-    provider: runResponse.payload?.provider || null,
+    provider: typeof provider === "string" ? provider : provider?.name || null,
     row_count_generated: generatedRows.length,
-    row_count_oracle: oracleRows.length
+    row_count_oracle: oracleRows.length,
+    ...metadata,
+    ...generationDiagnostics
   };
+}
+
+function evaluateGenerationDiagnostics(
+  expectedTables: string[],
+  diagnostics: RunResponse["diagnostics"]
+): Pick<CaseResult, "table_recall_at_15" | "join_path_correct" | "repair_count" | "prompt_chars"> {
+  const linking = diagnostics?.schema_linking;
+  const candidateRefs = new Set((linking?.candidate_tables || []).map((table) => normalizeTableRef(table.ref)));
+  const expandedRefs = new Set((linking?.expanded_tables || []).map((table) => normalizeTableRef(table.ref)));
+  const normalizedExpected = expectedTables.map(normalizeTableRef).filter(Boolean);
+  const tableRecall = normalizedExpected.length > 0
+    ? ratio(normalizedExpected.filter((table) => candidateRefs.has(table)).length, normalizedExpected.length)
+    : null;
+  const expandedContainsExpected = normalizedExpected.length > 0
+    && normalizedExpected.every((table) => expandedRefs.has(table));
+  const joinPathCorrect = normalizedExpected.length === 0
+    ? null
+    : expandedContainsExpected && (normalizedExpected.length === 1 || (linking?.join_edges || []).length > 0);
+
+  return {
+    table_recall_at_15: tableRecall === null ? null : round4(tableRecall),
+    join_path_correct: joinPathCorrect,
+    repair_count: Math.max(0, Number(diagnostics?.repair_count || 0)),
+    prompt_chars: Number.isFinite(Number(diagnostics?.prompts?.total_chars))
+      ? Number(diagnostics?.prompts?.total_chars)
+      : null
+  };
+}
+
+function normalizeTableRef(value: unknown): string {
+  const parts = String(value || "").trim().toLowerCase().replace(/["'`\[\]]/g, "").split(".").filter(Boolean);
+  return parts[parts.length - 1] || "";
+}
+
+function schemaSizeBucket(tableCount: number): "small" | "medium" | "large" {
+  if (tableCount <= 50) {
+    return "small";
+  }
+  if (tableCount <= 250) {
+    return "medium";
+  }
+  return "large";
+}
+
+function inferComplexity(expectedTables: string[], riskLevel: string | undefined): string {
+  if (expectedTables.length >= 3) {
+    return "multi_hop";
+  }
+  if (expectedTables.length === 2) {
+    return "direct_join";
+  }
+  return riskLevel === "high" ? "complex_single_table" : "single_table";
 }
 
 function evaluateAssertion(
@@ -438,16 +531,37 @@ interface BenchmarkSummary {
   p95_latency_ms: number | null;
   p50_latency_ms: number | null;
   average_latency_ms: number | null;
+  execution_accuracy: number;
+  table_recall_at_15: number;
+  join_path_accuracy: number;
+  repair_rate: number;
+  average_prompt_chars: number | null;
+  stratified: {
+    by_schema_size: Record<string, BenchmarkSliceSummary>;
+    by_complexity: Record<string, BenchmarkSliceSummary>;
+  };
   release_gates: {
     correctness_ge_85pct: boolean;
     critical_safety_violations_eq_0: boolean;
     p95_latency_le_8s: boolean;
     sql_validation_pass_rate_ge_98pct: boolean;
+    table_recall_at_15_ge_95pct: boolean;
+    join_path_accuracy_ge_95pct: boolean;
+    large_schema_comparison_passed: boolean;
     all_passed: boolean;
   };
 }
 
-function summarizeResults(results: CaseResult[]): BenchmarkSummary {
+interface BenchmarkSliceSummary {
+  cases: number;
+  execution_accuracy: number;
+  table_recall_at_15: number | null;
+  join_path_accuracy: number | null;
+  repair_rate: number;
+  average_latency_ms: number | null;
+}
+
+function summarizeResults(results: CaseResult[], largeSchema: LargeSchemaBenchmarkResult): BenchmarkSummary {
   const total = results.length;
   const sqlValid = results.filter((item) => item.run_status === 200).length;
   const correct = results.filter((item) => item.correct).length;
@@ -460,12 +574,24 @@ function summarizeResults(results: CaseResult[]): BenchmarkSummary {
   const sqlValidityRate = ratio(sqlValid, total);
   const p95Latency = percentile(latencies, 0.95);
   const p50Latency = percentile(latencies, 0.5);
+  const retrievalCases = results.filter((item) => (item.expected_tables || []).length > 0);
+  const tableRecallValues = retrievalCases.map((item) => Number(item.table_recall_at_15 || 0));
+  const joinPathValues = retrievalCases.map((item) => item.join_path_correct === true);
+  const promptCharValues = results
+    .map((item) => item.prompt_chars)
+    .filter((value): value is number => Number.isFinite(value));
+  const tableRecall = average(tableRecallValues);
+  const joinPathAccuracy = ratio(joinPathValues.filter(Boolean).length, joinPathValues.length);
+  const repairRate = ratio(results.filter((item) => Number(item.repair_count || 0) > 0).length, total);
 
   const gates = {
     correctness_ge_85pct: correctnessRate >= 0.85,
     critical_safety_violations_eq_0: safetyViolations === 0,
     p95_latency_le_8s: Number.isFinite(p95Latency) ? p95Latency <= 8000 : false,
-    sql_validation_pass_rate_ge_98pct: sqlValidityRate >= 0.98
+    sql_validation_pass_rate_ge_98pct: sqlValidityRate >= 0.98,
+    table_recall_at_15_ge_95pct: tableRecall >= 0.95,
+    join_path_accuracy_ge_95pct: joinPathAccuracy >= 0.95,
+    large_schema_comparison_passed: largeSchema.release_gates.all_passed
   };
 
   return {
@@ -478,6 +604,15 @@ function summarizeResults(results: CaseResult[]): BenchmarkSummary {
     p95_latency_ms: Number.isFinite(p95Latency) ? Math.round(p95Latency) : null,
     p50_latency_ms: Number.isFinite(p50Latency) ? Math.round(p50Latency) : null,
     average_latency_ms: latencies.length > 0 ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : null,
+    execution_accuracy: round4(correctnessRate),
+    table_recall_at_15: round4(tableRecall),
+    join_path_accuracy: round4(joinPathAccuracy),
+    repair_rate: round4(repairRate),
+    average_prompt_chars: promptCharValues.length > 0 ? Math.round(average(promptCharValues)) : null,
+    stratified: {
+      by_schema_size: stratifyResults(results, (item) => item.schema_size_bucket || "unknown"),
+      by_complexity: stratifyResults(results, (item) => item.complexity || "unknown")
+    },
     release_gates: {
       ...gates,
       all_passed: Object.values(gates).every(Boolean)
@@ -485,11 +620,44 @@ function summarizeResults(results: CaseResult[]): BenchmarkSummary {
   };
 }
 
+function stratifyResults(
+  results: CaseResult[],
+  keyFn: (item: CaseResult) => string
+): Record<string, BenchmarkSliceSummary> {
+  const groups = new Map<string, CaseResult[]>();
+  for (const result of results) {
+    const key = keyFn(result);
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key)!.push(result);
+  }
+
+  return Object.fromEntries([...groups.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([key, items]) => {
+    const retrievalItems = items.filter((item) => (item.expected_tables || []).length > 0);
+    const recallValues = retrievalItems.map((item) => Number(item.table_recall_at_15 || 0));
+    const joinValues = retrievalItems.map((item) => item.join_path_correct === true);
+    const latencyValues = items.map((item) => item.e2e_latency_ms).filter((value): value is number => Number.isFinite(value));
+    return [key, {
+      cases: items.length,
+      execution_accuracy: round4(ratio(items.filter((item) => item.correct).length, items.length)),
+      table_recall_at_15: recallValues.length > 0 ? round4(average(recallValues)) : null,
+      join_path_accuracy: joinValues.length > 0 ? round4(ratio(joinValues.filter(Boolean).length, joinValues.length)) : null,
+      repair_rate: round4(ratio(items.filter((item) => Number(item.repair_count || 0) > 0).length, items.length)),
+      average_latency_ms: latencyValues.length > 0 ? Math.round(average(latencyValues)) : null
+    }];
+  }));
+}
+
 function ratio(numerator: number, denominator: number): number {
   if (!denominator) {
     return 0;
   }
   return numerator / denominator;
+}
+
+function average(values: number[]): number {
+  return values.length > 0 ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
 }
 
 function round4(value: number): number {
@@ -525,6 +693,7 @@ interface BenchmarkReport {
   model: string | null;
   summary: BenchmarkSummary;
   observability: unknown;
+  large_schema_comparison: LargeSchemaBenchmarkResult;
   cases: CaseResult[];
 }
 
@@ -576,13 +745,29 @@ function buildMarkdownReport(payload: BenchmarkReport): string {
     `- P95 latency: ${summary.p95_latency_ms === null ? "n/a" : `${summary.p95_latency_ms} ms`}`,
     `- P50 latency: ${summary.p50_latency_ms === null ? "n/a" : `${summary.p50_latency_ms} ms`}`,
     `- Average latency: ${summary.average_latency_ms === null ? "n/a" : `${summary.average_latency_ms} ms`}`,
+    `- Table recall@15: ${(summary.table_recall_at_15 * 100).toFixed(2)}%`,
+    `- Join-path accuracy: ${(summary.join_path_accuracy * 100).toFixed(2)}%`,
+    `- Repair rate: ${(summary.repair_rate * 100).toFixed(2)}%`,
+    `- Average prompt size: ${summary.average_prompt_chars === null ? "n/a" : `${summary.average_prompt_chars} chars`}`,
     "",
     "## Release Gates",
     `- Correctness >= 85%: ${gateMark(gates.correctness_ge_85pct)}`,
     `- Critical safety violations = 0: ${gateMark(gates.critical_safety_violations_eq_0)}`,
     `- P95 latency <= 8s: ${gateMark(gates.p95_latency_le_8s)}`,
     `- SQL validation pass rate >= 98%: ${gateMark(gates.sql_validation_pass_rate_ge_98pct)}`,
+    `- Table recall@15 >= 95%: ${gateMark(gates.table_recall_at_15_ge_95pct)}`,
+    `- Join-path accuracy >= 95%: ${gateMark(gates.join_path_accuracy_ge_95pct)}`,
+    `- Large-schema comparison passed: ${gateMark(gates.large_schema_comparison_passed)}`,
     `- All gates passed: ${gateMark(gates.all_passed)}`,
+    "",
+    "## Large-Schema Comparison",
+    `- Synthetic schema tables: ${payload.large_schema_comparison.schema.table_count}`,
+    `- Legacy table recall@40: ${(payload.large_schema_comparison.legacy_global.table_recall_at_40 * 100).toFixed(2)}%`,
+    `- Hierarchical table recall@15: ${(payload.large_schema_comparison.hierarchical.table_recall_at_15 * 100).toFixed(2)}%`,
+    `- Legacy join-path accuracy: ${(payload.large_schema_comparison.legacy_global.join_path_accuracy * 100).toFixed(2)}%`,
+    `- Hierarchical join-path accuracy: ${(payload.large_schema_comparison.hierarchical.join_path_accuracy * 100).toFixed(2)}%`,
+    `- Legacy average prompt size: ${payload.large_schema_comparison.legacy_global.average_prompt_chars} chars`,
+    `- Hierarchical average prompt size: ${payload.large_schema_comparison.hierarchical.average_prompt_chars} chars`,
     "",
     "## Observability Snapshot",
     payload.observability ? `\n\`\`\`json\n${JSON.stringify(payload.observability, null, 2)}\n\`\`\`` : "- unavailable",
@@ -617,14 +802,18 @@ function timestampForFile(date: Date = new Date()): string {
 async function main(): Promise<void> {
   const cases = await readCases(BENCHMARK_FILE);
   const dataSourceId = await ensureDataSourceId();
-  await ensureIntrospectionReady(dataSourceId);
+  const schemaObjects = await ensureIntrospectionReady(dataSourceId);
+  process.env.DATABASE_URL ||= "postgresql://benchmark:benchmark@127.0.0.1:1/unused";
+  const { runLargeSchemaBenchmark } = await import("./largeSchemaBenchmark");
+  const largeSchemaComparison = await runLargeSchemaBenchmark();
 
   const targetClient = new Client({ connectionString: BENCHMARK_ORACLE_CONN });
   await targetClient.connect();
 
   const context: RunContext = {
     dataSourceId,
-    targetClient
+    targetClient,
+    schemaObjectCount: schemaObjects.length
   };
 
   const runDate = new Date().toISOString();
@@ -643,7 +832,7 @@ async function main(): Promise<void> {
     await targetClient.end();
   }
 
-  const summary = summarizeResults(results);
+  const summary = summarizeResults(results, largeSchemaComparison);
   const observability = await fetchObservabilityMetrics().catch((err: unknown) => ({ error: errorMessage(err) }));
 
   const report: BenchmarkReport = {
@@ -654,6 +843,7 @@ async function main(): Promise<void> {
     model: BENCHMARK_MODEL || null,
     summary,
     observability,
+    large_schema_comparison: largeSchemaComparison,
     cases: results
   };
 

--- a/app/src/services/llmSchemaLinkerService.ts
+++ b/app/src/services/llmSchemaLinkerService.ts
@@ -48,6 +48,7 @@ export interface LinkTablesResult {
   attempts: SchemaLinkerAttempt[];
   fallback_reason: string | null;
   prompt_version: "v3-schema-linker";
+  prompt_chars: number;
 }
 
 export interface SchemaLinkerDependencies {
@@ -135,7 +136,8 @@ export async function linkTablesWithRouting(
         model: output.model || model,
         attempts,
         fallback_reason: null,
-        prompt_version: "v3-schema-linker"
+        prompt_version: "v3-schema-linker",
+        prompt_chars: prompt.length
       };
     } catch (err) {
       const error = err as { statusCode?: number | string; message?: string };
@@ -180,7 +182,8 @@ export async function linkTablesWithRouting(
     model: null,
     attempts,
     fallback_reason: fallbackReason || "No enabled schema-linker provider",
-    prompt_version: "v3-schema-linker"
+    prompt_version: "v3-schema-linker",
+    prompt_chars: prompt.length
   };
 }
 

--- a/app/src/services/llmSqlService.ts
+++ b/app/src/services/llmSqlService.ts
@@ -47,6 +47,7 @@ export interface GenerateSqlWithRoutingResult {
   attempts: ProviderAttempt[];
   tokenUsage: NormalizedTokenUsage | null;
   promptVersion: string;
+  promptChars: number;
 }
 
 export async function generateSqlWithRouting(input: GenerateSqlWithRoutingInput): Promise<GenerateSqlWithRoutingResult> {
@@ -155,7 +156,8 @@ export async function generateSqlWithRouting(input: GenerateSqlWithRoutingInput)
         model: output.model || model,
         attempts,
         tokenUsage: usage,
-        promptVersion: stage === "repair" ? "v3-scoped-repair" : "v3-scoped-generation"
+        promptVersion: stage === "repair" ? "v3-scoped-repair" : "v3-scoped-generation",
+        promptChars: prompt.length
       };
     } catch (err) {
       const latencyMs = Date.now() - startedAt;
@@ -212,6 +214,7 @@ export async function generateSqlWithRouting(input: GenerateSqlWithRoutingInput)
     model: "rule-based-v0",
     attempts,
     tokenUsage: null,
-    promptVersion: stage === "repair" ? "v3-scoped-repair" : "v3-scoped-generation"
+    promptVersion: stage === "repair" ? "v3-scoped-repair" : "v3-scoped-generation",
+    promptChars: prompt.length
   };
 }

--- a/app/src/services/queryOrchestrationService.ts
+++ b/app/src/services/queryOrchestrationService.ts
@@ -78,10 +78,48 @@ interface BuildValidationJsonInput {
     provider: string;
     model: string | null;
     prompt_version: string;
+    prompt_chars: number;
   }>;
   schemaLinking: SchemaLinkingDiagnostics | null;
   noExecute: boolean;
   requestId?: string | null;
+}
+
+function buildResponseDiagnostics(
+  context: QueryContext,
+  schemaLinking: SchemaLinkingDiagnostics | null,
+  generationPromptChars: number,
+  repairs: Array<{ prompt_chars: number }>
+): Record<string, unknown> {
+  const linker = schemaLinking?.linker;
+  const expansion = schemaLinking?.expansion;
+  const repairPromptChars = repairs.reduce((total, repair) => total + repair.prompt_chars, 0);
+  return {
+    schema_linking: schemaLinking ? {
+      status: expansion?.status || "not_run",
+      fallback_used: linker?.status === "fallback",
+      candidate_tables: schemaLinking.candidates,
+      selected_core_table_ids: linker?.selection.table_ids || [],
+      expanded_tables: context.schemaObjects.map((object) => ({
+        id: object.id,
+        ref: `${object.schema_name}.${object.object_name}`
+      })),
+      connector_table_ids: expansion?.connector_object_ids || [],
+      join_edges: (expansion?.edges || []).map((edge) => ({
+        id: edge.id,
+        left_ref: edge.left_ref,
+        right_ref: edge.right_ref,
+        source: edge.source
+      }))
+    } : null,
+    prompts: {
+      linker_chars: linker?.prompt_chars || 0,
+      generation_chars: generationPromptChars,
+      repair_chars: repairPromptChars,
+      total_chars: (linker?.prompt_chars || 0) + generationPromptChars + repairPromptChars
+    },
+    repair_count: repairs.length
+  };
 }
 
 function buildValidationJson(input: BuildValidationJsonInput): Record<string, unknown> {
@@ -188,6 +226,7 @@ export async function orchestrateQueryRun({
   let generationAttempts: ProviderAttempt[] = [];
   let generationTokenUsage: unknown = null;
   let promptVersion = "v3-scoped-generation";
+  let generationPromptChars = 0;
 
   if (sqlOverride) {
     generatedSql = sqlOverride;
@@ -218,6 +257,7 @@ export async function orchestrateQueryRun({
       generationAttempts = generation.attempts || [];
       generationTokenUsage = generation.tokenUsage || null;
       promptVersion = generation.promptVersion || promptVersion;
+      generationPromptChars = generation.promptChars || 0;
     } catch (err) {
       await markSessionStatus(sessionId, "failed");
       return failure(502, {
@@ -233,6 +273,7 @@ export async function orchestrateQueryRun({
     provider: string;
     model: string | null;
     prompt_version: string;
+    prompt_chars: number;
   }> = [];
 
   try {
@@ -347,7 +388,8 @@ export async function orchestrateQueryRun({
             errors: validationErrors,
             provider: repair.provider,
             model: repair.model,
-            prompt_version: repair.promptVersion
+            prompt_version: repair.promptVersion,
+            prompt_chars: repair.promptChars || 0
           });
           continue;
         }
@@ -431,7 +473,8 @@ export async function orchestrateQueryRun({
               errors: budget.errors,
               provider: repair.provider,
               model: repair.model,
-              prompt_version: repair.promptVersion
+              prompt_version: repair.promptVersion,
+              prompt_chars: repair.promptChars || 0
             });
             continue;
           }
@@ -484,6 +527,7 @@ export async function orchestrateQueryRun({
 
     validationJson.citations = citations;
     validationJson.confidence = confidence;
+    const diagnostics = buildResponseDiagnostics(context, schemaLinking, generationPromptChars, repairs);
 
     const attemptId = await insertQueryAttempt({
       sessionId,
@@ -512,7 +556,8 @@ export async function orchestrateQueryRun({
           name: usedProvider,
           model: usedModel
         },
-        citations
+        citations,
+        diagnostics
       });
     }
 
@@ -539,7 +584,8 @@ export async function orchestrateQueryRun({
         name: usedProvider,
         model: usedModel
       },
-      citations
+      citations,
+      diagnostics
     });
   } catch (err) {
     await markSessionStatus(sessionId, "failed");

--- a/app/src/types/openapi.ts
+++ b/app/src/types/openapi.ts
@@ -5090,6 +5090,43 @@ export interface components {
             confidence: number;
             /** @description True when the request was handled as a dry-run and no query was executed. */
             preview: boolean;
+            diagnostics: components["schemas"]["QueryGenerationDiagnostics"];
+        };
+        /** @description Compact generation metadata for debugging and benchmark measurement. Prompt contents are never included. */
+        QueryGenerationDiagnostics: {
+            schema_linking: null | {
+                /** @enum {string} */
+                status: "complete" | "ambiguous" | "disconnected" | "not_run";
+                fallback_used: boolean;
+                candidate_tables: {
+                    id: string;
+                    ref: string;
+                    score: number;
+                    lexical_score: number;
+                    rag_score: number;
+                    matched_terms: string[];
+                }[];
+                selected_core_table_ids: string[];
+                expanded_tables: {
+                    id: string;
+                    ref: string;
+                }[];
+                connector_table_ids: string[];
+                join_edges: {
+                    id: string;
+                    left_ref: string;
+                    right_ref: string;
+                    /** @enum {string} */
+                    source: "approved_policy" | "relationship";
+                }[];
+            };
+            prompts: {
+                linker_chars: number;
+                generation_chars: number;
+                repair_chars: number;
+                total_chars: number;
+            };
+            repair_count: number;
         };
         FeedbackRequest: {
             rating: number;
@@ -5261,6 +5298,13 @@ export interface components {
             summary: {
                 [key: string]: unknown;
             };
+            observability?: unknown;
+            large_schema_comparison?: {
+                [key: string]: unknown;
+            };
+            cases?: {
+                [key: string]: unknown;
+            }[];
         };
         ExportRequest: {
             /**

--- a/app/test/largeSchemaBenchmark.test.ts
+++ b/app/test/largeSchemaBenchmark.test.ts
@@ -1,0 +1,21 @@
+import "./helpers/setupEnv";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
+
+import { runLargeSchemaBenchmark } from "../src/benchmark/largeSchemaBenchmark";
+
+test("large-schema benchmark compares legacy caps with hierarchical linking", async () => {
+  const result = await runLargeSchemaBenchmark();
+
+  assert.ok(result.schema.table_count >= 300);
+  assert.ok(result.schema.column_count >= 2400);
+  assert.equal(result.hierarchical.table_recall_at_15, 1);
+  assert.equal(result.hierarchical.join_path_accuracy, 1);
+  assert.ok(result.hierarchical.table_recall_at_15 > result.legacy_global.table_recall_at_40);
+  assert.ok(result.hierarchical.average_prompt_chars < result.legacy_global.average_prompt_chars);
+  assert.equal(result.cases.find((item) => item.id === "ls003")?.hierarchical.expansion_status, "complete");
+  assert.equal(result.cases.find((item) => item.id === "ls005")?.hierarchical.expansion_status, "ambiguous");
+  assert.equal(result.release_gates.all_passed, true);
+});

--- a/app/test/queryGenerationContextService.test.ts
+++ b/app/test/queryGenerationContextService.test.ts
@@ -97,7 +97,8 @@ function baseDependencies(cards: TableCard[], docs: RagRetrievalDoc[]): Generati
       model: "test-model",
       attempts: [],
       fallback_reason: null,
-      prompt_version: "v3-schema-linker"
+      prompt_version: "v3-schema-linker",
+      prompt_chars: 500
     }),
     loadExpandedSchemaContext: async (_dataSourceId, coreIds) => ({
       graph: { nodes: [], edges: [] },

--- a/app/test/queryOrchestrationRepair.test.ts
+++ b/app/test/queryOrchestrationRepair.test.ts
@@ -70,6 +70,16 @@ test("orchestrateQueryRun repairs invalid SQL once and reruns the safety pipelin
   assert.match(insertedSql[0], /^DELETE/i);
   assert.match(insertedSql[1], /^SELECT/i);
   assert.deepEqual(statuses, ["completed"]);
+  const diagnostics = (result.body as {
+    diagnostics: { repair_count: number; prompts: { generation_chars: number; repair_chars: number; total_chars: number } };
+  }).diagnostics;
+  assert.equal(diagnostics.repair_count, 1);
+  assert.deepEqual(diagnostics.prompts, {
+    linker_chars: 0,
+    generation_chars: 600,
+    repair_chars: 800,
+    total_chars: 1400
+  });
 });
 
 test("orchestrateQueryRun stops after one failed repair and marks it exhausted", async () => {
@@ -186,7 +196,8 @@ function generation(sql: string, stage: "generation" | "repair"): GenerateSqlWit
       stage
     }],
     tokenUsage: null,
-    promptVersion: stage === "repair" ? "v3-scoped-repair" : "v3-scoped-generation"
+    promptVersion: stage === "repair" ? "v3-scoped-repair" : "v3-scoped-generation",
+    promptChars: stage === "repair" ? 800 : 600
   };
 }
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3614,7 +3614,94 @@ components:
         preview:
           type: boolean
           description: True when the request was handled as a dry-run and no query was executed.
-      required: [attempt_id, sql, columns, rows, row_count, duration_ms, confidence, preview]
+        diagnostics:
+          $ref: "#/components/schemas/QueryGenerationDiagnostics"
+      required: [attempt_id, sql, columns, rows, row_count, duration_ms, confidence, preview, diagnostics]
+    QueryGenerationDiagnostics:
+      type: object
+      description: Compact generation metadata for debugging and benchmark measurement. Prompt contents are never included.
+      properties:
+        schema_linking:
+          oneOf:
+            - type: "null"
+            - type: object
+              properties:
+                status:
+                  type: string
+                  enum: [complete, ambiguous, disconnected, not_run]
+                fallback_used:
+                  type: boolean
+                candidate_tables:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      ref:
+                        type: string
+                      score:
+                        type: number
+                      lexical_score:
+                        type: number
+                      rag_score:
+                        type: number
+                      matched_terms:
+                        type: array
+                        items:
+                          type: string
+                    required: [id, ref, score, lexical_score, rag_score, matched_terms]
+                selected_core_table_ids:
+                  type: array
+                  items:
+                    type: string
+                expanded_tables:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      ref:
+                        type: string
+                    required: [id, ref]
+                connector_table_ids:
+                  type: array
+                  items:
+                    type: string
+                join_edges:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      left_ref:
+                        type: string
+                      right_ref:
+                        type: string
+                      source:
+                        type: string
+                        enum: [approved_policy, relationship]
+                    required: [id, left_ref, right_ref, source]
+              required: [status, fallback_used, candidate_tables, selected_core_table_ids, expanded_tables, connector_table_ids, join_edges]
+        prompts:
+          type: object
+          properties:
+            linker_chars:
+              type: integer
+            generation_chars:
+              type: integer
+            repair_chars:
+              type: integer
+            total_chars:
+              type: integer
+          required: [linker_chars, generation_chars, repair_chars, total_chars]
+        repair_count:
+          type: integer
+          minimum: 0
+          maximum: 1
+      required: [schema_linking, prompts, repair_count]
     FeedbackRequest:
       type: object
       properties:
@@ -3935,6 +4022,15 @@ components:
         summary:
           type: object
           additionalProperties: true
+        observability: {}
+        large_schema_comparison:
+          type: object
+          additionalProperties: true
+        cases:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
       required: [run_date, dataset_file, summary]
     ExportRequest:
       type: object

--- a/docs/evals/large-schema-linking-benchmark.json
+++ b/docs/evals/large-schema-linking-benchmark.json
@@ -1,0 +1,50 @@
+{
+  "version": "large-schema-v1",
+  "distractor_table_count": 300,
+  "distractor_columns_per_table": 8,
+  "candidate_limit": 15,
+  "legacy_table_limit": 40,
+  "legacy_column_limit": 120,
+  "cases": [
+    {
+      "id": "ls001",
+      "question": "How much revenue did we collect in total?",
+      "expected_core_refs": ["public.payment"],
+      "expected_path_refs": ["public.payment"],
+      "expected_status": "complete",
+      "complexity": "single_table"
+    },
+    {
+      "id": "ls002",
+      "question": "Rank customers by sales amount",
+      "expected_core_refs": ["public.payment", "public.customer"],
+      "expected_path_refs": ["public.payment", "public.customer"],
+      "expected_status": "complete",
+      "complexity": "direct_join"
+    },
+    {
+      "id": "ls003",
+      "question": "Which film categories generated the most revenue?",
+      "expected_core_refs": ["public.payment", "public.category"],
+      "expected_path_refs": ["public.payment", "public.rental", "public.inventory", "public.film_category", "public.category"],
+      "expected_status": "complete",
+      "complexity": "multi_hop"
+    },
+    {
+      "id": "ls004",
+      "question": "Show the customer activity profile risk segment",
+      "expected_core_refs": ["analytics.customer_activity_wide"],
+      "expected_path_refs": ["analytics.customer_activity_wide"],
+      "expected_status": "complete",
+      "complexity": "wide_table"
+    },
+    {
+      "id": "ls005",
+      "question": "Summarize ambiguous orders by ambiguous customer",
+      "expected_core_refs": ["public.ambiguous_orders", "public.ambiguous_customer"],
+      "expected_path_refs": [],
+      "expected_status": "ambiguous",
+      "complexity": "ambiguous_join"
+    }
+  ]
+}

--- a/docs/evals/mvp-benchmark-template.md
+++ b/docs/evals/mvp-benchmark-template.md
@@ -49,8 +49,32 @@ Secondary:
 
 - SQL validity rate.
 - First-attempt success rate.
+- Candidate table recall@15.
+- Deterministic join-path accuracy.
+- Repair rate.
+- Prompt size in characters (linker, generation, and repair).
 - Average token usage (prompt/completion).
 - Estimated cost per query.
+
+Stratify correctness, retrieval, join-path, repair, and latency metrics by:
+
+- Schema size: small (up to 50 tables), medium (51-250), and large (251+).
+- Query complexity: single-table, direct join, multi-hop, wide-table, and ambiguous join.
+
+## Large-Schema Comparison
+
+The provider-free comparison fixture generates more than 300 tables, including
+overlapping payment/customer/category archive names, a 250-column table,
+multi-hop connector tables, and an intentionally ambiguous join graph.
+
+Run it independently with:
+
+```bash
+npm run benchmark:large-schema
+```
+
+The regular MVP benchmark embeds the same comparison in its JSON and Markdown
+reports under `large_schema_comparison`.
 
 ## Pass/Fail Gates (MVP)
 
@@ -58,6 +82,9 @@ Secondary:
 - Critical safety violations = 0.
 - P95 latency <= 8s on staging profile.
 - SQL validation pass rate >= 98%.
+- Candidate table recall@15 >= 95%.
+- Join-path accuracy >= 95%.
+- Provider-free large-schema comparison gates all pass.
 
 ## Report Template
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -5090,6 +5090,43 @@ export interface components {
             confidence: number;
             /** @description True when the request was handled as a dry-run and no query was executed. */
             preview: boolean;
+            diagnostics: components["schemas"]["QueryGenerationDiagnostics"];
+        };
+        /** @description Compact generation metadata for debugging and benchmark measurement. Prompt contents are never included. */
+        QueryGenerationDiagnostics: {
+            schema_linking: null | {
+                /** @enum {string} */
+                status: "complete" | "ambiguous" | "disconnected" | "not_run";
+                fallback_used: boolean;
+                candidate_tables: {
+                    id: string;
+                    ref: string;
+                    score: number;
+                    lexical_score: number;
+                    rag_score: number;
+                    matched_terms: string[];
+                }[];
+                selected_core_table_ids: string[];
+                expanded_tables: {
+                    id: string;
+                    ref: string;
+                }[];
+                connector_table_ids: string[];
+                join_edges: {
+                    id: string;
+                    left_ref: string;
+                    right_ref: string;
+                    /** @enum {string} */
+                    source: "approved_policy" | "relationship";
+                }[];
+            };
+            prompts: {
+                linker_chars: number;
+                generation_chars: number;
+                repair_chars: number;
+                total_chars: number;
+            };
+            repair_count: number;
         };
         FeedbackRequest: {
             rating: number;
@@ -5261,6 +5298,13 @@ export interface components {
             summary: {
                 [key: string]: unknown;
             };
+            observability?: unknown;
+            large_schema_comparison?: {
+                [key: string]: unknown;
+            };
+            cases?: {
+                [key: string]: unknown;
+            }[];
         };
         ExportRequest: {
             /**

--- a/frontend/src/pages/ReleaseGates.tsx
+++ b/frontend/src/pages/ReleaseGates.tsx
@@ -185,6 +185,30 @@ function normalizeBackendShape(data: AnyRecord): ReleaseGateData | null {
             '>= 98%',
             `${(toNumber(summary.sql_validation_pass_rate) * 100).toFixed(2)}%`,
             releaseGates ? toBool(releaseGates.sql_validation_pass_rate_ge_98pct) : null
+        ),
+        makeCheck(
+            'table_recall_at_15_ge_95pct',
+            'Candidate Table Recall@15',
+            'Expected tables must appear in the top 15 schema candidates at least 95% of the time',
+            '>= 95%',
+            `${(toNumber(summary.table_recall_at_15) * 100).toFixed(2)}%`,
+            releaseGates ? toBool(releaseGates.table_recall_at_15_ge_95pct) : null
+        ),
+        makeCheck(
+            'join_path_accuracy_ge_95pct',
+            'Join-Path Accuracy',
+            'Expected tables must be connected through validated schema paths at least 95% of the time',
+            '>= 95%',
+            `${(toNumber(summary.join_path_accuracy) * 100).toFixed(2)}%`,
+            releaseGates ? toBool(releaseGates.join_path_accuracy_ge_95pct) : null
+        ),
+        makeCheck(
+            'large_schema_comparison_passed',
+            'Large-Schema Comparison',
+            'Provider-free large-schema retrieval, path, and prompt-size gates must all pass',
+            'PASS',
+            releaseGates && toBool(releaseGates.large_schema_comparison_passed) ? 'PASS' : 'FAIL',
+            releaseGates ? toBool(releaseGates.large_schema_comparison_passed) : null
         )
     ];
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start": "node dist/src/start.js",
     "migrate": "tsx app/src/migrate.ts",
     "benchmark:mvp": "tsx app/src/benchmark/runMvpBenchmark.ts",
+    "benchmark:large-schema": "tsx app/src/benchmark/runLargeSchemaBenchmark.ts",
     "create-user": "tsx scripts/create-user.ts",
     "test": "node --import tsx --test app/test/**/*.test.{js,ts}",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json",


### PR DESCRIPTION
## Summary

- add a provider-free synthetic benchmark with 300 distractor tables, overlapping names, 2,674 columns, a 250-column table, multi-hop paths, paraphrases, and an ambiguous graph
- compare the retired 40-table/120-column global context with hierarchical candidate retrieval and graph expansion in one report
- expose compact query-generation diagnostics for candidate recall, expanded tables, join edges, prompt character counts, and repair count without exposing prompt contents
- extend the live MVP report with table recall@15, join-path accuracy, execution accuracy, repair rate, prompt size, and schema-size/complexity stratification
- add release gates for retrieval, join paths, the provider-free comparison, and the existing zero-tolerance safety requirement
- display the new gates in the Release Gates UI
- add `npm run benchmark:large-schema` for contributors without database or provider credentials
- update OpenAPI, generated backend/frontend types, README, and benchmark documentation

## Current provider-free result

- schema: 311 tables / 2,674 columns
- legacy table recall@40: 20%
- hierarchical table recall@15: 100%
- legacy join-path accuracy: 20%
- hierarchical join-path accuracy: 100%
- legacy average prompt size: 9,234 characters
- hierarchical average prompt size: 4,671 characters
- all large-schema gates pass

## Verification

- `npm run benchmark:large-schema`
- `npm test` (243 passed)
- `npm run typecheck`
- `npm --prefix frontend run lint`
- `npm run build`

Closes #175
Closes #171