### PR TITLE
Migrate auth and OIDC tests to strict mode

### DIFF
--- a/app/test/authApi.test.ts
+++ b/app/test/authApi.test.ts
@@ -8,14 +8,53 @@ process.env.AUTH_COOKIE_SECURE = "false";
 
 import appDb = require("../src/lib/appDb");
 import authService = require("../src/services/authService");
+import type { AuthUserRow } from "../src/services/authService";
+
+type RoleName = keyof typeof ROLE_PERMISSIONS;
+
+interface TestSession {
+  id: string;
+  user_id: string;
+  token_hash: string;
+  user_agent: string | null;
+  ip_address: string | null;
+  created_at: string;
+  expires_at: string;
+  last_seen_at: string;
+  revoked_at: string | null;
+}
+
+interface SeedUserInput {
+  email: string;
+  password: string;
+  displayName?: string | null;
+  isActive?: boolean;
+  roles?: RoleName[];
+}
+
+interface AuthPayload {
+  user: {
+    email: string;
+    display_name: string | null;
+    roles: string[];
+    permissions: string[];
+  };
+  expires_at?: string | null;
+}
+
+interface ApiResult<T> {
+  status: number;
+  payload: T;
+  setCookie: string | null;
+}
 
 let server: import("http").Server;
 let baseUrl: string;
