### PR TITLE
Enforce strict checks for new test code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Report Pilot is a local-first NL-to-SQL reporting runtime. This file is canonica
 
 - Backend source and tests are TypeScript-only. Do not add `.js` files under `app/src/**` or `app/test/**`.
 - TypeScript 7 is the application compiler. The OpenAPI generator has an isolated TypeScript 5.9 toolchain because it still depends on the legacy compiler API.
-- Production backend code and scripts compile in strict mode. Tests remain on the transitional `tsconfig.test.json` profile while issue #148 tracks strict test-harness migration.
+- Production backend code, scripts, shared test helpers, and new tests compile in strict mode. The legacy suites listed in `tsconfig.test.legacy.json` remain transitional while issue #148 tracks their migration.
 - Prefer precise types or `unknown` over `any`; do not bypass type errors with `@ts-ignore`.
 
 ## Code Map

--- a/app/test/routePolicy.test.ts
+++ b/app/test/routePolicy.test.ts
@@ -6,40 +6,46 @@ process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@l
 
 import { findPolicy, POLICIES } from "../src/lib/routePolicy";
 
+function requirePolicy(method: string, path: string) {
+  const policy = findPolicy(method, path);
+  assert.ok(policy, `expected a policy for ${method} ${path}`);
+  return policy;
+}
+
 test("findPolicy maps known endpoints to the expected policy", () => {
   // Public
   assert.deepEqual(findPolicy("GET", "/health"), { method: "GET", pattern: /^\/health$/, public: true });
-  assert.equal(findPolicy("POST", "/v1/auth/login").public, true);
-  assert.equal(findPolicy("POST", "/v1/auth/logout").public, true);
-  assert.equal(findPolicy("GET", "/v1/auth/me").public, true);
+  assert.equal(requirePolicy("POST", "/v1/auth/login").public, true);
+  assert.equal(requirePolicy("POST", "/v1/auth/logout").public, true);
+  assert.equal(requirePolicy("GET", "/v1/auth/me").public, true);
 
   // Admin role
-  assert.equal(findPolicy("GET", "/v1/admin/users").role, "admin");
-  assert.equal(findPolicy("POST", "/v1/admin/users").role, "admin");
-  assert.equal(findPolicy("POST", "/v1/admin/users/00000000-0000-4000-8000-000000000001/roles").role, "admin");
+  assert.equal(requirePolicy("GET", "/v1/admin/users").role, "admin");
+  assert.equal(requirePolicy("POST", "/v1/admin/users").role, "admin");
+  assert.equal(requirePolicy("POST", "/v1/admin/users/00000000-0000-4000-8000-000000000001/roles").role, "admin");
 
   // Read permissions
-  assert.equal(findPolicy("GET", "/v1/data-sources").permission, "data_sources.read");
-  assert.equal(findPolicy("GET", "/v1/saved-queries").permission, "saved_queries.read");
-  assert.equal(findPolicy("GET", "/v1/saved-queries/00000000-0000-4000-8000-000000000001").permission, "saved_queries.read");
-  assert.equal(findPolicy("GET", "/v1/rag/notes").permission, "data_sources.read");
-  assert.equal(findPolicy("GET", "/v1/llm/providers").permission, "providers.read");
-  assert.equal(findPolicy("GET", "/v1/observability/metrics").permission, "observability.read");
+  assert.equal(requirePolicy("GET", "/v1/data-sources").permission, "data_sources.read");
+  assert.equal(requirePolicy("GET", "/v1/saved-queries").permission, "saved_queries.read");
+  assert.equal(requirePolicy("GET", "/v1/saved-queries/00000000-0000-4000-8000-000000000001").permission, "saved_queries.read");
+  assert.equal(requirePolicy("GET", "/v1/rag/notes").permission, "data_sources.read");
+  assert.equal(requirePolicy("GET", "/v1/llm/providers").permission, "providers.read");
+  assert.equal(requirePolicy("GET", "/v1/observability/metrics").permission, "observability.read");
 
   // Write permissions
-  assert.equal(findPolicy("POST", "/v1/data-sources").permission, "data_sources.write");
-  assert.equal(findPolicy("DELETE", "/v1/data-sources/00000000-0000-4000-8000-000000000001").permission, "data_sources.write");
-  assert.equal(findPolicy("POST", "/v1/saved-queries").permission, "saved_queries.write");
-  assert.equal(findPolicy("PUT", "/v1/saved-queries/00000000-0000-4000-8000-000000000001").permission, "saved_queries.write");
-  assert.equal(findPolicy("POST", "/v1/semantic-entities").permission, "semantic.write");
-  assert.equal(findPolicy("POST", "/v1/rag/notes").permission, "rag.write");
-  assert.equal(findPolicy("POST", "/v1/llm/providers").permission, "providers.write");
-  assert.equal(findPolicy("POST", "/v1/observability/release-gates/report").permission, "observability.write");
+  assert.equal(requirePolicy("POST", "/v1/data-sources").permission, "data_sources.write");
+  assert.equal(requirePolicy("DELETE", "/v1/data-sources/00000000-0000-4000-8000-000000000001").permission, "data_sources.write");
+  assert.equal(requirePolicy("POST", "/v1/saved-queries").permission, "saved_queries.write");
+  assert.equal(requirePolicy("PUT", "/v1/saved-queries/00000000-0000-4000-8000-000000000001").permission, "saved_queries.write");
+  assert.equal(requirePolicy("POST", "/v1/semantic-entities").permission, "semantic.write");
+  assert.equal(requirePolicy("POST", "/v1/rag/notes").permission, "rag.write");
+  assert.equal(requirePolicy("POST", "/v1/llm/providers").permission, "providers.write");
+  assert.equal(requirePolicy("POST", "/v1/observability/release-gates/report").permission, "observability.write");
 
   // Query / run
-  assert.equal(findPolicy("POST", "/v1/query/sessions").permission, "query.run");
-  assert.equal(findPolicy("POST", "/v1/saved-queries/00000000-0000-4000-8000-000000000001/run").permission, "query.run");
-  assert.equal(findPolicy("GET", "/v1/exports/00000000-0000-4000-8000-000000000001/status").permission, "query.run");
+  assert.equal(requirePolicy("POST", "/v1/query/sessions").permission, "query.run");
+  assert.equal(requirePolicy("POST", "/v1/saved-queries/00000000-0000-4000-8000-000000000001/run").permission, "query.run");
+  assert.equal(requirePolicy("GET", "/v1/exports/00000000-0000-4000-8000-000000000001/status").permission, "query.run");
 });
 
 test("findPolicy returns null for unknown /v1 paths", () => {

--- a/app/test/userConfigPolicy.test.ts
+++ b/app/test/userConfigPolicy.test.ts
@@ -79,7 +79,7 @@ test("validateConfig accepts null for nullable fields", () => {
 });
 
 test("validateConfig caps table_preferences serialized size", () => {
-  const big = {};
+  const big: Record<string, string> = {};
   for (let i = 0; i < 5000; i += 1) big[`key${i}`] = "value".repeat(10);
   const res = userConfigService.validateConfig({ table_preferences: big });
   assert.equal(res.ok, false);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "benchmark:large-schema": "tsx app/src/benchmark/runLargeSchemaBenchmark.ts",
     "create-user": "tsx scripts/create-user.ts",
     "test": "node --import tsx --test app/test/**/*.test.ts",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json && tsc --noEmit -p tsconfig.test.json",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json && tsc --noEmit -p tsconfig.test.json && tsc --noEmit -p tsconfig.test.legacy.json",
     "types:openapi": "npm --prefix tools/openapi-typescript run generate"
   },
   "engines": {

--- a/tsconfig.test.legacy.json
+++ b/tsconfig.test.legacy.json
@@ -2,13 +2,14 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": "app"
+    "rootDir": "app",
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
   },
-  "include": ["app/test/**/*.ts", "app/src/types/**/*.d.ts"],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "frontend",
+  "include": [
     "app/test/accountLinkingApi.test.ts",
     "app/test/adminUsersApi.test.ts",
     "app/test/auditEventsApi.test.ts",
@@ -24,6 +25,8 @@
     "app/test/savedQuerySchedulesApi.test.ts",
     "app/test/scimApi.test.ts",
     "app/test/securityHardeningApi.test.ts",
-    "app/test/userConfigApi.test.ts"
-  ]
+    "app/test/userConfigApi.test.ts",
+    "app/src/types/**/*.d.ts"
+  ],
+  "exclude": ["node_modules", "dist", "frontend"]
 }


### PR DESCRIPTION
## Summary

- make strict TypeScript the default for shared test helpers and all non-legacy suites
- isolate the remaining 16 migration targets in an explicit `tsconfig.test.legacy.json` allowlist
- keep both strict and legacy profiles in the normal `npm run typecheck` path
- migrate route-policy and user-config policy tests, reducing the legacy suite count from 18 to 16
- document the transitional test policy for contributors

Part of #148.

## Coverage

- 36 of 52 test suites now compile strictly
- all shared helpers compile strictly
- new test files compile strictly unless deliberately added to the reviewed legacy allowlist

## Verification

- `npm run typecheck`
- `npm test` (243 passing)
- `npm run build`
- `npm run benchmark:large-schema` (all release gates pass)

## Follow-up

Migrate the 16 named legacy API suites in bounded domain batches, removing each file from the allowlist as it becomes strict.