### PR TITLE
Enable strict TypeScript for backend source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Report Pilot is a local-first NL-to-SQL reporting runtime. This file is canonica
 
 - Backend source and tests are TypeScript-only. Do not add `.js` files under `app/src/**` or `app/test/**`.
 - TypeScript 7 is the application compiler. The OpenAPI generator has an isolated TypeScript 5.9 toolchain because it still depends on the legacy compiler API.
+- Production backend code and scripts compile in strict mode. Tests remain on the transitional `tsconfig.test.json` profile while issue #148 tracks strict test-harness migration.
 - Prefer precise types or `unknown` over `any`; do not bypass type errors with `@ts-ignore`.
 
 ## Code Map

--- a/app/src/adapters/llm/geminiAdapter.ts
+++ b/app/src/adapters/llm/geminiAdapter.ts
@@ -10,6 +10,19 @@ import type {
 
 const { postJson, extractJsonObject } = require("./httpClient");
 
+interface GeminiGenerateResponse {
+  candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+  };
+}
+
+interface GeminiEmbeddingResponse {
+  embedding?: { values?: unknown[] };
+}
+
 /**
  * Adapter for Google's Gemini generative-language REST API. Note that
  * embeddings use a separate `:embedContent` endpoint and must be requested
@@ -68,9 +81,9 @@ export class GeminiAdapter implements LlmAdapter {
       };
     }
 
-    const response = await postJson(endpoint, payload, { timeoutMs: this.timeoutMs });
+    const response = await postJson(endpoint, payload, { timeoutMs: this.timeoutMs }) as GeminiGenerateResponse;
     const parts = response?.candidates?.[0]?.content?.parts || [];
-    const text = parts.map((p: any) => p.text || "").join("\n").trim();
+    const text = parts.map((part) => part.text || "").join("\n").trim();
 
     if (!text) {
       throw new Error("Gemini returned an empty completion");
@@ -119,9 +132,9 @@ export class GeminiAdapter implements LlmAdapter {
         }
       };
 
-      const response = await postJson(endpoint, payload, { timeoutMs: this.timeoutMs });
+      const response = await postJson(endpoint, payload, { timeoutMs: this.timeoutMs }) as GeminiEmbeddingResponse;
       const values = response?.embedding?.values;
-      if (!Array.isArray(values) || values.length === 0) {
+      if (!Array.isArray(values) || values.length === 0 || !values.every((value) => typeof value === "number")) {
         throw new Error("Gemini returned an empty embedding vector");
       }
       vectors.push(values);

--- a/app/src/adapters/llm/httpClient.ts
+++ b/app/src/adapters/llm/httpClient.ts
@@ -8,7 +8,15 @@ export interface PostJsonOptions {
 }
 
 /** Provider response payloads are unknown JSON; callers downcast as needed. */
-export type ProviderResponse = any;
+export type ProviderResponse = unknown;
+
+function providerErrorMessage(payload: unknown): string | null {
+  if (payload === null || typeof payload !== "object") return null;
+  const error = (payload as Record<string, unknown>).error;
+  if (error === null || typeof error !== "object") return null;
+  const message = (error as Record<string, unknown>).message;
+  return typeof message === "string" && message.trim() ? message : null;
+}
 
 /**
  * POST a JSON body to `url` and return the parsed JSON response.
@@ -49,7 +57,7 @@ async function postJson(
 
     if (!response.ok) {
       const error: LlmAdapterError = new Error(
-        `HTTP ${response.status} from provider: ${parsed?.error?.message || text || "unknown error"}`
+        `HTTP ${response.status} from provider: ${providerErrorMessage(parsed) || text || "unknown error"}`
       );
       error.statusCode = response.status;
       throw error;

--- a/app/src/adapters/llm/openAiAdapter.ts
+++ b/app/src/adapters/llm/openAiAdapter.ts
@@ -4,10 +4,22 @@ import type {
   LlmEmbedInput,
   LlmEmbedResult,
   LlmGenerateInput,
-  LlmGenerateResult
+  LlmGenerateResult,
+  LlmTokenUsage
 } from "./types";
 
 const { postJson, extractJsonObject } = require("./httpClient");
+
+interface OpenAiCompletionResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+  model?: string;
+  usage?: LlmTokenUsage;
+}
+
+interface OpenAiEmbeddingResponse {
+  data?: Array<{ index: number; embedding: number[] }>;
+  model?: string;
+}
 
 /** Adapter for OpenAI's REST API (chat completions + embeddings). */
 export class OpenAiAdapter implements LlmAdapter {
@@ -59,7 +71,7 @@ export class OpenAiAdapter implements LlmAdapter {
       headers: {
         Authorization: `Bearer ${this.apiKey}`
       }
-    });
+    }) as OpenAiCompletionResponse;
 
     const text = response?.choices?.[0]?.message?.content;
     if (!text) {
@@ -97,12 +109,12 @@ export class OpenAiAdapter implements LlmAdapter {
       headers: {
         Authorization: `Bearer ${this.apiKey}`
       }
-    });
+    }) as OpenAiEmbeddingResponse;
 
     const vectors: number[][] = Array.isArray(response?.data)
       ? response.data
