### PR TITLE
Migrate user config and RAG tests to strict mode

### DIFF
--- a/app/test/ragNotesApi.test.ts
+++ b/app/test/ragNotesApi.test.ts
@@ -9,32 +9,52 @@ process.env.AUTH_COOKIE_SECURE = "false";
 import appDb = require("../src/lib/appDb");
 import ragService = require("../src/services/ragService");
 import { createAuthTestStub } from "./helpers/authTestStub";
+import type { RagNoteResponse } from "../src/types";
+
+interface RagNoteListPayload {
+  items: RagNoteResponse[];
+}
+
+interface DeleteNotePayload {
+  ok: boolean;
+  id: string;
+}
+
+interface ApiResult<T> {
+  status: number;
+  payload: T;
+}
 
 const DATA_SOURCE_ID = "00000000-0000-4000-8000-000000000111";
 const OTHER_SOURCE_ID = "00000000-0000-4000-8000-000000000333";
 
 let server: import("http").Server;
 let baseUrl: string;
-let notes;
-let reindexCalls;
-let noteCounter;
+let notes: Map<string, RagNoteResponse>;
+let reindexCalls: string[];
+let noteCounter: number;
 let originalQuery: typeof appDb.query;
-let originalReindex;
-let originalSetImmediate;
+let originalReindex: typeof ragService.reindexRagDocuments;
+let originalSetImmediate: typeof global.setImmediate;
 let authStub: import("./helpers/authTestStub").AuthTestStub;
-let analystCookie;
-let viewerCookie;
+let analystCookie: string;
+let viewerCookie: string;
 