-let users;
-let sessions;
-let userIdCounter;
-let sessionIdCounter;
-let userRoleAssignments;
+let users: Map<string, AuthUserRow>;
+let sessions: Map<string, TestSession>;
+let userIdCounter: number;
+let sessionIdCounter: number;
+let userRoleAssignments: Map<string, RoleName[]>;
 let originalQuery: typeof appDb.query;
 
 function uuid(prefix: string, counter: number) {
@@ -32,7 +71,7 @@ function nextSessionId() {
   return uuid("bbbb", sessionIdCounter);
 }
 
-function normalizeSql(sql) {
+function normalizeSql(sql: string) {
   return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
@@ -40,10 +79,10 @@ const ROLE_PERMISSIONS = {
   admin: ["users.read", "users.write", "data_sources.read", "data_sources.write"],
   analyst: ["data_sources.read", "saved_queries.read", "saved_queries.write", "query.run"],
   viewer: ["data_sources.read", "saved_queries.read"]
-};
+} as const;
 
-function seedUser({ email, password, displayName = null, isActive = true, roles = [] }) {
-  const row = {
+function seedUser({ email, password, displayName = null, isActive = true, roles = [] }: SeedUserInput): AuthUserRow {
+  const row: AuthUserRow = {
     id: nextUserId(),
     email,
     password_hash: authService.hashPassword(password),
@@ -58,7 +97,12 @@ function seedUser({ email, password, displayName = null, isActive = true, roles 
   return row;
 }
 
-async function api(method: string, path: string, body?: unknown, { cookie }: { cookie?: string } = {}) {
+async function api<T = unknown>(
+  method: string,
+  path: string,
+  body?: unknown,
+  { cookie }: { cookie?: string } = {}
+): Promise<ApiResult<T>> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (cookie) {
     headers.Cookie = cookie;
@@ -69,7 +113,7 @@ async function api(method: string, path: string, body?: unknown, { cookie }: { c
     body: body ? JSON.stringify(body) : undefined
   });
 
-  let payload = null;
+  let payload: unknown = null;
   try {
     payload = await response.json();
   } catch {
@@ -78,12 +122,12 @@ async function api(method: string, path: string, body?: unknown, { cookie }: { c
 
   return {
     status: response.status,
-    payload,
+    payload: payload as T,
     setCookie: response.headers.get("set-cookie")
   };
 }
 
-function parseSessionCookieValue(setCookieHeader) {
+function parseSessionCookieValue(setCookieHeader: string | null): string | null {
   if (!setCookieHeader) {
     return null;
   }
@@ -102,24 +146,24 @@ before(async () => {
   userIdCounter = 0;
   sessionIdCounter = 0;
 
-  appDb.query = (async (sql, params = []) => {
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
     const normalized = normalizeSql(sql);
 
     if (normalized.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
-      const [emailLower] = params;
+      const [emailLower] = params as [string];
       const row = [...users.values()].find((entry) => entry.email.toLowerCase() === emailLower);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
 
     if (normalized.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where id = $1")) {
-      const [id] = params;
+      const [id] = params as [string];
       const row = users.get(id);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
 
     if (normalized.startsWith("insert into users")) {
-      const [email, passwordHash, displayName] = params;
-      const row = {
+      const [email, passwordHash, displayName] = params as [string, string, string | null];
+      const row: AuthUserRow = {
         id: nextUserId(),
         email,
         password_hash: passwordHash,
@@ -134,8 +178,14 @@ before(async () => {
     }
 
     if (normalized.startsWith("insert into user_sessions")) {
-      const [userId, tokenHash, userAgent, ipAddress, expiresAt] = params;
-      const row = {
+      const [userId, tokenHash, userAgent, ipAddress, expiresAt] = params as [
+        string,
+        string,
+        string | null,
+        string | null,
+        string
+      ];
+      const row: TestSession = {
         id: nextSessionId(),
         user_id: userId,
         token_hash: tokenHash,
@@ -155,7 +205,7 @@ before(async () => {
         "select s.id as session_id, s.expires_at, s.revoked_at, u.id, u.email, u.password_hash, u.display_name, u.is_active, u.last_login_at, u.created_at, u.updated_at from user_sessions s join users u on u.id = s.user_id where s.token_hash = $1"
       )
     ) {
-      const [tokenHash] = params;
+      const [tokenHash] = params as [string];
       const session = [...sessions.values()].find((entry) => entry.token_hash === tokenHash);
       if (!session) {
         return { rowCount: 0, rows: [] };
@@ -183,7 +233,7 @@ before(async () => {
     }
 
     if (normalized.startsWith("update user_sessions set last_seen_at = now() where id = $1")) {
-      const [id] = params;
+      const [id] = params as [string];
       const session = sessions.get(id);
       if (session) {
         session.last_seen_at = new Date().toISOString();
@@ -192,7 +242,7 @@ before(async () => {
     }
 
     if (normalized.startsWith("update user_sessions set revoked_at = now() where token_hash = $1 and revoked_at is null")) {
-      const [tokenHash] = params;
+      const [tokenHash] = params as [string];
       let count = 0;
       for (const session of sessions.values()) {
         if (session.token_hash === tokenHash && !session.revoked_at) {
@@ -204,7 +254,7 @@ before(async () => {
     }
 
     if (normalized.startsWith("update users set last_login_at = now() where id = $1")) {
-      const [id] = params;
+      const [id] = params as [string];
       const user = users.get(id);
       if (user) {
         user.last_login_at = new Date().toISOString();
@@ -215,7 +265,7 @@ before(async () => {
     if (normalized.startsWith(
       "select r.id, r.name, r.description, r.is_system, ur.assigned_at from user_roles ur join roles r on r.id = ur.role_id where ur.user_id = $1 order by r.name"
     )) {
-      const [userId] = params;
+      const [userId] = params as [string];
       const assigned = userRoleAssignments.get(userId) || [];
       const rows = [...assigned].sort().map((name, idx) => ({
         id: `00000000-0000-4000-8000-cccc${String(idx + 1).padStart(8, "0")}`,
@@ -230,9 +280,9 @@ before(async () => {
     if (normalized.startsWith(
       "select distinct p.name from user_roles ur join role_permissions rp on rp.role_id = ur.role_id join permissions p on p.id = rp.permission_id where ur.user_id = $1 order by p.name"
     )) {
-      const [userId] = params;
+      const [userId] = params as [string];
       const assigned = userRoleAssignments.get(userId) || [];
-      const out = new Set();
+      const out = new Set<string>();
       for (const role of assigned) {
         for (const perm of ROLE_PERMISSIONS[role] || []) {
           out.add(perm);
@@ -274,7 +324,7 @@ test("login → me → logout happy path", async () => {
     roles: ["analyst"]
   });
 
-  const login = await api("POST", "/v1/auth/login", {
+  const login = await api<AuthPayload>("POST", "/v1/auth/login", {
     email: "Alice@Example.com",
     password: "hunter22ok"
   });
@@ -292,10 +342,11 @@ test("login → me → logout happy path", async () => {
   assert.match(login.setCookie, /SameSite=Lax/);
 
   const token = parseSessionCookieValue(login.setCookie);
+  assert.ok(token, "expected session token");
   assert.match(token, /^[0-9a-f]{64}$/);
 
   const cookie = `rp_session=${encodeURIComponent(token)}`;
-  const me = await api("GET", "/v1/auth/me", undefined, { cookie });
+  const me = await api<AuthPayload>("GET", "/v1/auth/me", undefined, { cookie });
   assert.equal(me.status, 200);
   assert.equal(me.payload.user.email, "alice@example.com");
   assert.deepEqual(me.payload.user.roles, ["analyst"]);
@@ -304,9 +355,10 @@ test("login → me → logout happy path", async () => {
     ["data_sources.read", "query.run", "saved_queries.read", "saved_queries.write"]
   );
 
-  const logout = await api("POST", "/v1/auth/logout", undefined, { cookie });
+  const logout = await api<{ ok: boolean }>("POST", "/v1/auth/logout", undefined, { cookie });
   assert.equal(logout.status, 200);
   assert.deepEqual(logout.payload, { ok: true });
+  assert.ok(logout.setCookie);
   assert.match(logout.setCookie, /Max-Age=0/);
 
   const meAfterLogout = await api("GET", "/v1/auth/me", undefined, { cookie });
@@ -361,5 +413,6 @@ test("me returns 401 without a cookie and with a bogus cookie", async () => {
 test("logout without a session is a no-op that still clears the cookie", async () => {
   const logout = await api("POST", "/v1/auth/logout");
   assert.equal(logout.status, 200);
+  assert.ok(logout.setCookie);
   assert.match(logout.setCookie, /Max-Age=0/);
 });

--- a/app/test/oidcLoginApi.test.ts
+++ b/app/test/oidcLoginApi.test.ts
@@ -14,15 +14,59 @@ process.env.AUTH_FLOW_SECRET = "x".repeat(48);
 import appDb = require("../src/lib/appDb");
 import { createAuthTestStub } from "./helpers/authTestStub";
 import { createMockOidcIdp } from "./helpers/mockOidcIdp";
+import type { MockOidcIdp } from "./helpers/mockOidcIdp";
+import type { ProviderRow } from "../src/services/authProviderService";
+import type { ApiSchema } from "../src/types";
+
+type OidcProviderListResponse = ApiSchema<"OidcProviderLoginListResponse">;
+
+interface SeedProviderInput {
+  id?: string;
+  type?: string;
+  name: string;
+  display_name?: string | null;
+  issuer: string;
+  client_id: string;
+  client_secret?: string | null;
+  scopes?: string[];
+  redirect_uri: string;
+  claims_mapping?: Record<string, unknown>;
+  enabled?: boolean;
+  auto_link_by_email?: boolean;
+  jit_enabled?: boolean;
+  jit_default_role?: string;
+  jit_allowed_domains?: string[];
+}
+
+interface AuthMePayload {
+  user: {
+    email: string;
+    roles: string[];
+  };
+}
+
+interface ErrorPayload {
+  error?: string;
+  message: string;
+}
+
+interface CallResult<T> {
+  status: number;
+  payload: T;
+  headers: Headers;
+  location: string | null;
+  setCookie: string[];
+}
 
 let server: import("http").Server;
 let baseUrl: string;
 let authStub: import("./helpers/authTestStub").AuthTestStub;
-let idp;
+let idp: MockOidcIdp;
+let issuer: string;
 let originalQuery: typeof appDb.query;
-let providers; // in-memory provider rows
-let providerCounter;
-let aliceUserId;
+let providers: Map<string, ProviderRow>; // in-memory provider rows
+let providerCounter: number;
+let aliceUserId: string;
 
 function normalize(sql: string) {
   return String(sql).replace(/\s+/g, " ").trim().toLowerCase();
@@ -37,8 +81,8 @@ function nextProviderId(): string {
   return uuid("eeee", providerCounter);
 }
 
-function seedProvider(row) {
-  const created = {
+function seedProvider(row: SeedProviderInput): ProviderRow {
+  const created: ProviderRow = {
     id: row.id || nextProviderId(),
     type: row.type || "oidc",
     name: row.name,
@@ -65,7 +109,11 @@ function seedProvider(row) {
 
 type FetchRedirect = "manual" | "follow" | "error";
 
-async function call(method: string, path: string, { cookie, body, redirect = "manual" }: { cookie?: string; body?: unknown; redirect?: FetchRedirect } = {}) {
+async function call<T = unknown>(
+  method: string,
+  path: string,
+  { cookie, body, redirect = "manual" }: { cookie?: string; body?: unknown; redirect?: FetchRedirect } = {}
+): Promise<CallResult<T>> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (cookie) headers.Cookie = cookie;
   const response = await fetch(`${baseUrl}${path}`, {
@@ -74,20 +122,22 @@ async function call(method: string, path: string, { cookie, body, redirect = "ma
     redirect,
     body: body ? JSON.stringify(body) : undefined
   });
-  let payload = null;
+  let payload: unknown = null;
   if ((response.headers.get("content-type") || "").includes("application/json")) {
     try { payload = await response.json(); } catch { payload = null; }
   }
   return {
     status: response.status,
-    payload,
+    payload: payload as T,
     headers: response.headers,
     location: response.headers.get("location"),
-    setCookie: response.headers.getSetCookie ? response.headers.getSetCookie() : (response.headers.get("set-cookie") ? [response.headers.get("set-cookie")] : [])
+    setCookie: response.headers.getSetCookie
+      ? response.headers.getSetCookie()
+      : [response.headers.get("set-cookie")].filter((value): value is string => value !== null)
   };
 }
 
-function pickCookie(setCookies, name) {
+function pickCookie(setCookies: string[], name: string): string | null {
   for (const sc of setCookies) {
     const match = sc.match(new RegExp(`(^|;\\s*)${name}=([^;]*)`));
     if (match) return `${name}=${match[2]}`;
@@ -102,7 +152,7 @@ before(async () => {
     clientId: "test-client",
     clientSecret: "test-secret"
   });
-  await idp.start();
+  issuer = await idp.start();
 
   originalQuery = appDb.query;
   providers = new Map();
@@ -122,7 +172,7 @@ before(async () => {
 
     // authService.findUserByEmail (lookup after callback)
     if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
-      const [emailLower] = params;
+      const [emailLower] = params as [string];
       if (emailLower === "alice@example.com") {
         return {
           rowCount: 1,
@@ -143,7 +193,7 @@ before(async () => {
 
     // authProviderService queries
     if (n.startsWith("select") && /from auth_providers\s+where id = \$1/.test(n)) {
-      const [id] = params;
+      const [id] = params as [string];
       const row = providers.get(id);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
@@ -164,21 +214,44 @@ before(async () => {
     }
 
     if (n.startsWith("insert into auth_providers")) {
-      const [type, name, displayName, issuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params;
+      const [type, name, displayName, providerIssuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params as [
+        string,
+        string,
+        string | null,
+        string,
+        string,
+        string | null,
+        string[],
+        string,
+        string,
+        boolean
+      ];
       const existing = [...providers.values()].find((p) => p.name.toLowerCase() === String(name).toLowerCase());
       if (existing) {
         const err = Object.assign(new Error("duplicate name"), { code: "23505" }); throw err;
       }
       const row = seedProvider({
-        type, name, display_name: displayName, issuer, client_id: clientId,
+        type, name, display_name: displayName, issuer: providerIssuer, client_id: clientId,
         client_secret: clientSecret, scopes, redirect_uri: redirectUri,
-        claims_mapping: JSON.parse(claimsMappingJson as string), enabled
+        claims_mapping: JSON.parse(claimsMappingJson) as Record<string, unknown>, enabled
       });
       return { rowCount: 1, rows: [row] };
     }
 
     if (n.startsWith("update auth_providers")) {
-      const [id, type, name, displayName, issuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params;
+      const [id, type, name, displayName, providerIssuer, clientId, clientSecret, scopes, redirectUri, claimsMappingJson, enabled] = params as [
+        string,
+        string,
+        string,
+        string | null,
+        string,
+        string,
+        string | null,
+        string[],
+        string,
+        string,
+        boolean
+      ];
       const existing = providers.get(id);
       if (!existing) return { rowCount: 0, rows: [] };
       const next = {
@@ -186,12 +259,12 @@ before(async () => {
         type,
         name,
         display_name: displayName,
-        issuer,
+        issuer: providerIssuer,
         client_id: clientId,
         client_secret: clientSecret === null ? existing.client_secret : clientSecret,
         scopes,
         redirect_uri: redirectUri,
-        claims_mapping: JSON.parse(claimsMappingJson as string),
+        claims_mapping: JSON.parse(claimsMappingJson) as Record<string, unknown>,
         enabled,
         updated_at: new Date().toISOString()
       };
@@ -200,7 +273,7 @@ before(async () => {
     }
 
     if (n.startsWith("delete from auth_providers where id = $1 returning id")) {
-      const [id] = params;
+      const [id] = params as [string];
       if (!providers.has(id)) return { rowCount: 0, rows: [] };
       providers.delete(id);
       return { rowCount: 1, rows: [{ id }] };
@@ -257,7 +330,7 @@ test("GET /v1/auth/oidc/providers exposes only enabled providers, no secrets", a
   const provider = seedProvider({
     name: "okta",
     display_name: "Okta SSO",
-    issuer: idp.issuer,
+    issuer,
     client_id: idp.clientId,
     client_secret: idp.clientSecret,
     redirect_uri: `${baseUrl}/v1/auth/oidc/callback`,
@@ -266,17 +339,18 @@ test("GET /v1/auth/oidc/providers exposes only enabled providers, no secrets", a
   seedProvider({
     name: "disabled",
     display_name: "Disabled",
-    issuer: idp.issuer,
+    issuer,
     client_id: "x",
     client_secret: "y",
     redirect_uri: `${baseUrl}/v1/auth/oidc/callback`,
     enabled: false
   });
 
-  const result = await call("GET", "/v1/auth/oidc/providers");
+  const result = await call<OidcProviderListResponse>("GET", "/v1/auth/oidc/providers");
   assert.equal(result.status, 200);
-  assert.equal(result.payload.items.length, 1);
-  const item = result.payload.items[0];
+  assert.equal(result.payload.items?.length, 1);
+  const item = result.payload.items?.[0];
+  assert.ok(item, "expected enabled provider");
   assert.equal(item.id, provider.id);
   assert.equal(item.display_name, "Okta SSO");
   assert.equal("client_secret" in item, false);
@@ -286,7 +360,7 @@ test("OIDC login flow: start → IdP authorize → callback → session cookie",
   const provider = seedProvider({
     name: "okta",
     display_name: "Okta",
-    issuer: idp.issuer,
+    issuer,
     client_id: idp.clientId,
     client_secret: idp.clientSecret,
     redirect_uri: `${baseUrl}/v1/auth/oidc/callback`,
@@ -296,14 +370,18 @@ test("OIDC login flow: start → IdP authorize → callback → session cookie",
   // 1. Start the flow.
   const start = await call("GET", `/v1/auth/oidc/login?provider_id=${provider.id}`);
   assert.equal(start.status, 302);
-  assert.ok(start.location && start.location.startsWith(`${idp.issuer}/authorize`));
+  assert.ok(start.location?.startsWith(`${issuer}/authorize`));
+  const startLocation = start.location;
+  assert.ok(startLocation, "expected IdP redirect");
   const flowCookie = pickCookie(start.setCookie, "rp_oidc_flow");
   assert.ok(flowCookie, "expected rp_oidc_flow cookie to be set");
 
   // 2. Hit the IdP's authorize endpoint directly (no cookie needed — it's another server).
-  const idpRedirect = await fetch(start.location, { redirect: "manual" });
+  const idpRedirect = await fetch(startLocation, { redirect: "manual" });
   assert.equal(idpRedirect.status, 302);
-  const callbackUrl = new URL(idpRedirect.headers.get("location"));
+  const callbackLocation = idpRedirect.headers.get("location");
+  assert.ok(callbackLocation, "expected callback redirect");
+  const callbackUrl = new URL(callbackLocation);
   assert.equal(callbackUrl.pathname, "/v1/auth/oidc/callback");
   assert.ok(callbackUrl.searchParams.get("code"));
   assert.ok(callbackUrl.searchParams.get("state"));
@@ -322,7 +400,7 @@ test("OIDC login flow: start → IdP authorize → callback → session cookie",
   assert.ok(clearFlow, "expected rp_oidc_flow cookie to be cleared");
 
   // 4. /v1/auth/me works with the new session.
-  const me = await call("GET", "/v1/auth/me", { cookie: sessionCookie });
+  const me = await call<AuthMePayload>("GET", "/v1/auth/me", { cookie: sessionCookie });
   assert.equal(me.status, 200);
   assert.equal(me.payload.user.email, "alice@example.com");
   assert.deepEqual(me.payload.user.roles, ["analyst"]);
@@ -332,7 +410,7 @@ test("OIDC callback returns 403 when the IdP email has no local user", async () 
   const provider = seedProvider({
     name: "okta",
     display_name: "Okta",
-    issuer: idp.issuer,
+    issuer,
     client_id: idp.clientId,
     client_secret: idp.clientSecret,
     redirect_uri: `${baseUrl}/v1/auth/oidc/callback`,
@@ -343,9 +421,13 @@ test("OIDC callback returns 403 when the IdP email has no local user", async () 
   try {
     const start = await call("GET", `/v1/auth/oidc/login?provider_id=${provider.id}`);
     const flowCookie = pickCookie(start.setCookie, "rp_oidc_flow");
+    assert.ok(flowCookie, "expected flow cookie");
+    assert.ok(start.location, "expected IdP redirect");
     const idpRedirect = await fetch(start.location, { redirect: "manual" });
-    const callbackUrl = new URL(idpRedirect.headers.get("location"));
-    const callback = await call(
+    const callbackLocation = idpRedirect.headers.get("location");
+    assert.ok(callbackLocation, "expected callback redirect");
+    const callbackUrl = new URL(callbackLocation);
+    const callback = await call<ErrorPayload>(
       "GET",
       `${callbackUrl.pathname}${callbackUrl.search}`,
       { cookie: flowCookie }
@@ -360,7 +442,7 @@ test("OIDC callback returns 403 when the IdP email has no local user", async () 
 
 test("OIDC callback rejects requests without the flow cookie", async () => {
   // Fabricate a plausible-looking callback URL with no cookie.
-  const callback = await call("GET", "/v1/auth/oidc/callback?code=abc&state=xyz");
+  const callback = await call<ErrorPayload>("GET", "/v1/auth/oidc/callback?code=abc&state=xyz");
   assert.equal(callback.status, 400);
   assert.match(callback.payload.message, /flow state/);
 });
@@ -371,7 +453,7 @@ test("/v1/auth/oidc/login returns 404 for disabled or unknown providers", async 
 
   const provider = seedProvider({
     name: "okta",
-    issuer: idp.issuer,
+    issuer,
     client_id: idp.clientId,
     client_secret: idp.clientSecret,
     redirect_uri: `${baseUrl}/v1/auth/oidc/callback`,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -11,8 +11,6 @@
     "frontend",
     "app/test/accountLinkingApi.test.ts",
     "app/test/adminUsersApi.test.ts",
-    "app/test/authApi.test.ts",
-    "app/test/oidcLoginApi.test.ts",
     "app/test/savedQueriesApi.test.ts",
     "app/test/savedQueryFoldersApi.test.ts",
     "app/test/savedQuerySchedulesApi.test.ts",

--- a/tsconfig.test.legacy.json
+++ b/tsconfig.test.legacy.json
@@ -12,8 +12,6 @@
   "include": [
     "app/test/accountLinkingApi.test.ts",
     "app/test/adminUsersApi.test.ts",
-    "app/test/authApi.test.ts",
-    "app/test/oidcLoginApi.test.ts",
     "app/test/savedQueriesApi.test.ts",
     "app/test/savedQueryFoldersApi.test.ts",
     "app/test/savedQuerySchedulesApi.test.ts",


### PR DESCRIPTION
## Summary
- type core auth users, sessions, role assignments, cookies, and response payloads
- type OIDC provider fixtures, mock IdP state, redirect locations, cookies, and API responses
- narrow nullable session and callback values before use
- move both suites out of the transitional TypeScript config, reducing the legacy allowlist from 8 suites to 6

Part of #148.

## Verification
- `npx tsc --noEmit -p tsconfig.test.json --pretty false`
- `node --import tsx --test app/test/authApi.test.ts app/test/oidcLoginApi.test.ts` (11 passing)
- `npm run typecheck`
- `npm test` (243 passing)
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)