-        .sort((a: any, b: any) => a.index - b.index)
-        .map((item: any) => item.embedding)
+        .sort((a, b) => a.index - b.index)
+        .map((item) => item.embedding)
       : [];
 
     if (vectors.length !== texts.length) {

--- a/app/src/adapters/mssqlAdapter.ts
+++ b/app/src/adapters/mssqlAdapter.ts
@@ -1,5 +1,5 @@
 import * as sql from "mssql";
-import type { ConnectionPool, IResult, IRecordSet, config as MssqlConfig, Request as MssqlRequest } from "mssql";
+import type { ConnectionPool, IResult, IRecordSet, ISqlType, config as MssqlConfig, Request as MssqlRequest } from "mssql";
 import type {
   DbAdapter,
   DbDialect,
@@ -145,41 +145,41 @@ class MssqlAdapter implements DbAdapter {
 
     const pkSet = new Set(
       tablesRows(pkResult).map(
-        (row: any) => `${row.schema_name}.${row.object_name}.${row.column_name}`
+        (row) => `${String(row.schema_name)}.${String(row.object_name)}.${String(row.column_name)}`
       )
     );
 
-    const objects = tablesRows(tablesResult).map((row: any) => ({
-      schemaName: row.schema_name as string,
-      objectName: row.object_name as string,
+    const objects = tablesRows(tablesResult).map((row) => ({
+      schemaName: String(row.schema_name),
+      objectName: String(row.object_name),
       objectType: (row.table_type === "VIEW" ? "view" : "table") as "table" | "view"
     }));
 
-    const columns = tablesRows(columnsResult).map((row: any) => ({
-      schemaName: row.schema_name as string,
-      objectName: row.object_name as string,
-      columnName: row.column_name as string,
-      dataType: row.data_type as string,
+    const columns = tablesRows(columnsResult).map((row) => ({
+      schemaName: String(row.schema_name),
+      objectName: String(row.object_name),
+      columnName: String(row.column_name),
+      dataType: String(row.data_type),
       nullable: String(row.is_nullable).toUpperCase() === "YES",
       isPk: pkSet.has(`${row.schema_name}.${row.object_name}.${row.column_name}`),
-      ordinalPosition: row.ordinal_position as number
+      ordinalPosition: Number(row.ordinal_position)
     }));
 
-    const relationships = tablesRows(fkResult).map((row: any) => ({
-      fromSchema: row.from_schema as string,
-      fromObject: row.from_table as string,
-      fromColumn: row.from_column as string,
-      toSchema: row.to_schema as string,
-      toObject: row.to_table as string,
-      toColumn: row.to_column as string,
+    const relationships = tablesRows(fkResult).map((row) => ({
+      fromSchema: String(row.from_schema),
+      fromObject: String(row.from_table),
+      fromColumn: String(row.from_column),
+      toSchema: String(row.to_schema),
+      toObject: String(row.to_table),
+      toColumn: String(row.to_column),
       relationshipType: "fk" as const
     }));
 
-    const indexes = tablesRows(indexesResult).map((row: any) => ({
-      schemaName: row.schema_name as string,
-      objectName: row.object_name as string,
-      indexName: row.index_name as string,
-      columns: parseIndexColumns(row.index_columns as string),
+    const indexes = tablesRows(indexesResult).map((row) => ({
+      schemaName: String(row.schema_name),
+      objectName: String(row.object_name),
+      indexName: String(row.index_name),
+      columns: parseIndexColumns(String(row.index_columns || "")),
       isUnique: Boolean(row.is_unique)
     }));
 
@@ -214,15 +214,15 @@ class MssqlAdapter implements DbAdapter {
       ${normalizedSql};
       SET SHOWPLAN_JSON OFF;
     `);
-    return Array.isArray((planResult as any).recordsets)
-      ? ((planResult as any).recordsets as unknown[][]).flat()
+    return Array.isArray(planResult.recordsets)
+      ? planResult.recordsets.flatMap((recordset) => Array.from(recordset))
       : tablesRows(planResult);
   }
 
   async execute(sqlText: string, params: unknown[] = []): Promise<QueryResult> {
     return this.executeWithRequest((request) => {
       params.forEach((value, index) => {
-        request.input(`p${index}`, value as any);
+        request.input(`p${index}`, value);
       });
       return request.query(sqlText);
     }, {});
@@ -282,11 +282,7 @@ class MssqlAdapter implements DbAdapter {
 
     await this.poolConnect;
     const request = this.pool.request();
-    if (Number.isFinite(timeoutMs)) {
-      (request as any).timeout = timeoutMs;
-    }
-
-    const result = await runQuery(request);
+    const result = await runMssqlRequestWithTimeout(request, timeoutMs, () => runQuery(request));
     const rows = tablesRows(result);
     const columns = extractColumns(result, rows);
     const truncated = rows.length > maxRows;
@@ -310,7 +306,7 @@ class MssqlAdapter implements DbAdapter {
   async describeFirstResultSet(sqlText: string): Promise<IResult<unknown>> {
     await this.poolConnect;
     const request = this.pool.request();
-    request.input("tsql", (sql as any).NVarChar((sql as any).MAX), String(sqlText || "").trim());
+    request.input("tsql", sql.NVarChar(sql.MAX), String(sqlText || "").trim());
     return request.query(`
       EXEC sys.sp_describe_first_result_set
         @tsql = @tsql,
@@ -322,10 +318,7 @@ class MssqlAdapter implements DbAdapter {
   async query(sqlText: string, timeoutMs?: number): Promise<IResult<unknown>> {
     await this.poolConnect;
     const request = this.pool.request();
-    if (Number.isFinite(timeoutMs)) {
-      (request as any).timeout = timeoutMs;
-    }
-    return request.query(sqlText);
+    return runMssqlRequestWithTimeout(request, timeoutMs, () => request.query(sqlText));
   }
 }
 
@@ -448,11 +441,39 @@ function parseBoolean(value: unknown, fallback: boolean = false): boolean {
   return ["true", "1", "yes", "y"].includes(normalized);
 }
 
-function tablesRows(result: any): QueryResultRow[] {
-  return Array.isArray(result?.recordset) ? (result.recordset as QueryResultRow[]) : [];
+async function runMssqlRequestWithTimeout<T>(
+  request: MssqlRequest,
+  timeoutMs: number | undefined,
+  operation: () => Promise<T>
+): Promise<T> {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return operation();
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      try {
+        request.cancel();
+      } catch {
+        // The request may have completed between the timer firing and cancellation.
+      }
+      reject(new Error(`MSSQL request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([operation(), timedOut]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
-function extractColumns(result: any, rows: QueryResultRow[]): string[] {
+function tablesRows(result: IResult<unknown>): QueryResultRow[] {
+  return Array.isArray(result.recordset) ? (result.recordset as QueryResultRow[]) : [];
+}
+
+function extractColumns(result: IResult<unknown>, rows: QueryResultRow[]): string[] {
   if (rows.length > 0) {
     return Object.keys(rows[0]);
   }
@@ -501,24 +522,23 @@ function parseIndexColumns(rawColumns: string): string[] {
     .filter(Boolean);
 }
 
-function getMssqlParameterType(type: string): any {
-  const s: any = sql;
+function getMssqlParameterType(type: string): ISqlType | (() => ISqlType) {
   if (type === "integer") {
-    return s.Int;
+    return sql.Int;
   }
   if (type === "decimal") {
-    return s.Decimal(18, 6);
+    return sql.Decimal(18, 6);
   }
   if (type === "date") {
-    return s.Date;
+    return sql.Date;
   }
   if (type === "boolean") {
-    return s.Bit;
+    return sql.Bit;
   }
   if (type === "timestamp") {
-    return s.DateTime2;
+    return sql.DateTime2;
   }
-  return s.NVarChar(s.MAX);
+  return sql.NVarChar(sql.MAX);
 }
 
 function convertMssqlParameterValue(type: string, value: unknown): unknown {
@@ -534,11 +554,28 @@ function convertMssqlParameterValue(type: string, value: unknown): unknown {
   return value;
 }
 
-function normalizeMssqlValidationError(err: any): string {
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function nestedMessage(value: unknown, ...path: string[]): unknown {
+  let current: unknown = value;
+  for (const key of path) {
+    const record = asRecord(current);
+    if (!record) return undefined;
+    current = record[key];
+  }
+  return current;
+}
+
+function normalizeMssqlValidationError(err: unknown): string {
+  const precedingErrors = nestedMessage(err, "precedingErrors");
   const candidates = [
-    err?.originalError?.info?.message,
-    Array.isArray(err?.precedingErrors) ? err.precedingErrors[0]?.message : null,
-    err?.message
+    nestedMessage(err, "originalError", "info", "message"),
+    Array.isArray(precedingErrors) ? nestedMessage(precedingErrors[0], "message") : null,
+    nestedMessage(err, "message")
   ];
 
   const message =
@@ -552,8 +589,8 @@ function normalizeMssqlValidationError(err: any): string {
   );
 }
 
-function isDescribeFirstResultUnavailable(err: any): boolean {
-  const message = String(err?.message || "").toLowerCase();
+function isDescribeFirstResultUnavailable(err: unknown): boolean {
+  const message = String(nestedMessage(err, "message") || "").toLowerCase();
   return (
     message.includes("sp_describe_first_result_set") &&
     (message.includes("permission") || message.includes("could not find stored procedure"))

--- a/app/src/adapters/postgresAdapter.ts
+++ b/app/src/adapters/postgresAdapter.ts
@@ -10,6 +10,43 @@ import type {
   SqlValidationResult
 } from "./types";
 
+interface PgTableRow extends PgRow {
+  table_schema: string;
+  table_name: string;
+  table_type: string;
+}
+
+interface PgColumnRow extends PgRow {
+  table_schema: string;
+  table_name: string;
+  column_name: string;
+  data_type: string;
+  is_nullable: string;
+  ordinal_position: number;
+}
+
+interface PgPrimaryKeyRow extends PgRow {
+  table_schema: string;
+  table_name: string;
+  column_name: string;
+}
+
+interface PgForeignKeyRow extends PgRow {
+  from_schema: string;
+  from_table: string;
+  from_column: string;
+  to_schema: string;
+  to_table: string;
+  to_column: string;
+}
+
+interface PgIndexRow extends PgRow {
+  schemaname: string;
+  tablename: string;
+  indexname: string;
+  indexdef: string;
+}
+
 const { validateAstReadOnly } = require("../services/sqlAstValidator");
 const { replaceNamedPlaceholders } = require("../services/queryParameterParser");
 
@@ -103,50 +140,48 @@ class PostgresAdapter implements DbAdapter {
     `;
 
     const [tablesResult, columnsResult, pkResult, fkResult, indexesResult] = await Promise.all([
-      this.pool.query<PgRow>(tablesSql),
-      this.pool.query<PgRow>(columnsSql),
-      this.pool.query<PgRow>(pkSql),
-      this.pool.query<PgRow>(fkSql),
-      this.pool.query<PgRow>(indexesSql)
+      this.pool.query<PgTableRow>(tablesSql),
+      this.pool.query<PgColumnRow>(columnsSql),
+      this.pool.query<PgPrimaryKeyRow>(pkSql),
+      this.pool.query<PgForeignKeyRow>(fkSql),
+      this.pool.query<PgIndexRow>(indexesSql)
     ]);
 
     const pkSet = new Set(
-      pkResult.rows.map(
-        (row: any) => `${row.table_schema}.${row.table_name}.${row.column_name}`
-      )
+      pkResult.rows.map((row) => `${row.table_schema}.${row.table_name}.${row.column_name}`)
     );
 
-    const objects = tablesResult.rows.map((row: any) => ({
-      schemaName: row.table_schema as string,
-      objectName: row.table_name as string,
+    const objects = tablesResult.rows.map((row) => ({
+      schemaName: row.table_schema,
+      objectName: row.table_name,
       objectType: (row.table_type === "VIEW" ? "view" : "table") as "table" | "view"
     }));
 
-    const columns = columnsResult.rows.map((row: any) => ({
-      schemaName: row.table_schema as string,
-      objectName: row.table_name as string,
-      columnName: row.column_name as string,
-      dataType: row.data_type as string,
+    const columns = columnsResult.rows.map((row) => ({
+      schemaName: row.table_schema,
+      objectName: row.table_name,
+      columnName: row.column_name,
+      dataType: row.data_type,
       nullable: row.is_nullable === "YES",
       isPk: pkSet.has(`${row.table_schema}.${row.table_name}.${row.column_name}`),
-      ordinalPosition: row.ordinal_position as number
+      ordinalPosition: row.ordinal_position
     }));
 
-    const relationships = fkResult.rows.map((row: any) => ({
-      fromSchema: row.from_schema as string,
-      fromObject: row.from_table as string,
-      fromColumn: row.from_column as string,
-      toSchema: row.to_schema as string,
-      toObject: row.to_table as string,
-      toColumn: row.to_column as string,
+    const relationships = fkResult.rows.map((row) => ({
+      fromSchema: row.from_schema,
+      fromObject: row.from_table,
+      fromColumn: row.from_column,
+      toSchema: row.to_schema,
+      toObject: row.to_table,
+      toColumn: row.to_column,
       relationshipType: "fk" as const
     }));
 
-    const indexes = indexesResult.rows.map((row: any) => ({
-      schemaName: row.schemaname as string,
-      objectName: row.tablename as string,
-      indexName: row.indexname as string,
-      columns: parseIndexColumns(row.indexdef as string),
+    const indexes = indexesResult.rows.map((row) => ({
+      schemaName: row.schemaname,
+      objectName: row.tablename,
+      indexName: row.indexname,
+      columns: parseIndexColumns(row.indexdef),
       isUnique: String(row.indexdef).toLowerCase().includes(" unique ")
     }));
 
@@ -198,10 +233,10 @@ class PostgresAdapter implements DbAdapter {
         `SET LOCAL statement_timeout = ${Number.isFinite(timeoutMs) ? timeoutMs : 20000}`
       );
       const built = buildQuery();
-      const result: PgQueryResult =
+      const result: PgQueryResult<QueryResultRow> =
         typeof built === "string"
-          ? await client.query(built)
-          : await client.query(built.text, built.values as any[]);
+          ? await client.query<QueryResultRow>(built)
+          : await client.query<QueryResultRow, unknown[]>(built.text, built.values);
       await client.query("COMMIT");
 
       const rows = Array.isArray(result.rows) ? (result.rows as QueryResultRow[]) : [];

--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -16,32 +16,37 @@ export interface HttpError extends Error {
  * `server.js`. Use them by passing the matching OpenAPI schema, e.g.
  * `RouteHandler<LoginRequest, AuthMeResponse>`.
  */
-export type RouteHandler<TBody = unknown, TResp = unknown> = (
+type RouteContract<TBody, TResp> = {
+  readonly __requestBody?: TBody;
+  readonly __responseBody?: TResp;
+};
+
+export type RouteHandler<TBody = unknown, TResp = unknown> = ((
   req: AuthedRequest,
   res: ServerResponse
-) => Promise<void>;
+) => Promise<void>) & RouteContract<TBody, TResp>;
 
 /** Handler variant for routes whose path captures a single id. */
-export type RouteHandlerWithId<TBody = unknown, TResp = unknown> = (
+export type RouteHandlerWithId<TBody = unknown, TResp = unknown> = ((
   req: AuthedRequest,
   res: ServerResponse,
   id: string
-) => Promise<void>;
+) => Promise<void>) & RouteContract<TBody, TResp>;
 
 /** Handler variant for nested resources that capture two ids. */
-export type RouteHandlerWithIds<TBody = unknown, TResp = unknown> = (
+export type RouteHandlerWithIds<TBody = unknown, TResp = unknown> = ((
   req: AuthedRequest,
   res: ServerResponse,
   idA: string,
   idB: string
-) => Promise<void>;
+) => Promise<void>) & RouteContract<TBody, TResp>;
 
 /** Handler variant for routes that receive the parsed request URL. */
-export type RouteHandlerWithUrl<TBody = unknown, TResp = unknown> = (
+export type RouteHandlerWithUrl<TBody = unknown, TResp = unknown> = ((
   req: AuthedRequest,
   res: ServerResponse,
   requestUrl: URL
-) => Promise<void>;
+) => Promise<void>) & RouteContract<TBody, TResp>;
 
 /** Shape returned by typed services in `app/src/services/*`. */
 export interface ServiceResult<TBody = unknown> {

--- a/app/src/lib/oidcFlowCookie.ts
+++ b/app/src/lib/oidcFlowCookie.ts
@@ -11,12 +11,11 @@ export const COOKIE_NAME = "rp_oidc_flow" as const;
 export const FLOW_MAX_AGE_SECONDS = 10 * 60; // 10 minutes is plenty for the user to log in
 
 export interface OidcFlowPayload {
-  provider_id?: string;
-  code_verifier?: string;
-  state?: string;
-  nonce?: string;
+  provider_id: string;
+  code_verifier: string;
+  state: string;
+  nonce: string;
   redirect_uri?: string;
-  [key: string]: unknown;
 }
 
 interface SignedOidcFlowPayload extends OidcFlowPayload {
@@ -88,6 +87,14 @@ function verify(value: unknown): SignedOidcFlowPayload | null {
     return null;
   }
   if (typeof payload.exp !== "number" || payload.exp <= Math.floor(Date.now() / 1000)) {
+    return null;
+  }
+  if (
+    typeof payload.provider_id !== "string" || !payload.provider_id ||
+    typeof payload.code_verifier !== "string" || !payload.code_verifier ||
+    typeof payload.state !== "string" || !payload.state ||
+    typeof payload.nonce !== "string" || !payload.nonce
+  ) {
     return null;
   }
   return payload;

--- a/app/src/routes/admin.ts
+++ b/app/src/routes/admin.ts
@@ -160,7 +160,7 @@ const handleDeleteAuthProvider: RouteHandlerWithId = async (req, res, providerId
   return writeServiceResult(res, result);
 };
 
-const handleListAuditEvents: RouteHandlerWithUrl = async (req, res, requestUrl) => {
+const handleListAuditEvents: RouteHandlerWithUrl = async (_req, res, requestUrl) => {
   const params = requestUrl.searchParams;
   const actorUserIdRaw = params.get("actor_user_id");
   if (actorUserIdRaw && !isUuid(actorUserIdRaw)) {

--- a/app/src/routes/auth.ts
+++ b/app/src/routes/auth.ts
@@ -1,4 +1,3 @@
-import type { ServerResponse } from "http";
 import { json, readJsonBody, badRequest, type RouteHandler } from "../lib/http";
 import {
   buildSessionCookie,

--- a/app/src/routes/oidc.ts
+++ b/app/src/routes/oidc.ts
@@ -7,13 +7,13 @@ import {
   type RouteHandler,
   type RouteHandlerWithUrl
 } from "../lib/http";
-import { buildFlowCookie, buildClearFlowCookie, readFlowCookie, OidcFlowPayload } from "../lib/oidcFlowCookie";
+import { buildFlowCookie, buildClearFlowCookie, readFlowCookie } from "../lib/oidcFlowCookie";
 import { buildSessionCookie, buildClearSessionCookie } from "../lib/sessionCookie";
 import { createSession } from "../services/authService";
 import { writeEvent } from "../services/auditService";
 import { listEnabledProvidersForLogin, findProviderById } from "../services/authProviderService";
 import { resolveExternalLogin } from "../services/externalLoginService";
-import { startLogin, completeLogin, FlowState } from "../services/oidcService";
+import { startLogin, completeLogin } from "../services/oidcService";
 import { recordUsedState } from "../services/oidcStateService";
 
 function clientAddress(req: AuthedRequest): string | null {
@@ -37,7 +37,7 @@ const handleListEnabledProviders: RouteHandler = async (_req, res) => {
   return json(res, 200, { items });
 };
 
-const handleStartLogin: RouteHandlerWithUrl = async (req, res, requestUrl) => {
+const handleStartLogin: RouteHandlerWithUrl = async (_req, res, requestUrl) => {
   const providerId = requestUrl.searchParams.get("provider_id");
   if (!providerId) {
     return badRequest(res, "provider_id query parameter is required");
@@ -54,7 +54,7 @@ const handleStartLogin: RouteHandlerWithUrl = async (req, res, requestUrl) => {
     return json(res, errorStatusCode(err), { error: "oidc_error", message: errorMessage(err) });
   }
 
-  res.setHeader("Set-Cookie", buildFlowCookie(result.flowState as OidcFlowPayload));
+  res.setHeader("Set-Cookie", buildFlowCookie(result.flowState));
   res.writeHead(302, { Location: result.authorizeUrl });
   res.end();
   return;
@@ -119,7 +119,7 @@ const handleCallback: RouteHandlerWithUrl = async (req, res, requestUrl) => {
 
   let principal;
   try {
-    principal = await completeLogin(provider, currentUrl, flowState as FlowState);
+    principal = await completeLogin(provider, currentUrl, flowState);
   } catch (err) {
     res.setHeader("Set-Cookie", buildClearFlowCookie());
     const message = errorMessage(err);
@@ -191,7 +191,7 @@ const handleCallback: RouteHandlerWithUrl = async (req, res, requestUrl) => {
 };
 
 // Exposed for use by AUTH-009 (admin "test connection" button) and tests.
-const handleStartLoginJson: RouteHandlerWithUrl = async (req, res, requestUrl) => {
+const handleStartLoginJson: RouteHandlerWithUrl = async (_req, res, requestUrl) => {
   const providerId = requestUrl.searchParams.get("provider_id");
   if (!providerId) {
     return badRequest(res, "provider_id query parameter is required");
@@ -202,7 +202,7 @@ const handleStartLoginJson: RouteHandlerWithUrl = async (req, res, requestUrl) =
   }
   try {
     const result = await startLogin(provider);
-    res.setHeader("Set-Cookie", buildFlowCookie(result.flowState as OidcFlowPayload));
+    res.setHeader("Set-Cookie", buildFlowCookie(result.flowState));
     return json(res, 200, { authorize_url: result.authorizeUrl });
   } catch (err) {
     return json(res, errorStatusCode(err), { error: "oidc_error", message: errorMessage(err) });

--- a/app/src/routes/providers.ts
+++ b/app/src/routes/providers.ts
@@ -14,32 +14,32 @@ function buildHealthAdapter(provider: string, apiKeyRef: string | null, defaultM
   if (provider === "openai") {
     return new OpenAiAdapter({
       apiKey: resolveApiKey(apiKeyRef, "OPENAI_API_KEY"),
-      defaultModel
+      defaultModel: defaultModel ?? undefined
     });
   }
   if (provider === "gemini") {
     return new GeminiAdapter({
       apiKey: resolveApiKey(apiKeyRef, "GEMINI_API_KEY"),
-      defaultModel
+      defaultModel: defaultModel ?? undefined
     });
   }
   if (provider === "deepseek") {
     return new DeepSeekAdapter({
       apiKey: resolveApiKey(apiKeyRef, "DEEPSEEK_API_KEY"),
-      defaultModel
+      defaultModel: defaultModel ?? undefined
     });
   }
   if (provider === "openrouter") {
     return new OpenRouterAdapter({
       apiKey: resolveApiKey(apiKeyRef, "OPENROUTER_API_KEY"),
-      defaultModel
+      defaultModel: defaultModel ?? undefined
     });
   }
   if (baseUrl) {
     return new CustomAdapter({
       provider,
       apiKey: resolveApiKey(apiKeyRef, null),
-      defaultModel,
+      defaultModel: defaultModel ?? undefined,
       baseUrl
     });
   }

--- a/app/src/routes/scim.ts
+++ b/app/src/routes/scim.ts
@@ -28,6 +28,8 @@ import {
 import { authenticateScim, writeScimError } from "../lib/scimAuth";
 import * as scimUserService from "../services/scimUserService";
 import * as scimGroupService from "../services/scimGroupService";
+import type { ScimPatchBody, ScimUserBody } from "../services/scimUserService";
+import type { ScimGroupBody } from "../services/scimGroupService";
 
 function scimJson(res: ServerResponse, statusCode: number, body: unknown): void {
   if (statusCode === 204 || body == null) {
@@ -128,21 +130,19 @@ const handleListUsers: RouteHandlerWithUrl = async (req, res, requestUrl) => {
   const count = Number(params.get("count")) || 100;
   const result = await scimUserService.listUsers({
     providerId: token.provider_id,
-    filter: params.get("filter"),
+    filter: params.get("filter") ?? undefined,
     startIndex,
     count
   });
   return scimJson(res, 200, result);
 };
 
-// SCIM message bodies aren't fully described in our OpenAPI surface — keep them
-// as `unknown` and let the service do schema validation.
 const handleCreateUser: RouteHandler = async (req, res) => {
   const token = await authenticateScim(req, res);
   if (!token) return;
-  let body: unknown;
+  let body: ScimUserBody;
   try {
-    body = await readJsonBody(req);
+    body = await readJsonBody<ScimUserBody>(req);
   } catch {
     return writeScimError(res, 400, "request body is not valid JSON");
   }
@@ -165,7 +165,7 @@ const handleGetUser: RouteHandlerWithId = async (req, res, userId) => {
 const handleReplaceUser: RouteHandlerWithId = async (req, res, userId) => {
   const token = await authenticateScim(req, res);
   if (!token) return;
-  const body = await readJsonBody<Record<string, unknown> | null>(req).catch(() => null);
+  const body = await readJsonBody<ScimUserBody | undefined>(req).catch(() => undefined);
   const result = await scimUserService.replaceUser({
     providerId: token.provider_id,
     userId,
@@ -179,7 +179,7 @@ const handleReplaceUser: RouteHandlerWithId = async (req, res, userId) => {
 const handlePatchUser: RouteHandlerWithId = async (req, res, userId) => {
   const token = await authenticateScim(req, res);
   if (!token) return;
-  const body = await readJsonBody<Record<string, unknown> | null>(req).catch(() => null);
+  const body = await readJsonBody<ScimPatchBody | undefined>(req).catch(() => undefined);
   const result = await scimUserService.patchUser({
     providerId: token.provider_id,
     userId,
@@ -212,7 +212,7 @@ const handleListGroups: RouteHandler = async (req, res) => {
 const handleCreateOrReplaceGroup: RouteHandler = async (req, res) => {
   const token = await authenticateScim(req, res);
   if (!token) return;
-  const body = await readJsonBody<Record<string, unknown> | null>(req).catch(() => null);
+  const body = await readJsonBody<ScimGroupBody | undefined>(req).catch(() => undefined);
   const result = await scimGroupService.createOrReplaceGroup({
     providerId: token.provider_id,
     body
@@ -223,7 +223,7 @@ const handleCreateOrReplaceGroup: RouteHandler = async (req, res) => {
 const handlePatchGroup: RouteHandler = async (req, res) => {
   const token = await authenticateScim(req, res);
   if (!token) return;
-  const body = await readJsonBody<Record<string, unknown> | null>(req).catch(() => null);
+  const body = await readJsonBody<ScimGroupBody | undefined>(req).catch(() => undefined);
   const result = await scimGroupService.patchGroup({
     providerId: token.provider_id,
     body

--- a/app/src/services/exportService.ts
+++ b/app/src/services/exportService.ts
@@ -310,25 +310,21 @@ async function exportParquet(rows: Array<Record<string, unknown>>, columnOrder: 
     };
   }
 
-  const schema = new (parquet as { ParquetSchema: new (def: unknown) => unknown }).ParquetSchema(schemaDefinition);
+  const schema = new parquet.ParquetSchema(schemaDefinition);
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "report-pilot-export-"));
   const filePath = path.join(tempDir, `export-${Date.now()}.parquet`);
 
   let writer: { appendRow: (row: Record<string, unknown>) => Promise<void>; close: () => Promise<void> } | null = null;
   try {
-    writer = await (parquet as {
-      ParquetWriter: {
-        openFile: (schema: unknown, path: string) => Promise<{ appendRow: (row: Record<string, unknown>) => Promise<void>; close: () => Promise<void> }>;
-      };
-    }).ParquetWriter.openFile(schema, filePath);
+    writer = await parquet.ParquetWriter.openFile(schema, filePath);
     for (const row of rows) {
       const normalizedRow: Record<string, unknown> = {};
       for (const column of columnOrder) {
         normalizedRow[column] = normalizeParquetValue(row[column], schemaDefinition[column].type);
       }
-      await writer!.appendRow(normalizedRow);
+      await writer.appendRow(normalizedRow);
     }
-    await writer!.close();
+    await writer.close();
     writer = null;
 
     return await fs.readFile(filePath);

--- a/app/src/services/externalLoginService.ts
+++ b/app/src/services/externalLoginService.ts
@@ -24,8 +24,8 @@ export interface ExternalProvider {
   require_email_verified?: boolean;
   auto_link_by_email?: boolean;
   jit_enabled?: boolean;
-  jit_allowed_domains?: unknown[];
-  jit_default_role?: string;
+  jit_allowed_domains?: unknown[] | null;
+  jit_default_role?: string | null;
 }
 
 export interface ExternalPrincipal {
@@ -288,7 +288,7 @@ export async function resolveExternalLogin(
       message: `cannot provision ${principal.email}: the IdP did not assert that the email is verified.`
     };
   }
-  if (!domainAllowed(principal.email, provider.jit_allowed_domains)) {
+  if (!domainAllowed(principal.email, provider.jit_allowed_domains ?? undefined)) {
     await recordAuditLinkRejected({
       provider, principal, reason: "domain_not_allowed", context
     });

--- a/app/src/services/llmSchemaLinkerService.ts
+++ b/app/src/services/llmSchemaLinkerService.ts
@@ -5,8 +5,7 @@ import {
   buildProviderOrder,
   loadProviderConfigs,
   loadRoutingRule,
-  type ProviderConfigRow,
-  type RoutingRule
+  type ProviderConfigRow
 } from "./llmProviderRouting";
 import { logLlmDebug, normalizeStatusCode, normalizeTokenUsage, type NormalizedTokenUsage } from "./llmDebug";
 import type { TableCandidate } from "./schemaLinkingService";

--- a/app/src/services/scimGroupService.ts
+++ b/app/src/services/scimGroupService.ts
@@ -62,7 +62,7 @@ interface ScimOperation {
   value?: unknown;
 }
 
-interface ScimGroupBody {
+export interface ScimGroupBody {
   id?: string;
   externalId?: string;
   displayName?: string;
@@ -170,7 +170,7 @@ function groupToScim({ providerId, body }: { providerId: string; body: ScimGroup
 }
 
 export async function createOrReplaceGroup(
-  { providerId, body, actorUserId = null }: { providerId: string; body: ScimGroupBody; actorUserId?: string | null }
+  { providerId, body, actorUserId = null }: { providerId: string; body?: ScimGroupBody; actorUserId?: string | null }
 ): Promise<ScimErrorResult> {
   if (!body || typeof body.displayName !== "string" || !body.displayName.trim()) {
     return scimUserService.scimError(400, "displayName is required", "invalidValue");
@@ -193,7 +193,7 @@ export async function createOrReplaceGroup(
 }
 
 export async function patchGroup(
-  { providerId, body, actorUserId = null }: { providerId: string; body: ScimGroupBody; actorUserId?: string | null }
+  { providerId, body, actorUserId = null }: { providerId: string; body?: ScimGroupBody; actorUserId?: string | null }
 ): Promise<ScimErrorResult> {
   if (!body || !Array.isArray(body.Operations)) {
     return scimUserService.scimError(400, "Operations array is required", "invalidSyntax");

--- a/app/src/services/scimUserService.ts
+++ b/app/src/services/scimUserService.ts
@@ -45,7 +45,7 @@ interface ScimName {
   familyName?: string;
 }
 
-interface ScimUserBody {
+export interface ScimUserBody {
   id?: string;
   externalId?: string;
   userName?: string;
@@ -61,7 +61,7 @@ interface ScimOperation {
   value?: unknown;
 }
 
-interface ScimPatchBody {
+export interface ScimPatchBody {
   Operations?: ScimOperation[];
 }
 

--- a/app/src/types/parquetjs-lite.d.ts
+++ b/app/src/types/parquetjs-lite.d.ts
@@ -1,0 +1,16 @@
+declare module "parquetjs-lite" {
+  export interface ParquetFieldDefinition {
+    type: string;
+    optional?: boolean;
+  }
+
+  export class ParquetSchema {
+    constructor(definition: Record<string, ParquetFieldDefinition>);
+  }
+
+  export class ParquetWriter {
+    static openFile(schema: ParquetSchema, path: string): Promise<ParquetWriter>;
+    appendRow(row: Record<string, unknown>): Promise<void>;
+    close(): Promise<void>;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "benchmark:large-schema": "tsx app/src/benchmark/runLargeSchemaBenchmark.ts",
     "create-user": "tsx scripts/create-user.ts",
     "test": "node --import tsx --test app/test/**/*.test.ts",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json && tsc --noEmit -p tsconfig.test.json",
     "types:openapi": "npm --prefix tools/openapi-typescript run generate"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,14 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "sourceMap": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["app/src/**/*", "app/test/**/*"],
+  "include": ["app/src/**/*"],
   "exclude": ["node_modules", "dist", "frontend"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "app",
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["app/src/**/*", "app/test/**/*"],
+  "exclude": ["node_modules", "dist", "frontend"]
+}


### PR DESCRIPTION
## Summary

- enable strict TypeScript, null checks, implicit-any checks, and unused-symbol checks for production backend code and scripts
- replace explicit `any` usage in hand-written backend source with typed database rows, provider payloads, SCIM contracts, and `unknown` narrowing
- validate required OIDC flow-cookie state and add local Parquet declarations
- enforce MSSQL request timeouts through cancellation instead of an untyped request property
- keep tests in a documented transitional `tsconfig.test.json` profile for the next strict-migration batch

Part of #148.

## Verification

- `npm run typecheck`
- `npm test` (243 passing)
- `npm run build`
- `npm run types:openapi`
- `npm run benchmark:large-schema` (all release gates pass)
- `docker build -t report-pilot:strict-source-check .`

## Follow-up

The remaining work in #148 is enabling strict mode for the test harness and fixing its fixture/mock typing debt. No suppressions were added.