### PR TITLE
Migrate federation provider tests to strict mode

### DIFF
--- a/app/test/authProvidersAdminApi.test.ts
+++ b/app/test/authProvidersAdminApi.test.ts
@@ -14,16 +14,46 @@ process.env.AUTH_FLOW_SECRET = "x".repeat(48);
 import appDb = require("../src/lib/appDb");
 import { createAuthTestStub } from "./helpers/authTestStub";
 import { createMockOidcIdp } from "./helpers/mockOidcIdp";
+import type { MockOidcIdp } from "./helpers/mockOidcIdp";
+import type { ProviderRow } from "../src/services/authProviderService";
+import type { ApiSchema, AuthProvider } from "../src/types";
+
+type AuthProviderListResponse = ApiSchema<"AuthProviderListResponse">;
+type AuthProviderTestResult = ApiSchema<"AuthProviderTestResult">;
+
+interface SeedProviderInput {
+  id?: string;
+  type?: string;
+  name: string;
+  display_name?: string | null;
+  issuer: string;
+  client_id: string;
+  client_secret?: string | null;
+  scopes?: string[];
+  redirect_uri: string;
+  claims_mapping?: Record<string, unknown>;
+  enabled?: boolean;
+}
+
+interface ErrorPayload {
+  message: string;
+}
+
+interface CallResult<T> {
+  status: number;
+  payload: T;
+}
 
 let server: import("http").Server;
 let baseUrl: string;
 let authStub: import("./helpers/authTestStub").AuthTestStub;
-let idp;
+let idp: MockOidcIdp;
+let issuer: string;
 let originalQuery: typeof appDb.query;
