### PR TITLE
Migrate audit and security tests to strict mode

### DIFF
--- a/app/test/auditEventsApi.test.ts
+++ b/app/test/auditEventsApi.test.ts
@@ -20,16 +20,50 @@ process.env.PORT = "0";
 process.env.AUTH_COOKIE_SECURE = "false";
 
 import appDb = require("../src/lib/appDb");
-import authService = require("../src/services/authService");
 import { createAuthTestStub } from "./helpers/authTestStub";
+import type { ListEventsResult } from "../src/services/auditService";
+
+type TestUser = ReturnType<import("./helpers/authTestStub").AuthTestStub["seedUser"]>;
+
+interface AuditRow {
+  id: string;
+  actor_user_id: string | null;
+  actor_email: string | null;
+  target_user_id: string | null;
+  action: string;
+  outcome: string | null;
+  details: Record<string, unknown>;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: string;
+}
+
+interface ListFilters {
+  _action: string | null;
+  _actorUserId: string | null;
+  _targetUserId: string | null;
+  _outcome: string | null;
+  _since: string | null;
+  _until: string | null;
+  _limit: number;
+  _offset: number;
+}
+
+type FilterValueKey = "_action" | "_actorUserId" | "_targetUserId" | "_outcome" | "_since" | "_until";
+
+interface CallResult<T> {
+  status: number;
+  payload: T;
+  setCookie: string | null;
+}
 
 let server: import("http").Server;
 let baseUrl: string;
 let authStub: import("./helpers/authTestStub").AuthTestStub;
 let originalQuery: typeof appDb.query;