-function normalizeSql(sql) {
+function normalizeSql(sql: string): string {
   return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
-function nextNoteId() {
+function nextNoteId(): string {
   noteCounter += 1;
   return `00000000-0000-4000-8000-${String(noteCounter).padStart(12, "0")}`;
 }
 
-async function api(method: string, path: string, body?: unknown, { cookie }: { cookie?: string } = {}) {
+async function api<T = unknown>(
+  method: string,
+  path: string,
+  body?: unknown,
+  { cookie }: { cookie?: string } = {}
+): Promise<ApiResult<T>> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   headers.Cookie = cookie || analystCookie;
   const response = await fetch(`${baseUrl}${path}`, {
@@ -43,7 +63,7 @@ async function api(method: string, path: string, body?: unknown, { cookie }: { c
     body: body ? JSON.stringify(body) : undefined
   });
 
-  let payload = null;
+  let payload: unknown = null;
   try {
     payload = await response.json();
   } catch {
@@ -52,7 +72,7 @@ async function api(method: string, path: string, body?: unknown, { cookie }: { c
 
   return {
     status: response.status,
-    payload
+    payload: payload as T
   };
 }
 
@@ -78,14 +98,14 @@ before(async () => {
   analystCookie = authStub.cookieFor(authStub.seedSession(analyst.id).token);
   viewerCookie = authStub.cookieFor(authStub.seedSession(viewer.id).token);
 
-  appDb.query = (async (sql, params = []) => {
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
     const auth = authStub.handleSql(sql, params);
     if (auth) return auth;
 
     const normalized = normalizeSql(sql);
 
     if (normalized === "select id from data_sources where id = $1") {
-      const id = params[0];
+      const id = String(params[0]);
       if (id === DATA_SOURCE_ID || id === OTHER_SOURCE_ID) {
         return { rowCount: 1, rows: [{ id }] };
       }
@@ -93,7 +113,7 @@ before(async () => {
     }
 
     if (normalized.startsWith("select id, data_source_id, title, content, active, created_at, updated_at from rag_notes")) {
-      const dataSourceId = params[0];
+      const dataSourceId = String(params[0]);
       const rows = [...notes.values()]
         .filter((note) => note.data_source_id === dataSourceId)
         .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
@@ -102,14 +122,17 @@ before(async () => {
 
     if (normalized.startsWith("insert into rag_notes")) {
       const now = new Date().toISOString();
-      const [dataSourceId, title, content, active] = params;
+      const dataSourceId = String(params[0]);
+      const title = String(params[1]);
+      const content = String(params[2]);
+      const active = Boolean(params[3]);
       const id = nextNoteId();
       const note = {
         id,
         data_source_id: dataSourceId,
         title,
         content,
-        active: Boolean(active),
+        active,
         created_at: now,
         updated_at: now
       };
@@ -118,7 +141,11 @@ before(async () => {
     }
 
     if (normalized.startsWith("update rag_notes")) {
-      const [id, dataSourceId, title, content, active] = params;
+      const id = String(params[0]);
+      const dataSourceId = String(params[1]);
+      const title = String(params[2]);
+      const content = String(params[3]);
+      const active = params[4];
       const existing = notes.get(id);
       if (!existing) {
         return { rowCount: 0, rows: [] };
@@ -128,7 +155,7 @@ before(async () => {
         data_source_id: dataSourceId,
         title,
         content,
-        active: active === null ? existing.active : active,
+        active: active === null ? existing.active : Boolean(active),
         updated_at: new Date().toISOString()
       };
       notes.set(id, updated);
@@ -136,7 +163,7 @@ before(async () => {
     }
 
     if (normalized.startsWith("select id, data_source_id from rag_notes where id = $1")) {
-      const [id] = params;
+      const id = String(params[0]);
       const existing = notes.get(id);
       return existing
         ? { rowCount: 1, rows: [{ id: existing.id, data_source_id: existing.data_source_id }] }
@@ -144,7 +171,7 @@ before(async () => {
     }
 
     if (normalized.startsWith("delete from rag_notes")) {
-      const [id] = params;
+      const id = String(params[0]);
       const existing = notes.get(id);
       if (!existing) {
         return { rowCount: 0, rows: [] };
@@ -201,7 +228,7 @@ after(async () => {
 });
 
 test("RAG notes create/update/list/delete happy path", async () => {
-  const create = await api("POST", "/v1/rag/notes", {
+  const create = await api<RagNoteResponse>("POST", "/v1/rag/notes", {
     data_source_id: DATA_SOURCE_ID,
     title: "  Revenue policy  ",
     content: "  Exclude test transactions.  "
@@ -214,12 +241,12 @@ test("RAG notes create/update/list/delete happy path", async () => {
 
   const noteId = create.payload.id;
 
-  const list = await api("GET", `/v1/rag/notes?data_source_id=${DATA_SOURCE_ID}`);
+  const list = await api<RagNoteListPayload>("GET", `/v1/rag/notes?data_source_id=${DATA_SOURCE_ID}`);
   assert.equal(list.status, 200);
   assert.equal(list.payload.items.length, 1);
   assert.equal(list.payload.items[0].id, noteId);
 
-  const update = await api("POST", "/v1/rag/notes", {
+  const update = await api<RagNoteResponse>("POST", "/v1/rag/notes", {
     id: noteId,
     data_source_id: DATA_SOURCE_ID,
     title: "Updated policy",
@@ -230,13 +257,13 @@ test("RAG notes create/update/list/delete happy path", async () => {
   assert.equal(reindexCalls.length, 2);
   assert.equal(reindexCalls[1], DATA_SOURCE_ID);
 
-  const del = await api("DELETE", `/v1/rag/notes/${noteId}`);
+  const del = await api<DeleteNotePayload>("DELETE", `/v1/rag/notes/${noteId}`);
   assert.equal(del.status, 200);
   assert.deepEqual(del.payload, { ok: true, id: noteId });
   assert.equal(reindexCalls.length, 3);
   assert.equal(reindexCalls[2], DATA_SOURCE_ID);
 
-  const listAfterDelete = await api("GET", `/v1/rag/notes?data_source_id=${DATA_SOURCE_ID}`);
+  const listAfterDelete = await api<RagNoteListPayload>("GET", `/v1/rag/notes?data_source_id=${DATA_SOURCE_ID}`);
   assert.equal(listAfterDelete.status, 200);
   assert.equal(listAfterDelete.payload.items.length, 0);
 });

--- a/app/test/userConfigApi.test.ts
+++ b/app/test/userConfigApi.test.ts
@@ -10,22 +10,42 @@ process.env.AUTH_COOKIE_SECURE = "false";
 
 import appDb = require("../src/lib/appDb");
 import { createAuthTestStub } from "./helpers/authTestStub";
+import type { UserConfig } from "../src/services/userConfigService";
+
+interface UserConfigPayload {
+  config: UserConfig;
+}
+
+interface ErrorPayload {
+  error?: string;
+  code?: string;
+  message?: string;
+}
+
+interface ApiResult<T> {
+  status: number;
+  payload: T;
+}
 
 let server: import("http").Server;
 let baseUrl: string;
 let authStub: import("./helpers/authTestStub").AuthTestStub;
 let originalQuery: typeof appDb.query;
-let configs;       // user_id -> stored config object
-let dataSources;   // id -> row
+let configs: Map<string, UserConfig>;
+let dataSources: Set<string>;
 
-let analystCookie;
-let viewerCookie;
+let analystCookie: string;
+let viewerCookie: string;
 
 function normalize(sql: string) {
   return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
-async function call(method: string, path: string, { cookie, body }: { cookie?: string; body?: unknown } = {}) {
+async function call<T = ErrorPayload>(
+  method: string,
+  path: string,
+  { cookie, body }: { cookie?: string; body?: unknown } = {}
+): Promise<ApiResult<T>> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (cookie) headers.Cookie = cookie;
   const response = await fetch(`${baseUrl}${path}`, {
@@ -33,18 +53,18 @@ async function call(method: string, path: string, { cookie, body }: { cookie?: s
     headers,
     body: body ? JSON.stringify(body) : undefined
   });
-  let payload = null;
+  let payload: unknown = null;
   if ((response.headers.get("content-type") || "").includes("application/json")) {
     try { payload = await response.json(); } catch { payload = null; }
   }
-  return { status: response.status, payload };
+  return { status: response.status, payload: payload as T };
 }
 
 before(async () => {
   authStub = createAuthTestStub();
   originalQuery = appDb.query;
   configs = new Map();
-  dataSources = new Map();
+  dataSources = new Set();
 
   const analyst = authStub.seedUser({ email: "alice@example.com", roles: ["analyst"], password: "Hunter22ok!" });
   analystCookie = authStub.cookieFor(authStub.seedSession(analyst.id).token);
@@ -52,16 +72,16 @@ before(async () => {
   viewerCookie = authStub.cookieFor(authStub.seedSession(viewer.id).token);
 
   // Pre-seed a data source so the validation FK check has something to find.
-  dataSources.set("00000000-0000-4000-8000-d5d5d5d5d5d5", { id: "00000000-0000-4000-8000-d5d5d5d5d5d5" });
+  dataSources.add("00000000-0000-4000-8000-d5d5d5d5d5d5");
 
-  appDb.query = (async (sql, params = []) => {
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
     const auth = authStub.handleSql(sql, params);
     if (auth) return auth;
 
     const n = normalize(sql);
 
     if (n.startsWith("select config, updated_at from user_configs where user_id = $1")) {
-      const [userId] = params;
+      const userId = String(params[0]);
       const row = configs.get(userId);
       return row
         ? { rowCount: 1, rows: [{ config: row, updated_at: new Date().toISOString() }] }
@@ -69,13 +89,14 @@ before(async () => {
     }
 
     if (n.startsWith("insert into user_configs (user_id, config, updated_at)")) {
-      const [userId, configJson] = params;
-      configs.set(userId, JSON.parse(configJson));
+      const userId = String(params[0]);
+      const configJson = String(params[1]);
+      configs.set(userId, JSON.parse(configJson) as UserConfig);
       return { rowCount: 1, rows: [] };
     }
 
     if (n.startsWith("select id from data_sources where id = $1")) {
-      const [id] = params;
+      const id = String(params[0]);
       return dataSources.has(id)
         ? { rowCount: 1, rows: [{ id }] }
         : { rowCount: 0, rows: [] };
@@ -105,7 +126,7 @@ test("GET requires authentication", async () => {
 });
 
 test("GET returns baseline defaults when nothing is saved", async () => {
-  const result = await call("GET", "/v1/users/me/config", { cookie: analystCookie });
+  const result = await call<UserConfigPayload>("GET", "/v1/users/me/config", { cookie: analystCookie });
   assert.equal(result.status, 200);
   assert.equal(result.payload.config.theme, "system");
   assert.equal(result.payload.config.max_rows, 1000);
@@ -113,7 +134,7 @@ test("GET returns baseline defaults when nothing is saved", async () => {
 });
 
 test("PUT saves a config; subsequent GET returns it", async () => {
-  const put = await call("PUT", "/v1/users/me/config", {
+  const put = await call<UserConfigPayload>("PUT", "/v1/users/me/config", {
     cookie: analystCookie,
     body: {
       default_data_source_id: "00000000-0000-4000-8000-d5d5d5d5d5d5",
@@ -127,7 +148,7 @@ test("PUT saves a config; subsequent GET returns it", async () => {
   assert.equal(put.payload.config.theme, "dark");
   assert.equal(put.payload.config.max_rows, 500);
 
-  const get = await call("GET", "/v1/users/me/config", { cookie: analystCookie });
+  const get = await call<UserConfigPayload>("GET", "/v1/users/me/config", { cookie: analystCookie });
   assert.equal(get.status, 200);
   assert.equal(get.payload.config.default_data_source_id, "00000000-0000-4000-8000-d5d5d5d5d5d5");
   assert.equal(get.payload.config.theme, "dark");
@@ -162,11 +183,11 @@ test("PUT rejects unknown fields", async () => {
 
 test("viewer role can also read and write their own config", async () => {
   // The two new permissions are granted to admin / analyst / viewer alike.
-  const put = await call("PUT", "/v1/users/me/config", {
+  const put = await call<UserConfigPayload>("PUT", "/v1/users/me/config", {
     cookie: viewerCookie,
     body: { theme: "light" }
   });
   assert.equal(put.status, 200);
-  const get = await call("GET", "/v1/users/me/config", { cookie: viewerCookie });
+  const get = await call<UserConfigPayload>("GET", "/v1/users/me/config", { cookie: viewerCookie });
   assert.equal(get.payload.config.theme, "light");
 });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -18,12 +18,10 @@
     "app/test/federationHardeningApi.test.ts",
     "app/test/oidcLoginApi.test.ts",
     "app/test/promptPresetsApi.test.ts",
-    "app/test/ragNotesApi.test.ts",
     "app/test/savedQueriesApi.test.ts",
     "app/test/savedQueryFoldersApi.test.ts",
     "app/test/savedQuerySchedulesApi.test.ts",
     "app/test/scimApi.test.ts",
-    "app/test/securityHardeningApi.test.ts",
-    "app/test/userConfigApi.test.ts"
+    "app/test/securityHardeningApi.test.ts"
   ]
 }

--- a/tsconfig.test.legacy.json
+++ b/tsconfig.test.legacy.json
@@ -19,13 +19,11 @@
     "app/test/federationHardeningApi.test.ts",
     "app/test/oidcLoginApi.test.ts",
     "app/test/promptPresetsApi.test.ts",
-    "app/test/ragNotesApi.test.ts",
     "app/test/savedQueriesApi.test.ts",
     "app/test/savedQueryFoldersApi.test.ts",
     "app/test/savedQuerySchedulesApi.test.ts",
     "app/test/scimApi.test.ts",
     "app/test/securityHardeningApi.test.ts",
-    "app/test/userConfigApi.test.ts",
     "app/src/types/**/*.d.ts"
   ],
   "exclude": ["node_modules", "dist", "frontend"]


### PR DESCRIPTION
## Summary

- add typed user-config response contracts, fixture maps, cookies, and SQL parameters
- add typed RAG note/list/delete responses, note fixtures, reindex tracking, and SQL parameters
- move both API suites from the transitional profile into strict test checking
- reduce the legacy test allowlist from 16 suites to 14

Part of #148.

## Verification

- `npm run typecheck`
- `node --import tsx --test app/test/userConfigApi.test.ts app/test/ragNotesApi.test.ts` (11 passing)
- `npm test` (243 passing)
- `npm run build`
- `npm run benchmark:large-schema` (all release gates pass)

## Follow-up

Continue shrinking the 14-suite legacy allowlist in domain batches.