-let providers;
-let providerCounter;
-let adminCookie;
-let analystCookie;
+let providers: Map<string, ProviderRow>;
+let providerCounter: number;
+let adminCookie: string;
+let analystCookie: string;
 
 function normalize(sql: string) {
   return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
@@ -38,8 +68,8 @@ function nextProviderId(): string {
   return uuid("eeee", providerCounter);
 }
 
-function seedProvider(row) {
-  const created = {
+function seedProvider(row: SeedProviderInput): ProviderRow {
+  const created: ProviderRow = {
     id: row.id || nextProviderId(),
     type: row.type || "oidc",
     name: row.name,
@@ -58,7 +88,11 @@ function seedProvider(row) {
   return created;
 }
 
-async function call(method: string, path: string, { cookie, body }: { cookie?: string; body?: unknown } = {}) {
+async function call<T = unknown>(
+  method: string,
+  path: string,
+  { cookie, body }: { cookie?: string; body?: unknown } = {}
+): Promise<CallResult<T>> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (cookie) headers.Cookie = cookie;
   const response = await fetch(`${baseUrl}${path}`, {
@@ -66,11 +100,11 @@ async function call(method: string, path: string, { cookie, body }: { cookie?: s
     headers,
     body: body ? JSON.stringify(body) : undefined
   });
-  let payload = null;
+  let payload: unknown = null;
   if ((response.headers.get("content-type") || "").includes("application/json")) {
     try { payload = await response.json(); } catch { payload = null; }
   }
-  return { status: response.status, payload };
+  return { status: response.status, payload: payload as T };
 }
 
 before(async () => {
@@ -80,7 +114,7 @@ before(async () => {
     clientId: "test-client",
     clientSecret: "test-secret"
   });
-  await idp.start();
+  issuer = await idp.start();
 
   originalQuery = appDb.query;
   providers = new Map();
@@ -91,14 +125,14 @@ before(async () => {
   adminCookie = authStub.cookieFor(authStub.seedSession(admin.id).token);
   analystCookie = authStub.cookieFor(authStub.seedSession(analyst.id).token);
 
-  appDb.query = (async (sql, params = []) => {
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
     const auth = authStub.handleSql(sql, params);
     if (auth) return auth;
 
     const n = normalize(sql);
 
     if (n.startsWith("select") && /from auth_providers\s+where id = \$1/.test(n)) {
-      const [id] = params;
+      const [id] = params as [string];
       const row = providers.get(id);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
@@ -109,29 +143,52 @@ before(async () => {
     }
 
     if (n.startsWith("insert into auth_providers")) {
-      const [type, name, displayName, issuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params;
+      const [type, name, displayName, providerIssuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params as [
+        string,
+        string,
+        string | null,
+        string,
+        string,
+        string | null,
+        string[],
+        string,
+        string,
+        boolean
+      ];
       const existing = [...providers.values()].find((p) => p.name.toLowerCase() === String(name).toLowerCase());
       if (existing) {
         const err = Object.assign(new Error("duplicate name"), { code: "23505" }); throw err;
       }
       const row = seedProvider({
-        type, name, display_name: displayName, issuer, client_id: clientId,
+        type, name, display_name: displayName, issuer: providerIssuer, client_id: clientId,
         client_secret: clientSecret, scopes, redirect_uri: redirectUri,
-        claims_mapping: JSON.parse(claimsMappingJson), enabled
+        claims_mapping: JSON.parse(claimsMappingJson) as Record<string, unknown>, enabled
       });
       return { rowCount: 1, rows: [row] };
     }
 
     if (n.startsWith("update auth_providers")) {
-      const [id, type, name, displayName, issuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params;
+      const [id, type, name, displayName, providerIssuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params as [
+        string,
+        string,
+        string,
+        string | null,
+        string,
+        string,
+        string | null,
+        string[],
+        string,
+        string,
+        boolean
+      ];
       const existing = providers.get(id);
       if (!existing) return { rowCount: 0, rows: [] };
       const next = {
         ...existing,
-        type, name, display_name: displayName, issuer, client_id: clientId,
+        type, name, display_name: displayName, issuer: providerIssuer, client_id: clientId,
         client_secret: clientSecret === null ? existing.client_secret : clientSecret,
         scopes, redirect_uri: redirectUri,
-        claims_mapping: JSON.parse(claimsMappingJson),
+        claims_mapping: JSON.parse(claimsMappingJson) as Record<string, unknown>,
         enabled,
         updated_at: new Date().toISOString()
       };
@@ -140,7 +197,7 @@ before(async () => {
     }
 
     if (n.startsWith("delete from auth_providers where id = $1 returning id")) {
-      const [id] = params;
+      const [id] = params as [string];
       if (!providers.has(id)) return { rowCount: 0, rows: [] };
       providers.delete(id);
       return { rowCount: 1, rows: [{ id }] };
@@ -167,13 +224,13 @@ after(async () => {
 });
 
 test("admin can create, list, update, and delete auth providers; client_secret is redacted", async () => {
-  const create = await call("POST", "/v1/admin/auth-providers", {
+  const create = await call<AuthProvider>("POST", "/v1/admin/auth-providers", {
     cookie: adminCookie,
     body: {
       type: "oidc",
       name: "okta",
       display_name: "Okta SSO",
-      issuer: idp.issuer,
+      issuer,
       client_id: idp.clientId,
       client_secret: idp.clientSecret,
       redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
@@ -184,20 +241,20 @@ test("admin can create, list, update, and delete auth providers; client_secret i
   assert.equal(create.payload.display_name, "Okta SSO");
   assert.equal(create.payload.client_secret, "***", "client_secret should be redacted in API responses");
 
-  const list = await call("GET", "/v1/admin/auth-providers", { cookie: adminCookie });
+  const list = await call<AuthProviderListResponse>("GET", "/v1/admin/auth-providers", { cookie: adminCookie });
   assert.equal(list.status, 200);
-  assert.equal(list.payload.items.length, 1);
-  assert.equal(list.payload.items[0].client_secret, "***");
+  assert.equal(list.payload.items?.length, 1);
+  assert.equal(list.payload.items?.[0].client_secret, "***");
 
   // Updating without client_secret keeps the old one (still redacted in response).
-  const update = await call("POST", "/v1/admin/auth-providers", {
+  const update = await call<AuthProvider>("POST", "/v1/admin/auth-providers", {
     cookie: adminCookie,
     body: {
       id: create.payload.id,
       type: "oidc",
       name: "okta",
       display_name: "Okta (prod)",
-      issuer: idp.issuer,
+      issuer,
       client_id: idp.clientId,
       redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
     }
@@ -211,7 +268,7 @@ test("admin can create, list, update, and delete auth providers; client_secret i
 });
 
 test("auth provider validation surfaces field-level errors", async () => {
-  const badIssuer = await call("POST", "/v1/admin/auth-providers", {
+  const badIssuer = await call<ErrorPayload>("POST", "/v1/admin/auth-providers", {
     cookie: adminCookie,
     body: {
       type: "oidc",
@@ -224,12 +281,12 @@ test("auth provider validation surfaces field-level errors", async () => {
   assert.equal(badIssuer.status, 400);
   assert.match(badIssuer.payload.message, /issuer/i);
 
-  const badRedirect = await call("POST", "/v1/admin/auth-providers", {
+  const badRedirect = await call<ErrorPayload>("POST", "/v1/admin/auth-providers", {
     cookie: adminCookie,
     body: {
       type: "oidc",
       name: "bad2",
-      issuer: idp.issuer,
+      issuer,
       client_id: "x",
       redirect_uri: "not-a-url"
     }
@@ -237,12 +294,12 @@ test("auth provider validation surfaces field-level errors", async () => {
   assert.equal(badRedirect.status, 400);
   assert.match(badRedirect.payload.message, /redirect_uri/i);
 
-  const badName = await call("POST", "/v1/admin/auth-providers", {
+  const badName = await call<ErrorPayload>("POST", "/v1/admin/auth-providers", {
     cookie: adminCookie,
     body: {
       type: "oidc",
       name: "spaces in name",
-      issuer: idp.issuer,
+      issuer,
       client_id: "x",
       redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
     }
@@ -256,7 +313,7 @@ test("auth provider validation surfaces field-level errors", async () => {
     body: {
       type: "oidc",
       name: "dup",
-      issuer: idp.issuer,
+      issuer,
       client_id: "x",
       redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
     }
@@ -266,7 +323,7 @@ test("auth provider validation surfaces field-level errors", async () => {
     body: {
       type: "oidc",
       name: "DUP",
-      issuer: idp.issuer,
+      issuer,
       client_id: "x",
       redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
     }
@@ -277,17 +334,17 @@ test("auth provider validation surfaces field-level errors", async () => {
 test("POST .../test returns discovery metadata for a reachable provider", async () => {
   const provider = seedProvider({
     name: "okta",
-    issuer: idp.issuer,
+    issuer,
     client_id: idp.clientId,
     client_secret: idp.clientSecret,
     redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
   });
 
-  const result = await call("POST", `/v1/admin/auth-providers/${provider.id}/test`, { cookie: adminCookie });
+  const result = await call<AuthProviderTestResult>("POST", `/v1/admin/auth-providers/${provider.id}/test`, { cookie: adminCookie });
   assert.equal(result.status, 200);
   assert.equal(result.payload.ok, true);
-  assert.equal(result.payload.issuer, idp.issuer);
-  assert.ok(result.payload.authorization_endpoint && result.payload.authorization_endpoint.startsWith(idp.issuer));
+  assert.equal(result.payload.issuer, issuer);
+  assert.ok(result.payload.authorization_endpoint?.startsWith(issuer));
   assert.ok(result.payload.token_endpoint);
   assert.ok(result.payload.jwks_uri);
   assert.ok(Array.isArray(result.payload.code_challenge_methods_supported));
@@ -302,7 +359,7 @@ test("POST .../test reports failure with the error message when discovery fails"
     redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
   });
 
-  const result = await call("POST", `/v1/admin/auth-providers/${provider.id}/test`, { cookie: adminCookie });
+  const result = await call<AuthProviderTestResult>("POST", `/v1/admin/auth-providers/${provider.id}/test`, { cookie: adminCookie });
   assert.equal(result.status, 200);
   assert.equal(result.payload.ok, false);
   assert.ok(typeof result.payload.error === "string" && result.payload.error.length > 0);
@@ -311,7 +368,7 @@ test("POST .../test reports failure with the error message when discovery fails"
 test("test endpoint is admin-only and 404s for unknown providers", async () => {
   const provider = seedProvider({
     name: "okta",
-    issuer: idp.issuer,
+    issuer,
     client_id: idp.clientId,
     redirect_uri: `${baseUrl}/v1/auth/oidc/callback`
   });

--- a/app/test/federationHardeningApi.test.ts
+++ b/app/test/federationHardeningApi.test.ts
@@ -21,19 +21,42 @@ process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@l
 import appDb = require("../src/lib/appDb");
 import externalLoginService = require("../src/services/externalLoginService");
 import oidcStateService = require("../src/services/oidcStateService");
+import type { PoolClient } from "pg";
+import type { ProviderRow } from "../src/services/authProviderService";
+import type { AuthUserRow } from "../src/services/authService";
+import type { LinkedIdentity } from "../src/services/linkedIdentityService";
+
+interface AuditRow {
+  id: string;
+  actor_user_id: string | null;
+  actor_email: string | null;
+  target_user_id: string | null;
+  action: string;
+  outcome: string | null;
+  details: Record<string, unknown>;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: string;
+}
+
+interface UsedStateRow {
+  state_hash: string;
+  provider_id: string;
+  expires_at: Date | string;
+}
 
 let originalQuery: typeof appDb.query;
 let originalWithTransaction: typeof appDb.withTransaction;
 
-let providers;
-let users;
-let linkedIdentities;
-let auditRows;
-let usedStates;
-let providerCounter;
-let userCounter;
-let identityCounter;
-let auditCounter;
+let providers: Map<string, ProviderRow>;
+let users: Map<string, AuthUserRow>;
+let linkedIdentities: Map<string, LinkedIdentity>;
+let auditRows: AuditRow[];
+let usedStates: Map<string, UsedStateRow>;
+let providerCounter: number;
+let userCounter: number;
+let identityCounter: number;
+let auditCounter: number;
 
 function uuid(prefix: string, counter: number) {
   return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
@@ -47,24 +70,24 @@ function nextProviderId(): string { providerCounter += 1; return uuid("eeee", pr
 function nextUserId(): string { userCounter += 1; return uuid("aaab", userCounter); }
 function nextIdentityId(): string { identityCounter += 1; return uuid("ffff", identityCounter); }
 
-function seedProvider(overrides: Record<string, unknown> = {}) {
-  const row = {
-    id: overrides.id || nextProviderId(),
+function seedProvider(overrides: Partial<ProviderRow> = {}): ProviderRow {
+  const row: ProviderRow = {
+    id: overrides.id ?? nextProviderId(),
     type: "oidc",
-    name: overrides.name || "okta",
-    display_name: overrides.display_name || "Okta",
-    issuer: overrides.issuer || "https://okta.example.com",
+    name: overrides.name ?? "okta",
+    display_name: overrides.display_name ?? "Okta",
+    issuer: overrides.issuer ?? "https://okta.example.com",
     client_id: "test-client",
     client_secret: null,
     scopes: ["openid", "email", "profile"],
     redirect_uri: "http://localhost/cb",
     claims_mapping: {},
     enabled: true,
-    auto_link_by_email: overrides.auto_link_by_email !== undefined ? overrides.auto_link_by_email : true,
-    jit_enabled: overrides.jit_enabled === true,
-    jit_default_role: overrides.jit_default_role || "viewer",
-    jit_allowed_domains: overrides.jit_allowed_domains || [],
-    require_email_verified: overrides.require_email_verified !== undefined ? overrides.require_email_verified : true,
+    auto_link_by_email: overrides.auto_link_by_email ?? true,
+    jit_enabled: overrides.jit_enabled ?? false,
+    jit_default_role: overrides.jit_default_role ?? "viewer",
+    jit_allowed_domains: overrides.jit_allowed_domains ?? [],
+    require_email_verified: overrides.require_email_verified ?? true,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString()
   };
@@ -85,34 +108,36 @@ before(() => {
   identityCounter = 0;
   auditCounter = 0;
 
-  appDb.withTransaction = (async (handler) => {
-    const txClient = { query: async (sql, params) => appDb.query(sql, params) };
-    return handler(txClient);
-  }) as unknown as typeof appDb.withTransaction;
+  const txClient = {
+    query: (sql: string, params: unknown[] = []) => appDb.query(sql, params)
+  } as unknown as PoolClient;
+  appDb.withTransaction = (async <T>(handler: (client: PoolClient) => Promise<T>): Promise<T> => (
+    handler(txClient)
+  )) as typeof appDb.withTransaction;
 
-  appDb.query = (async (sql, params = []) => {
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
     const n = normalize(sql);
 
     if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
-      const [emailLower] = params;
+      const [emailLower] = params as [string];
       const row = [...users.values()].find((u) => u.email.toLowerCase() === emailLower);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
     if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where id = $1")) {
-      const [id] = params;
+      const [id] = params as [string];
       const row = users.get(id);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
     if (n.startsWith("select id, user_id, provider_id, subject, email_at_link, created_at, last_seen_at from linked_identities where provider_id = $1 and subject = $2")) {
-      const [providerId, subject] = params;
+      const [providerId, subject] = params as [string, string];
       const row = [...linkedIdentities.values()].find(
         (li) => li.provider_id === providerId && li.subject === subject
       );
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
     if (n.startsWith("insert into linked_identities")) {
-      const [userId, providerId, subject, emailAtLink] = params;
-      const row = {
+      const [userId, providerId, subject, emailAtLink] = params as [string, string, string, string | null];
+      const row: LinkedIdentity = {
         id: nextIdentityId(),
         user_id: userId, provider_id: providerId, subject, email_at_link: emailAtLink || null,
         created_at: new Date().toISOString(), last_seen_at: new Date().toISOString()
@@ -121,9 +146,9 @@ before(() => {
       return { rowCount: 1, rows: [row] };
     }
     if (n.startsWith("insert into users")) {
-      const [email] = params;
-      const row = {
-        id: nextUserId(), email, password_hash: null, display_name: params[2] || null,
+      const [email, , displayName] = params as [string, null, string | null];
+      const row: AuthUserRow = {
+        id: nextUserId(), email, password_hash: null, display_name: displayName,
         is_active: true, last_login_at: null,
         created_at: new Date().toISOString(), updated_at: new Date().toISOString()
       };
@@ -131,20 +156,29 @@ before(() => {
       return { rowCount: 1, rows: [row] };
     }
     if (n.startsWith("select id, name from roles where lower(name) = any($1::text[])")) {
-      const [names] = params;
-      return { rowCount: (names || []).length, rows: (names || []).map((name, idx) => ({ id: uuid("ccc1", idx + 1), name })) };
+      const [names] = params as [string[]];
+      return { rowCount: names.length, rows: names.map((name, idx) => ({ id: uuid("ccc1", idx + 1), name })) };
     }
     if (n.startsWith("insert into user_roles")) {
       return { rowCount: 1, rows: [{ role_id: params[1], user_id: params[0] }] };
     }
     if (n.startsWith("insert into auth_audit_log")) {
       auditCounter += 1;
-      const [actorUserId, actorEmail, targetUserId, action, outcome, detailsJson, ipAddress, userAgent] = params;
+      const [actorUserId, actorEmail, targetUserId, action, outcome, detailsJson, ipAddress, userAgent] = params as [
+        string | null,
+        string | null,
+        string | null,
+        string,
+        string | null,
+        string,
+        string | null,
+        string | null
+      ];
       auditRows.push({
         id: uuid("dddd", auditCounter),
         actor_user_id: actorUserId, actor_email: actorEmail,
         target_user_id: targetUserId, action, outcome,
-        details: JSON.parse(detailsJson),
+        details: JSON.parse(detailsJson) as Record<string, unknown>,
         ip_address: ipAddress, user_agent: userAgent,
         created_at: new Date().toISOString()
       });
@@ -152,7 +186,7 @@ before(() => {
     }
     // oidcStateService.recordUsedState
     if (n.startsWith("insert into oidc_used_states")) {
-      const [hash, providerId, expiresAt] = params;
+      const [hash, providerId, expiresAt] = params as [string, string, Date | string];
       if (usedStates.has(hash)) {
         const err = Object.assign(new Error("dup state"), { code: "23505" }); throw err;
       }
@@ -194,7 +228,7 @@ test("auto-link by email is refused when email_verified is explicitly false", as
   });
 
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     {
       email: "alice@example.com",
       sub: "sub-1",
@@ -219,7 +253,7 @@ test("auto-link by email proceeds when email_verified is true", async () => {
   });
 
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     {
       email: "alice@example.com",
       sub: "sub-2",
@@ -234,7 +268,7 @@ test("auto-link by email proceeds when email_verified is true", async () => {
 test("JIT is refused when email_verified is explicitly false", async () => {
   const provider = seedProvider({ jit_enabled: true });
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     {
       email: "new@example.com",
       sub: "sub-3",
@@ -256,7 +290,7 @@ test("turning require_email_verified off lets unverified emails through (ops opt
     created_at: new Date().toISOString(), updated_at: new Date().toISOString()
   });
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     { email: "alice@example.com", sub: "sub-x", claims: { email_verified: false } },
     {}
   );

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -12,8 +12,6 @@
     "app/test/accountLinkingApi.test.ts",
     "app/test/adminUsersApi.test.ts",
     "app/test/authApi.test.ts",
-    "app/test/authProvidersAdminApi.test.ts",
-    "app/test/federationHardeningApi.test.ts",
     "app/test/oidcLoginApi.test.ts",
     "app/test/savedQueriesApi.test.ts",
     "app/test/savedQueryFoldersApi.test.ts",

--- a/tsconfig.test.legacy.json
+++ b/tsconfig.test.legacy.json
@@ -13,8 +13,6 @@
     "app/test/accountLinkingApi.test.ts",
     "app/test/adminUsersApi.test.ts",
     "app/test/authApi.test.ts",
-    "app/test/authProvidersAdminApi.test.ts",
-    "app/test/federationHardeningApi.test.ts",
     "app/test/oidcLoginApi.test.ts",
     "app/test/savedQueriesApi.test.ts",
     "app/test/savedQueryFoldersApi.test.ts",


### PR DESCRIPTION
## Summary
- type auth-provider fixtures, mock IdP state, database parameters, and API responses
- type federation users, linked identities, audit rows, used OIDC states, and transaction stubs
- remove obsolete casts around external-login provider fixtures
- move both suites out of the transitional TypeScript config, reducing the legacy allowlist from 10 suites to 8

Part of #148.

## Verification
- `npx tsc --noEmit -p tsconfig.test.json --pretty false`
- `node --import tsx --test app/test/authProvidersAdminApi.test.ts app/test/federationHardeningApi.test.ts` (11 passing)
- `npm run typecheck`
- `npm test` (243 passing)
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)