-let auditRows;
-let auditCounter;
-let users; // additional users not seeded via the stub (kept by id)
+let auditRows: AuditRow[];
+let auditCounter: number;
+let users: Map<string, TestUser>; // additional users not seeded via the stub (kept by id)
 
 function uuid(prefix: string, counter: number) {
   return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
@@ -39,7 +73,11 @@ function normalize(sql: string) {
   return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
-async function call(method: string, path: string, { cookie, body }: { cookie?: string; body?: unknown } = {}) {
+async function call<T = unknown>(
+  method: string,
+  path: string,
+  { cookie, body }: { cookie?: string; body?: unknown } = {}
+): Promise<CallResult<T>> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (cookie) headers.Cookie = cookie;
   const response = await fetch(`${baseUrl}${path}`, {
@@ -47,32 +85,30 @@ async function call(method: string, path: string, { cookie, body }: { cookie?: s
     headers,
     body: body ? JSON.stringify(body) : undefined
   });
-  let payload = null;
+  let payload: unknown = null;
   if ((response.headers.get("content-type") || "").includes("application/json")) {
     try { payload = await response.json(); } catch { payload = null; }
   }
-  return { status: response.status, payload, setCookie: response.headers.get("set-cookie") };
+  return { status: response.status, payload: payload as T, setCookie: response.headers.get("set-cookie") };
 }
 
-function parseSessionCookieValue(setCookieHeader) {
+function parseSessionCookieValue(setCookieHeader: string | null): string | null {
   if (!setCookieHeader) return null;
   const match = setCookieHeader.match(/rp_session=([^;]*)/);
   return match ? decodeURIComponent(match[1]) : null;
 }
 
-function applyFilters(rows, params) {
+function applyFilters(rows: AuditRow[], params: ListFilters): AuditRow[] {
   let out = [...rows];
-  const conditions = []; // mirror order auditService.listEvents builds
+  const { _action, _actorUserId, _targetUserId, _outcome, _since, _until } = params;
   // We replay the same predicate set here. params start at $1 in the SQL but
   // we already know the JS-side order; just check by name supplied at call.
-  if (params._action) out = out.filter((r) => r.action === params._action);
-  if (params._actorUserId) out = out.filter((r) => r.actor_user_id === params._actorUserId);
-  if (params._targetUserId) out = out.filter((r) => r.target_user_id === params._targetUserId);
-  if (params._outcome) out = out.filter((r) => r.outcome === params._outcome);
-  if (params._since) out = out.filter((r) => r.created_at >= params._since);
-  if (params._until) out = out.filter((r) => r.created_at < params._until);
-  // unused; conditions stay separate so we can audit them later if needed
-  void conditions;
+  if (_action) out = out.filter((r) => r.action === _action);
+  if (_actorUserId) out = out.filter((r) => r.actor_user_id === _actorUserId);
+  if (_targetUserId) out = out.filter((r) => r.target_user_id === _targetUserId);
+  if (_outcome) out = out.filter((r) => r.outcome === _outcome);
+  if (_since) out = out.filter((r) => r.created_at >= _since);
+  if (_until) out = out.filter((r) => r.created_at < _until);
   return out;
 }
 
@@ -90,7 +126,7 @@ before(async () => {
   const analyst = authStub.seedUser({ email: "alice@example.com", roles: ["analyst"], password: "hunter22ok" });
   users.set(analyst.id, analyst);
 
-  appDb.query = (async (sql, params = []) => {
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
     // First let the shared auth stub handle session/role lookups.
     const auth = authStub.handleSql(sql, params);
     if (auth) return auth;
@@ -99,7 +135,7 @@ before(async () => {
 
     // findUserByEmail
     if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
-      const [emailLower] = params;
+      const emailLower = String(params[0]);
       const row = [...users.values()].find((u) => u.email.toLowerCase() === emailLower);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
@@ -120,14 +156,14 @@ before(async () => {
       auditCounter += 1;
       auditRows.push({
         id: uuid("dddd", auditCounter),
-        actor_user_id: actorUserId,
-        actor_email: actorEmail,
-        target_user_id: targetUserId,
-        action,
-        outcome,
-        details: JSON.parse(detailsJson),
-        ip_address: ipAddress,
-        user_agent: userAgent,
+        actor_user_id: typeof actorUserId === "string" ? actorUserId : null,
+        actor_email: typeof actorEmail === "string" ? actorEmail : null,
+        target_user_id: typeof targetUserId === "string" ? targetUserId : null,
+        action: String(action),
+        outcome: typeof outcome === "string" ? outcome : null,
+        details: JSON.parse(String(detailsJson)) as Record<string, unknown>,
+        ip_address: typeof ipAddress === "string" ? ipAddress : null,
+        user_agent: typeof userAgent === "string" ? userAgent : null,
         // ensure stable ordering: insertion order also reflects time order
         created_at: new Date(Date.now() + auditCounter).toISOString()
       });
@@ -185,8 +221,8 @@ beforeEach(() => {
 // predicates the auditService built. The service appends parameters in a known
 // order, ending with $LIMIT and $OFFSET. We don't try to parse the SQL —
 // instead, the helper mirrors the construction in auditService.listEvents.
-function parseListFilters(sql, params) {
-  const filters = {
+function parseListFilters(sql: string, params: unknown[]): ListFilters {
+  const filters: ListFilters = {
     _action: null,
     _actorUserId: null,
     _targetUserId: null,
@@ -198,7 +234,7 @@ function parseListFilters(sql, params) {
   };
   // Match the predicates that exist in the SQL to figure out which params slot
   // into which filter (count vs list queries share the WHERE clause).
-  const order = [];
+  const order: FilterValueKey[] = [];
   if (/a\.action = \$/.test(sql)) order.push("_action");
   if (/a\.actor_user_id = \$/.test(sql)) order.push("_actorUserId");
   if (/a\.target_user_id = \$/.test(sql)) order.push("_targetUserId");
@@ -206,9 +242,10 @@ function parseListFilters(sql, params) {
   if (/a\.created_at >= \$/.test(sql)) order.push("_since");
   if (/a\.created_at < \$/.test(sql)) order.push("_until");
 
-  for (let i = 0; i < order.length; i += 1) {
-    filters[order[i]] = params[i];
-  }
+  order.forEach((key, index) => {
+    const value = params[index];
+    filters[key] = typeof value === "string" ? value : null;
+  });
   const isListQuery = /limit \$/i.test(sql);
   if (isListQuery) {
     filters._limit = Number(params[params.length - 2]);
@@ -240,6 +277,7 @@ test("successful login and logout each record an audit event tied to the user", 
   });
   assert.equal(login.status, 200);
   const token = parseSessionCookieValue(login.setCookie);
+  assert.ok(token, "expected session token");
   await new Promise((r) => setImmediate(r));
 
   const success = auditRows.find((r) => r.action === "auth.login.success");
@@ -262,6 +300,7 @@ test("successful login and logout each record an audit event tied to the user", 
 
 test("GET /v1/admin/audit-events lists events newest-first with pagination", async () => {
   const adminUser = [...users.values()].find((u) => u.email === "admin@example.com");
+  assert.ok(adminUser, "expected admin fixture");
   const adminCookie = authStub.cookieFor(authStub.seedSession(adminUser.id).token);
 
   // Trigger a few events.
@@ -269,7 +308,7 @@ test("GET /v1/admin/audit-events lists events newest-first with pagination", asy
   await call("POST", "/v1/auth/login", { body: { email: "alice@example.com", password: "hunter22ok" } });
   await new Promise((r) => setImmediate(r));
 
-  const list = await call("GET", "/v1/admin/audit-events", { cookie: adminCookie });
+  const list = await call<ListEventsResult>("GET", "/v1/admin/audit-events", { cookie: adminCookie });
   assert.equal(list.status, 200);
   assert.equal(list.payload.limit, 50);
   assert.equal(list.payload.offset, 0);
@@ -279,30 +318,32 @@ test("GET /v1/admin/audit-events lists events newest-first with pagination", asy
   assert.ok(actions.indexOf("auth.login.success") < actions.indexOf("auth.login.failure"));
 
   // Pagination
-  const paged = await call("GET", "/v1/admin/audit-events?limit=1", { cookie: adminCookie });
+  const paged = await call<ListEventsResult>("GET", "/v1/admin/audit-events?limit=1", { cookie: adminCookie });
   assert.equal(paged.payload.items.length, 1);
   assert.equal(paged.payload.limit, 1);
 });
 
 test("GET /v1/admin/audit-events filters by action and outcome", async () => {
   const adminUser = [...users.values()].find((u) => u.email === "admin@example.com");
+  assert.ok(adminUser, "expected admin fixture");
   const adminCookie = authStub.cookieFor(authStub.seedSession(adminUser.id).token);
 
   await call("POST", "/v1/auth/login", { body: { email: "nobody@example.com", password: "x".repeat(10) } });
   await call("POST", "/v1/auth/login", { body: { email: "alice@example.com", password: "hunter22ok" } });
   await new Promise((r) => setImmediate(r));
 
-  const byAction = await call("GET", "/v1/admin/audit-events?action=auth.login.failure", { cookie: adminCookie });
+  const byAction = await call<ListEventsResult>("GET", "/v1/admin/audit-events?action=auth.login.failure", { cookie: adminCookie });
   assert.equal(byAction.status, 200);
   assert.ok(byAction.payload.items.every((it) => it.action === "auth.login.failure"));
   assert.ok(byAction.payload.items.length >= 1);
 
-  const byOutcome = await call("GET", "/v1/admin/audit-events?outcome=failure", { cookie: adminCookie });
+  const byOutcome = await call<ListEventsResult>("GET", "/v1/admin/audit-events?outcome=failure", { cookie: adminCookie });
   assert.ok(byOutcome.payload.items.every((it) => it.outcome === "failure"));
 });
 
 test("GET /v1/admin/audit-events is admin-only", async () => {
   const analystUser = [...users.values()].find((u) => u.email === "alice@example.com");
+  assert.ok(analystUser, "expected analyst fixture");
   const analystCookie = authStub.cookieFor(authStub.seedSession(analystUser.id).token);
 
   const forbidden = await call("GET", "/v1/admin/audit-events", { cookie: analystCookie });
@@ -314,6 +355,7 @@ test("GET /v1/admin/audit-events is admin-only", async () => {
 
 test("audit list rejects malformed uuid filters", async () => {
   const adminUser = [...users.values()].find((u) => u.email === "admin@example.com");
+  assert.ok(adminUser, "expected admin fixture");
   const adminCookie = authStub.cookieFor(authStub.seedSession(adminUser.id).token);
 
   const badActor = await call("GET", "/v1/admin/audit-events?actor_user_id=not-a-uuid", { cookie: adminCookie });
@@ -322,7 +364,3 @@ test("audit list rejects malformed uuid filters", async () => {
   const badTarget = await call("GET", "/v1/admin/audit-events?target_user_id=not-a-uuid", { cookie: adminCookie });
   assert.equal(badTarget.status, 400);
 });
-
-// Silence the variable-unused warning by exporting the helper modules used at
-// the top — keeps lint happy without changing runtime behavior.
-void authService;

--- a/app/test/securityHardeningApi.test.ts
+++ b/app/test/securityHardeningApi.test.ts
@@ -18,16 +18,54 @@ process.env.AUTH_LOCKOUT_IP_THRESHOLD = "10";
 
 import appDb = require("../src/lib/appDb");
 import authService = require("../src/services/authService");
+import type { AuthUserRow } from "../src/services/authService";
+
+interface TestSession {
+  id: string;
+  user_id: string;
+  token_hash: string;
+  user_agent: string | null;
+  ip_address: string | null;
+  expires_at: string;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+interface AuditRow {
+  id: string;
+  actor_user_id: string | null;
+  actor_email: string | null;
+  target_user_id: string | null;
+  action: string;
+  outcome: string | null;
+  details: Record<string, unknown>;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: string;
+}
+
+interface LockoutPayload {
+  error: string;
+  reason: string;
+  retry_after_seconds: number;
+}
+
+interface CallResult<T> {
+  status: number;
+  payload: T;
+  setCookie: string | null;
+  headers: Headers;
+}
 
 let server: import("http").Server;
 let baseUrl: string;
-let users;
-let sessions;
-let auditRows;
+let users: Map<string, AuthUserRow>;
+let sessions: Map<string, TestSession>;
+let auditRows: AuditRow[];
 let originalQuery: typeof appDb.query;
-let userCounter;
-let sessionCounter;
-let auditCounter;
+let userCounter: number;
+let sessionCounter: number;
+let auditCounter: number;
 
 function uuid(prefix: string, counter: number) {
   return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
@@ -37,7 +75,11 @@ function normalize(sql: string) {
   return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
-async function call(method: string, path: string, { cookie, body }: { cookie?: string; body?: unknown } = {}) {
+async function call<T = unknown>(
+  method: string,
+  path: string,
+  { cookie, body }: { cookie?: string; body?: unknown } = {}
+): Promise<CallResult<T>> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (cookie) headers.Cookie = cookie;
   const response = await fetch(`${baseUrl}${path}`, {
@@ -45,19 +87,19 @@ async function call(method: string, path: string, { cookie, body }: { cookie?: s
     headers,
     body: body ? JSON.stringify(body) : undefined
   });
-  let payload = null;
+  let payload: unknown = null;
   if ((response.headers.get("content-type") || "").includes("application/json")) {
     try { payload = await response.json(); } catch { payload = null; }
   }
   return {
     status: response.status,
-    payload,
+    payload: payload as T,
     setCookie: response.headers.get("set-cookie"),
     headers: response.headers
   };
 }
 
-function emailFailureCount(email) {
+function emailFailureCount(email: string): number {
   return auditRows.filter(
     (r) => r.action === "auth.login.failure" && r.actor_email === email.toLowerCase()
   ).length;
@@ -86,17 +128,21 @@ before(async () => {
     updated_at: new Date().toISOString()
   });
 
-  appDb.query = (async (sql, params = []) => {
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
     const n = normalize(sql);
 
     if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
-      const [emailLower] = params;
+      const emailLower = String(params[0]);
       const row = [...users.values()].find((u) => u.email.toLowerCase() === emailLower);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
 
     if (n.startsWith("insert into user_sessions")) {
-      const [uid, tokenHash, ua, ip, expiresAt] = params;
+      const uid = String(params[0]);
+      const tokenHash = String(params[1]);
+      const ua = typeof params[2] === "string" ? params[2] : null;
+      const ip = typeof params[3] === "string" ? params[3] : null;
+      const expiresAt = String(params[4]);
       sessionCounter += 1;
       const id = uuid("bbbb", sessionCounter);
       sessions.set(id, { id, user_id: uid, token_hash: tokenHash, user_agent: ua, ip_address: ip, expires_at: expiresAt, created_at: new Date().toISOString(), revoked_at: null });
@@ -113,14 +159,14 @@ before(async () => {
       auditCounter += 1;
       auditRows.push({
         id: uuid("dddd", auditCounter),
-        actor_user_id: actorUserId,
-        actor_email: actorEmail,
-        target_user_id: targetUserId,
-        action,
-        outcome,
-        details: JSON.parse(detailsJson),
-        ip_address: ipAddress,
-        user_agent: userAgent,
+        actor_user_id: typeof actorUserId === "string" ? actorUserId : null,
+        actor_email: typeof actorEmail === "string" ? actorEmail : null,
+        target_user_id: typeof targetUserId === "string" ? targetUserId : null,
+        action: String(action),
+        outcome: typeof outcome === "string" ? outcome : null,
+        details: JSON.parse(String(detailsJson)) as Record<string, unknown>,
+        ip_address: typeof ipAddress === "string" ? ipAddress : null,
+        user_agent: typeof userAgent === "string" ? userAgent : null,
         created_at: new Date(Date.now() + auditCounter).toISOString()
       });
       return { rowCount: 1, rows: [] };
@@ -128,7 +174,8 @@ before(async () => {
 
     // loginLockoutService — email-window query
     if (n.startsWith("with recent as ( select outcome, created_at from auth_audit_log where action in")) {
-      const [emailLower, sinceIso] = params;
+      const emailLower = String(params[0]);
+      const sinceIso = String(params[1]);
       const relevant = auditRows.filter(
         (r) => (r.action === "auth.login.failure" || r.action === "auth.login.success")
           && (r.actor_email || "").toLowerCase() === emailLower
@@ -139,27 +186,34 @@ before(async () => {
         .reduce((max, r) => (r.created_at > max ? r.created_at : max), "");
       const failures = relevant
         .filter((r) => r.outcome === "failure" && (lastSuccess === "" || r.created_at > lastSuccess));
-      const lastFailureAt = failures.reduce((max, r) => (r.created_at > max ? r.created_at : max), null);
+      const lastFailureAt = failures.reduce<string | null>(
+        (max, row) => max === null || row.created_at > max ? row.created_at : max,
+        null
+      );
       return { rowCount: 1, rows: [{ failures: failures.length, last_failure_at: lastFailureAt }] };
     }
 
     // loginLockoutService — IP query
     if (n.startsWith("select count(*)::int as failures, max(created_at) as last_failure_at from auth_audit_log where action = 'auth.login.failure'")) {
-      const [ipAddress, sinceIso] = params;
+      const ipAddress = String(params[0]);
+      const sinceIso = String(params[1]);
       const matching = auditRows.filter(
         (r) => r.action === "auth.login.failure"
           && r.outcome === "failure"
           && r.ip_address === ipAddress
           && r.created_at >= sinceIso
       );
-      const lastFailureAt = matching.reduce((max, r) => (r.created_at > max ? r.created_at : max), null);
+      const lastFailureAt = matching.reduce<string | null>(
+        (max, row) => max === null || row.created_at > max ? row.created_at : max,
+        null
+      );
       return { rowCount: 1, rows: [{ failures: matching.length, last_failure_at: lastFailureAt }] };
     }
 
     // Session lookup (after successful login, used by /v1/auth/me) — not
     // strictly needed by this suite but kept for completeness.
     if (n.startsWith("select s.id as session_id, s.expires_at, s.revoked_at, u.id, u.email")) {
-      const [tokenHash] = params;
+      const tokenHash = String(params[0]);
       const session = [...sessions.values()].find((s) => s.token_hash === tokenHash);
       if (!session) return { rowCount: 0, rows: [] };
       const user = users.get(session.user_id);
@@ -251,7 +305,7 @@ test("repeated failed logins return 429 with Retry-After and emit an audit row",
   await new Promise<void>((resolve) => setImmediate(resolve));
   assert.equal(emailFailureCount("alice@example.com"), 3);
 
-  const locked = await call("POST", "/v1/auth/login", { body });
+  const locked = await call<LockoutPayload>("POST", "/v1/auth/login", { body });
   assert.equal(locked.status, 429);
   assert.equal(locked.payload.error, "too_many_requests");
   assert.equal(locked.payload.reason, "too_many_failed_logins");

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -11,7 +11,6 @@
     "frontend",
     "app/test/accountLinkingApi.test.ts",
     "app/test/adminUsersApi.test.ts",
-    "app/test/auditEventsApi.test.ts",
     "app/test/authApi.test.ts",
     "app/test/authProvidersAdminApi.test.ts",
     "app/test/dataSourceAccessApi.test.ts",
@@ -21,7 +20,6 @@
     "app/test/savedQueriesApi.test.ts",
     "app/test/savedQueryFoldersApi.test.ts",
     "app/test/savedQuerySchedulesApi.test.ts",
-    "app/test/scimApi.test.ts",
-    "app/test/securityHardeningApi.test.ts"
+    "app/test/scimApi.test.ts"
   ]
 }

--- a/tsconfig.test.legacy.json
+++ b/tsconfig.test.legacy.json
@@ -12,7 +12,6 @@
   "include": [
     "app/test/accountLinkingApi.test.ts",
     "app/test/adminUsersApi.test.ts",
-    "app/test/auditEventsApi.test.ts",
     "app/test/authApi.test.ts",
     "app/test/authProvidersAdminApi.test.ts",
     "app/test/dataSourceAccessApi.test.ts",
@@ -23,7 +22,6 @@
     "app/test/savedQueryFoldersApi.test.ts",
     "app/test/savedQuerySchedulesApi.test.ts",
     "app/test/scimApi.test.ts",
-    "app/test/securityHardeningApi.test.ts",
     "app/src/types/**/*.d.ts"
   ],
   "exclude": ["node_modules", "dist", "frontend"]


### PR DESCRIPTION
## Summary
- type audit-event fixtures, filters, rows, and API payloads for strict compilation
- type security-hardening users, sessions, audit rows, and lockout responses
- move both suites out of the transitional TypeScript config, reducing the legacy allowlist from 14 suites to 12

Part of #148.

## Verification
- `npx tsc --noEmit -p tsconfig.test.json --pretty false`
- `npm run typecheck`
- `node --import tsx --test app/test/auditEventsApi.test.ts app/test/securityHardeningApi.test.ts` (10 passing)
- `npm test` (243 passing)
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)