### PR TITLE
Migrate account linking and SCIM tests to strict mode

### DIFF
--- a/app/test/accountLinkingApi.test.ts
+++ b/app/test/accountLinkingApi.test.ts
@@ -17,6 +17,30 @@ process.env.AUTH_COOKIE_SECURE = "false";
 import appDb = require("../src/lib/appDb");
 import externalLoginService = require("../src/services/externalLoginService");
 import { createAuthTestStub } from "./helpers/authTestStub";
+import type { PoolClient } from "pg";
+import type { ProviderRow } from "../src/services/authProviderService";
+import type { AuthUserRow } from "../src/services/authService";
+import type { LinkedIdentity } from "../src/services/linkedIdentityService";
+import type { ApiSchema } from "../src/types";
+
+type MappingRulesResponse = ApiSchema<"AuthProviderMappingRulesResponse">;
+type LinkedIdentityListResponse = ApiSchema<"LinkedIdentityListResponse">;
+
+interface AuditRow {
+  id: string;
+  actor_user_id: string | null;
+  actor_email: string | null;
+  target_user_id: string | null;
+  action: string;
+  outcome: string | null;
+  details: Record<string, unknown>;
+  created_at: string;
+}
+
+interface CallResult<T> {
+  status: number;
+  payload: T;
+}
 
 let server: import("http").Server;
 let baseUrl: string;
@@ -25,16 +49,15 @@ let originalQuery: typeof appDb.query;
 let originalWithTransaction: typeof appDb.withTransaction;
 
 // In-memory state.
-let providers;            // Map<id, providerRow>
-let users;                // Map<id, userRow> (additional users not seeded via authStub)
-let linkedIdentities;     // Map<id, linkRow>
-let auditRows;
-let adminCookie;
-let adminUserId;
-let providerCounter;
-let identityCounter;
-let userCounter;
-let auditCounter;
+let providers: Map<string, ProviderRow>;
+let users: Map<string, AuthUserRow>;
+let linkedIdentities: Map<string, LinkedIdentity>;
+let auditRows: AuditRow[];
+let adminCookie: string;
+let providerCounter: number;
+let identityCounter: number;
+let userCounter: number;
+let auditCounter: number;
 
 function uuid(prefix: string, counter: number) {
   return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
@@ -49,23 +72,23 @@ function nextIdentityId(): string { identityCounter += 1; return uuid("ffff", id
 function nextUserId(): string { userCounter += 1; return uuid("aaab", userCounter); }
 function nextAuditId() { auditCounter += 1; return uuid("dddd", auditCounter); }
 
-function seedProvider(overrides: Record<string, unknown> = {}) {
-  const row = {
-    id: overrides.id || nextProviderId(),
+function seedProvider(overrides: Partial<ProviderRow> = {}): ProviderRow {
+  const row: ProviderRow = {
+    id: overrides.id ?? nextProviderId(),
     type: "oidc",
-    name: overrides.name || "okta",
-    display_name: overrides.display_name || "Okta",
-    issuer: overrides.issuer || "https://okta.example.com",
-    client_id: overrides.client_id || "test-client",
-    client_secret: overrides.client_secret || null,
+    name: overrides.name ?? "okta",
+    display_name: overrides.display_name ?? "Okta",
+    issuer: overrides.issuer ?? "https://okta.example.com",
+    client_id: overrides.client_id ?? "test-client",
+    client_secret: overrides.client_secret ?? null,
     scopes: ["openid", "email", "profile"],
     redirect_uri: "http://localhost/cb",
     claims_mapping: {},
     enabled: true,
-    auto_link_by_email: overrides.auto_link_by_email !== undefined ? overrides.auto_link_by_email : true,
-    jit_enabled: overrides.jit_enabled === true,
-    jit_default_role: overrides.jit_default_role || "viewer",
-    jit_allowed_domains: overrides.jit_allowed_domains || [],
+    auto_link_by_email: overrides.auto_link_by_email ?? true,
+    jit_enabled: overrides.jit_enabled ?? false,
+    jit_default_role: overrides.jit_default_role ?? "viewer",
+    jit_allowed_domains: overrides.jit_allowed_domains ?? [],
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString()
   };
@@ -73,7 +96,11 @@ function seedProvider(overrides: Record<string, unknown> = {}) {
   return row;
 }
 
-async function call(method: string, path: string, { cookie, body }: { cookie?: string; body?: unknown } = {}) {
+async function call<T = unknown>(
+  method: string,
+  path: string,
+  { cookie, body }: { cookie?: string; body?: unknown } = {}
+): Promise<CallResult<T>> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (cookie) headers.Cookie = cookie;
   const response = await fetch(`${baseUrl}${path}`, {
@@ -81,11 +108,11 @@ async function call(method: string, path: string, { cookie, body }: { cookie?: s
     headers,
     body: body ? JSON.stringify(body) : undefined
   });
-  let payload = null;
+  let payload: unknown = null;
   if ((response.headers.get("content-type") || "").includes("application/json")) {
     try { payload = await response.json(); } catch { payload = null; }
   }
-  return { status: response.status, payload };
+  return { status: response.status, payload: payload as T };
 }
 
 before(async () => {
@@ -103,17 +130,18 @@ before(async () => {
   auditCounter = 0;
 
   const admin = authStub.seedUser({ email: "admin@example.com", roles: ["admin"], password: "Hunter22ok!" });
-  adminUserId = admin.id;
   adminCookie = authStub.cookieFor(authStub.seedSession(admin.id).token);
 
   // The resolver opens a transaction for the JIT path; we run the handler
   // against the same in-memory store so consumers see the writes.
-  appDb.withTransaction = (async (handler) => {
-    const txClient = { query: async (sql, params) => appDb.query(sql, params) };
-    return handler(txClient);
-  }) as unknown as typeof appDb.withTransaction;
+  const txClient = {
+    query: (sql: string, params: unknown[] = []) => appDb.query(sql, params)
+  } as unknown as PoolClient;
+  appDb.withTransaction = (async <T>(handler: (client: PoolClient) => Promise<T>): Promise<T> => (
+    handler(txClient)
+  )) as typeof appDb.withTransaction;
 
-  appDb.query = (async (sql, params = []) => {
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
     const auth = authStub.handleSql(sql, params);
     if (auth) return auth;
 
@@ -121,26 +149,26 @@ before(async () => {
 
     // findUserByEmail
     if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
-      const [emailLower] = params;
+      const [emailLower] = params as [string];
       const row = [...users.values()].find((u) => u.email.toLowerCase() === emailLower);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
     // findUserById (used by resolver to load linked user)
     if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where id = $1")) {
-      const [id] = params;
+      const [id] = params as [string];
       const row = users.get(id);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
     // user existence check from admin route
     if (n === "select id from users where id = $1") {
-      const [id] = params;
+      const [id] = params as [string];
       const row = users.get(id);
       return row ? { rowCount: 1, rows: [{ id: row.id }] } : { rowCount: 0, rows: [] };
     }
 
     // linkedIdentityService.findByProviderAndSubject
     if (n.startsWith("select id, user_id, provider_id, subject, email_at_link, created_at, last_seen_at from linked_identities where provider_id = $1 and subject = $2")) {
-      const [providerId, subject] = params;
+      const [providerId, subject] = params as [string, string];
       const row = [...linkedIdentities.values()].find(
         (li) => li.provider_id === providerId && li.subject === subject
       );
@@ -149,7 +177,7 @@ before(async () => {
 
     // linkedIdentityService.touchLastSeen
     if (n.startsWith("update linked_identities set last_seen_at = now() where id = $1")) {
-      const [id] = params;
+      const [id] = params as [string];
       const row = linkedIdentities.get(id);
       if (row) row.last_seen_at = new Date().toISOString();
       return { rowCount: row ? 1 : 0, rows: [] };
@@ -157,7 +185,7 @@ before(async () => {
 
     // linkedIdentityService.listForUser
     if (n.startsWith("select li.id, li.user_id, li.provider_id, li.subject, li.email_at_link, li.created_at, li.last_seen_at, p.name as provider_name")) {
-      const [userId] = params;
+      const [userId] = params as [string];
       const rows = [...linkedIdentities.values()]
         .filter((li) => li.user_id === userId)
         .map((li) => {
@@ -176,7 +204,7 @@ before(async () => {
     // linkedIdentityService.unlink — iterate by predicate so the test's
     // arbitrary map-key choice doesn't matter.
     if (n.startsWith("delete from linked_identities where user_id = $1 and provider_id = $2")) {
-      const [userId, providerId] = params;
+      const [userId, providerId] = params as [string, string];
       for (const [key, row] of linkedIdentities) {
         if (row.user_id === userId && row.provider_id === providerId) {
           linkedIdentities.delete(key);
@@ -188,14 +216,14 @@ before(async () => {
 
     // INSERT into linked_identities (link path or JIT path)
     if (n.startsWith("insert into linked_identities")) {
-      const [userId, providerId, subject, emailAtLink] = params;
+      const [userId, providerId, subject, emailAtLink] = params as [string, string, string, string | null];
       const dup = [...linkedIdentities.values()].some(
         (li) => li.provider_id === providerId && li.subject === subject
       );
       if (dup) {
         const err = Object.assign(new Error("duplicate provider+subject"), { code: "23505" }); throw err;
       }
-      const row = {
+      const row: LinkedIdentity = {
         id: nextIdentityId(),
         user_id: userId,
         provider_id: providerId,
@@ -210,16 +238,16 @@ before(async () => {
 
     // INSERT into users (JIT path)
     if (n.startsWith("insert into users")) {
-      const [email] = params;
+      const [email, , displayName] = params as [string, null, string | null];
       const dup = [...users.values()].some((u) => u.email.toLowerCase() === String(email).toLowerCase());
       if (dup) {
         const err = Object.assign(new Error("duplicate email"), { code: "23505" }); throw err;
       }
-      const row = {
+      const row: AuthUserRow = {
         id: nextUserId(),
         email,
         password_hash: null,
-        display_name: params[2] || null,
+        display_name: displayName,
         is_active: true,
         last_login_at: null,
         created_at: new Date().toISOString(),
@@ -231,15 +259,15 @@ before(async () => {
 
     // roleService.assignRolesByName transactional inserts
     if (n.startsWith("select id, name from roles where lower(name) = any($1::text[])")) {
-      const [names] = params;
-      const rows = (names || []).map((name, idx) => ({
+      const [names] = params as [string[]];
+      const rows = names.map((name, idx) => ({
         id: uuid("ccc1", idx + 1),
         name
       }));
       return { rowCount: rows.length, rows };
     }
     if (n.startsWith("insert into user_roles")) {
-      const [userId, roleId] = params;
+      const [userId, roleId] = params as [string, string];
       return { rowCount: 1, rows: [{ role_id: roleId, user_id: userId }] };
     }
 
@@ -247,10 +275,12 @@ before(async () => {
     if (n.startsWith("update auth_providers")) {
       // The SQL is dynamic; rather than reconstructing it, extract assignments
       // from the SQL after "set" and before "where" and apply them.
-      const [providerId, ...rest] = params;
+      const [providerId, ...rest] = params as [string, ...unknown[]];
       const row = providers.get(providerId);
       if (!row) return { rowCount: 0, rows: [] };
-      const setSql = n.match(/set (.*?) where id = \$1/)[1];
+      const setMatch = n.match(/set (.*?) where id = \$1/);
+      assert.ok(setMatch, "expected provider update assignments");
+      const setSql = setMatch[1];
       const assignments = setSql.split(",").map((s) => s.trim());
       let restIdx = 0;
       for (const assign of assignments) {
@@ -258,7 +288,7 @@ before(async () => {
         if (m) {
           const field = m[1];
           if (field === "updated_at") continue;
-          row[field] = rest[restIdx];
+          (row as unknown as Record<string, unknown>)[field] = rest[restIdx];
           restIdx += 1;
         } else if (/^updated_at = now\(\)$/.test(assign)) {
           row.updated_at = new Date().toISOString();
@@ -270,7 +300,14 @@ before(async () => {
 
     // Audit insert
     if (n.startsWith("insert into auth_audit_log")) {
-      const [actorUserId, actorEmail, targetUserId, action, outcome, detailsJson] = params;
+      const [actorUserId, actorEmail, targetUserId, action, outcome, detailsJson] = params as [
+        string | null,
+        string | null,
+        string | null,
+        string,
+        string | null,
+        string
+      ];
       auditRows.push({
         id: nextAuditId(),
         actor_user_id: actorUserId,
@@ -278,7 +315,7 @@ before(async () => {
         target_user_id: targetUserId,
         action,
         outcome,
-        details: JSON.parse(detailsJson),
+        details: JSON.parse(detailsJson) as Record<string, unknown>,
         created_at: new Date(Date.now() + auditCounter).toISOString()
       });
       return { rowCount: 1, rows: [] };
@@ -324,7 +361,7 @@ test("returning user with an existing link logs in via linked_by_sub (fast path)
   });
 
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     { email: "alice@example.com", sub: "sub-1", display_name: "Alice" },
     { ipAddress: "127.0.0.1", userAgent: "test" }
   );
@@ -342,7 +379,7 @@ test("existing local user without a link is auto-linked by email when allowed", 
   });
 
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     { email: "alice@example.com", sub: "sub-fresh", display_name: "Alice" },
     {}
   );
@@ -364,7 +401,7 @@ test("existing local user with auto-link disabled returns 409 conflict", async (
   });
 
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     { email: "alice@example.com", sub: "sub-1" },
     {}
   );
@@ -377,7 +414,7 @@ test("existing local user with auto-link disabled returns 409 conflict", async (
 test("JIT disabled returns 403 when no local user matches", async () => {
   const provider = seedProvider({ jit_enabled: false });
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     { email: "stranger@example.com", sub: "sub-2" },
     {}
   );
@@ -393,7 +430,7 @@ test("JIT provisions a new user when enabled and the email domain is allowed", a
     jit_allowed_domains: ["example.com"]
   });
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     { email: "newperson@example.com", sub: "sub-jit", display_name: "New Person" },
     { ipAddress: "127.0.0.1" }
   );
@@ -414,7 +451,7 @@ test("JIT refuses when the email domain is not in the allowlist", async () => {
     jit_allowed_domains: ["example.com"]
   });
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     { email: "outsider@other.org", sub: "sub-x" },
     {}
   );
@@ -450,7 +487,7 @@ test("a subject already linked to a different user surfaces as a conflict", asyn
   // a `subject_owned_by_another_user` refusal.
   // To force the email-path code, we tweak alice's email + subject:
   const result = await externalLoginService.resolveExternalLogin(
-    provider as unknown as Parameters<typeof externalLoginService.resolveExternalLogin>[0],
+    provider,
     { email: "alice@example.com", sub: "sub-shared" },
     {}
   );
@@ -464,7 +501,7 @@ test("a subject already linked to a different user surfaces as a conflict", asyn
 
 test("POST /v1/admin/auth-providers/{id}/mapping-rules updates fields and audits", async () => {
   const provider = seedProvider({ jit_enabled: false });
-  const result = await call("POST", `/v1/admin/auth-providers/${provider.id}/mapping-rules`, {
+  const result = await call<MappingRulesResponse>("POST", `/v1/admin/auth-providers/${provider.id}/mapping-rules`, {
     cookie: adminCookie,
     body: {
       jit_enabled: true,
@@ -476,14 +513,14 @@ test("POST /v1/admin/auth-providers/{id}/mapping-rules updates fields and audits
   assert.equal(result.payload.jit_enabled, true);
   assert.equal(result.payload.jit_default_role, "analyst");
   assert.deepEqual(result.payload.jit_allowed_domains, ["example.com", "other.org"]);
-  assert.equal(providers.get(provider.id).jit_enabled, true);
+  assert.equal(providers.get(provider.id)?.jit_enabled, true);
   await new Promise((r) => setImmediate(r));
   assert.ok(auditRows.some((r) => r.action === "auth_provider.mapping_rules.updated"));
 });
 
 test("mapping rules validation rejects malformed input", async () => {
   const provider = seedProvider();
-  const bad = await call("POST", `/v1/admin/auth-providers/${provider.id}/mapping-rules`, {
+  const bad = await call<{ message: string }>("POST", `/v1/admin/auth-providers/${provider.id}/mapping-rules`, {
     cookie: adminCookie,
     body: { jit_allowed_domains: ["not a domain"] }
   });
@@ -510,11 +547,11 @@ test("GET /v1/admin/users/{id}/linked-identities lists links with provider summa
     created_at: new Date().toISOString(), last_seen_at: new Date().toISOString()
   });
 
-  const result = await call("GET", `/v1/admin/users/${userId}/linked-identities`, { cookie: adminCookie });
+  const result = await call<LinkedIdentityListResponse>("GET", `/v1/admin/users/${userId}/linked-identities`, { cookie: adminCookie });
   assert.equal(result.status, 200);
   assert.equal(result.payload.items.length, 1);
-  assert.equal(result.payload.items[0].subject, "sub-1");
-  assert.equal(result.payload.items[0].provider.name, provider.name);
+  assert.equal(result.payload.items[0]?.subject, "sub-1");
+  assert.equal(result.payload.items[0]?.provider?.name, provider.name);
 });
 
 test("DELETE /v1/admin/users/{id}/linked-identities/{providerId} unlinks and audits", async () => {
@@ -530,7 +567,7 @@ test("DELETE /v1/admin/users/{id}/linked-identities/{providerId} unlinks and aud
     created_at: new Date().toISOString(), last_seen_at: new Date().toISOString()
   });
 
-  const removed = await call(
+  const removed = await call<{ ok: boolean }>(
     "DELETE",
     `/v1/admin/users/${userId}/linked-identities/${provider.id}`,
     { cookie: adminCookie }
@@ -548,5 +585,3 @@ test("DELETE /v1/admin/users/{id}/linked-identities/{providerId} unlinks and aud
   );
   assert.equal(missing.status, 404);
 });
-
-void adminUserId;

--- a/app/test/scimApi.test.ts
+++ b/app/test/scimApi.test.ts
@@ -20,22 +20,56 @@ process.env.AUTH_COOKIE_SECURE = "false";
 
 import appDb = require("../src/lib/appDb");
 import scimTokenService = require("../src/services/scimTokenService");
+import type { PoolClient } from "pg";
+import type { ProviderRow } from "../src/services/authProviderService";
+import type { AuthUserRow } from "../src/services/authService";
+import type { LinkedIdentity } from "../src/services/linkedIdentityService";
+import type { ScimTokenPublic } from "../src/services/scimTokenService";
+
+interface ScimTokenRow extends ScimTokenPublic {
+  token_hash: string;
+}
+
+interface AuditRow {
+  id: string;
+  actor_user_id: string | null;
+  actor_email: string | null;
+  target_user_id: string | null;
+  action: string;
+  outcome: string | null;
+  details: Record<string, unknown>;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: string;
+}
+
+interface ScimUserPayload {
+  id: string;
+  userName: string;
+  externalId: string;
+  active: boolean;
+}
+
+interface CallResult<T> {
+  status: number;
+  payload: T;
+}
 
 let server: import("http").Server;
 let baseUrl: string;
 let originalQuery: typeof appDb.query;
 let originalWithTransaction: typeof appDb.withTransaction;
 
-let providers;
-let users;
-let linkedIdentities;
-let scimTokens;
-let auditRows;
-let userRoleLinks; // Set of "userId:roleName"
-let userCounter;
-let identityCounter;
-let auditCounter;
-let tokenCounter;
+let providers: Map<string, ProviderRow>;
+let users: Map<string, AuthUserRow>;
+let linkedIdentities: Map<string, LinkedIdentity>;
+let scimTokens: Map<string, ScimTokenRow>;
+let auditRows: AuditRow[];
+let userRoleLinks: Set<string>; // Set of "userId:roleName"
+let userCounter: number;
+let identityCounter: number;
+let auditCounter: number;
+let tokenCounter: number;
 
 function uuid(prefix: string, counter: number) {
   return `00000000-0000-4000-8000-${prefix}${String(counter).padStart(8, "0")}`;
@@ -50,11 +84,11 @@ function nextIdentityId(): string { identityCounter += 1; return uuid("ffff", id
 function nextAuditId() { auditCounter += 1; return uuid("dddd", auditCounter); }
 function nextTokenId() { tokenCounter += 1; return uuid("9999", tokenCounter); }
 
-function seedProvider(overrides: Record<string, unknown> = {}) {
-  const row = {
-    id: overrides.id || uuid("eeee", 1),
+function seedProvider(overrides: Partial<ProviderRow> = {}): ProviderRow {
+  const row: ProviderRow = {
+    id: overrides.id ?? uuid("eeee", 1),
     type: "oidc",
-    name: overrides.name || "okta",
+    name: overrides.name ?? "okta",
     display_name: "Okta",
     issuer: "https://okta.example.com",
     client_id: "test-client",
@@ -68,7 +102,7 @@ function seedProvider(overrides: Record<string, unknown> = {}) {
     jit_default_role: "viewer",
     jit_allowed_domains: [],
     require_email_verified: true,
-    scim_group_mappings: overrides.scim_group_mappings || {},
+    scim_group_mappings: overrides.scim_group_mappings ?? {},
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString()
   };
@@ -76,9 +110,10 @@ function seedProvider(overrides: Record<string, unknown> = {}) {
   return row;
 }
 
-function seedToken(providerId, { label = "okta", revoked = false } = {}) {
+function seedToken(providerId: string, { label = "okta", revoked = false }: { label?: string; revoked?: boolean } = {}) {
   const raw = scimTokenService.generateRawToken();
   const hash = scimTokenService.hashToken(raw);
+  assert.ok(hash, "expected SCIM token hash");
   const id = nextTokenId();
   scimTokens.set(id, {
     id,
@@ -92,7 +127,11 @@ function seedToken(providerId, { label = "okta", revoked = false } = {}) {
   return { id, token: raw };
 }
 
-async function call(method: string, path: string, { authToken, body }: { authToken?: string; body?: unknown } = {}) {
+async function call<T = unknown>(
+  method: string,
+  path: string,
+  { authToken, body }: { authToken?: string; body?: unknown } = {}
+): Promise<CallResult<T>> {
   const headers: Record<string, string> = { "Content-Type": "application/scim+json" };
   if (authToken) headers.Authorization = `Bearer ${authToken}`;
   const response = await fetch(`${baseUrl}${path}`, {
@@ -100,12 +139,12 @@ async function call(method: string, path: string, { authToken, body }: { authTok
     headers,
     body: body ? JSON.stringify(body) : undefined
   });
-  let payload = null;
+  let payload: unknown = null;
   const text = await response.text();
   if (text) {
     try { payload = JSON.parse(text); } catch { payload = null; }
   }
-  return { status: response.status, payload };
+  return { status: response.status, payload: payload as T };
 }
 
 before(async () => {
@@ -122,17 +161,19 @@ before(async () => {
   auditCounter = 0;
   tokenCounter = 0;
 
-  appDb.withTransaction = (async (handler) => {
-    const txClient = { query: async (sql, params) => appDb.query(sql, params) };
-    return handler(txClient);
-  }) as unknown as typeof appDb.withTransaction;
+  const txClient = {
+    query: (sql: string, params: unknown[] = []) => appDb.query(sql, params)
+  } as unknown as PoolClient;
+  appDb.withTransaction = (async <T>(handler: (client: PoolClient) => Promise<T>): Promise<T> => (
+    handler(txClient)
+  )) as typeof appDb.withTransaction;
 
-  appDb.query = (async (sql, params = []) => {
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
     const n = normalize(sql);
 
     // scimTokenService.verifyToken — SELECT by hash
     if (n.startsWith("select id, provider_id, label, token_hash, created_at, last_used_at, revoked_at from scim_tokens where token_hash = $1")) {
-      const [hash] = params;
+      const [hash] = params as [string];
       const row = [...scimTokens.values()].find((t) => t.token_hash === hash);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
@@ -143,19 +184,19 @@ before(async () => {
 
     // findProviderById (used by SCIM group sync)
     if (n.startsWith("select") && /from auth_providers\s+where id = \$1/.test(n)) {
-      const [id] = params;
+      const [id] = params as [string];
       const row = providers.get(id);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
 
     // scimUserService.listUsers — count + page
     if (n.startsWith("select count(*)::int as total from linked_identities li join users u on u.id = li.user_id where li.provider_id =")) {
-      const [providerId] = params;
+      const [providerId] = params as [string];
       const links = [...linkedIdentities.values()].filter((li) => li.provider_id === providerId);
       return { rowCount: 1, rows: [{ total: links.length }] };
     }
     if (n.startsWith("select u.id, u.email, u.display_name, u.is_active, u.created_at, u.updated_at, li.subject as external_id from linked_identities li join users u on u.id = li.user_id where li.provider_id =")) {
-      const [providerId] = params;
+      const [providerId] = params as [string];
       const out = [];
       for (const li of linkedIdentities.values()) {
         if (li.provider_id !== providerId) continue;
@@ -168,7 +209,7 @@ before(async () => {
 
     // scimUserService.findUserByExternalId
     if (n.startsWith("select u.id, u.email, u.password_hash, u.display_name, u.is_active, u.last_login_at, u.created_at, u.updated_at from linked_identities li join users u on u.id = li.user_id where li.provider_id = $1 and li.subject = $2")) {
-      const [providerId, subject] = params;
+      const [providerId, subject] = params as [string, string];
       const link = [...linkedIdentities.values()].find(
         (li) => li.provider_id === providerId && li.subject === subject
       );
@@ -178,7 +219,7 @@ before(async () => {
     }
     // findUserByExternalIdOrUserId (by users.id + linked_identities join)
     if (n.startsWith("select u.id, u.email, u.display_name, u.is_active, u.created_at, u.updated_at from users u join linked_identities li on li.user_id = u.id where u.id = $1 and li.provider_id = $2")) {
-      const [userId, providerId] = params;
+      const [userId, providerId] = params as [string, string];
       const link = [...linkedIdentities.values()].find(
         (li) => li.user_id === userId && li.provider_id === providerId
       );
@@ -189,15 +230,15 @@ before(async () => {
 
     // Lookup by lower(email) inside the SCIM create flow
     if (n.startsWith("select id, email, password_hash, display_name, is_active, last_login_at, created_at, updated_at from users where lower(email) = $1")) {
-      const [emailLower] = params;
+      const [emailLower] = params as [string];
       const row = [...users.values()].find((u) => u.email.toLowerCase() === emailLower);
       return row ? { rowCount: 1, rows: [row] } : { rowCount: 0, rows: [] };
     }
 
     // INSERT users (SCIM create new local user)
     if (n.startsWith("insert into users")) {
-      const [email, displayName, isActive] = params;
-      const row = {
+      const [email, displayName, isActive] = params as [string, string | null, boolean];
+      const row: AuthUserRow = {
         id: nextUserId(),
         email,
         password_hash: null,
@@ -213,7 +254,7 @@ before(async () => {
 
     // UPDATE users (SCIM replace/patch/deactivate)
     if (n.startsWith("update users set email = $2, display_name = $3, is_active = $4, updated_at = now() where id = $1")) {
-      const [id, email, displayName, isActive] = params;
+      const [id, email, displayName, isActive] = params as [string, string, string | null, boolean];
       const row = users.get(id);
       if (!row) return { rowCount: 0, rows: [] };
       row.email = email;
@@ -224,7 +265,7 @@ before(async () => {
       return { rowCount: 1, rows: [row] };
     }
     if (n.startsWith("update users set is_active = false, updated_at = now() where id = $1")) {
-      const [id] = params;
+      const [id] = params as [string];
       const row = users.get(id);
       if (row) { row.is_active = false; row.updated_at = new Date().toISOString(); }
       return { rowCount: row ? 1 : 0, rows: [] };
@@ -232,14 +273,14 @@ before(async () => {
 
     // INSERT linked_identities
     if (n.startsWith("insert into linked_identities")) {
-      const [userId, providerId, subject, email] = params;
+      const [userId, providerId, subject, email] = params as [string, string, string, string | null];
       const dup = [...linkedIdentities.values()].some(
         (li) => li.provider_id === providerId && li.subject === subject
       );
       if (dup) {
         const err = Object.assign(new Error("duplicate"), { code: "23505" }); throw err;
       }
-      const row = {
+      const row: LinkedIdentity = {
         id: nextIdentityId(),
         user_id: userId, provider_id: providerId, subject, email_at_link: email || null,
         created_at: new Date().toISOString(), last_seen_at: new Date().toISOString()
@@ -249,7 +290,7 @@ before(async () => {
     }
     // SELECT subject linked for user
     if (n.startsWith("select subject from linked_identities where provider_id = $1 and user_id = $2")) {
-      const [providerId, userId] = params;
+      const [providerId, userId] = params as [string, string];
       const row = [...linkedIdentities.values()].find(
         (li) => li.provider_id === providerId && li.user_id === userId
       );
@@ -257,7 +298,7 @@ before(async () => {
     }
     // Unlink
     if (n.startsWith("delete from linked_identities where user_id = $1 and provider_id = $2")) {
-      const [userId, providerId] = params;
+      const [userId, providerId] = params as [string, string];
       for (const [key, row] of linkedIdentities) {
         if (row.user_id === userId && row.provider_id === providerId) {
           linkedIdentities.delete(key);
@@ -269,18 +310,18 @@ before(async () => {
 
     // roleService.assignRolesByName / revokeRolesByName
     if (n.startsWith("select id, name from roles where lower(name) = any($1::text[])")) {
-      const [names] = params;
-      return { rowCount: (names || []).length, rows: (names || []).map((name, idx) => ({ id: uuid("ccc1", idx + 1), name })) };
+      const [names] = params as [string[]];
+      return { rowCount: names.length, rows: names.map((name, idx) => ({ id: uuid("ccc1", idx + 1), name })) };
     }
     if (n.startsWith("insert into user_roles")) {
-      const [userId, roleId] = params;
+      const [userId, roleId] = params as [string, string];
       const key = `${userId}:${roleId}`;
       const had = userRoleLinks.has(key);
       userRoleLinks.add(key);
       return { rowCount: had ? 0 : 1, rows: had ? [] : [{ role_id: roleId }] };
     }
     if (n.startsWith("delete from user_roles where user_id = $1 and role_id = $2 returning role_id")) {
-      const [userId, roleId] = params;
+      const [userId, roleId] = params as [string, string];
       const key = `${userId}:${roleId}`;
       const had = userRoleLinks.has(key);
       userRoleLinks.delete(key);
@@ -289,12 +330,21 @@ before(async () => {
 
     // Audit insert
     if (n.startsWith("insert into auth_audit_log")) {
-      const [actorUserId, actorEmail, targetUserId, action, outcome, detailsJson, ipAddress, userAgent] = params;
+      const [actorUserId, actorEmail, targetUserId, action, outcome, detailsJson, ipAddress, userAgent] = params as [
+        string | null,
+        string | null,
+        string | null,
+        string,
+        string | null,
+        string,
+        string | null,
+        string | null
+      ];
       auditRows.push({
         id: nextAuditId(),
         actor_user_id: actorUserId, actor_email: actorEmail,
         target_user_id: targetUserId, action, outcome,
-        details: JSON.parse(detailsJson),
+        details: JSON.parse(detailsJson) as Record<string, unknown>,
         ip_address: ipAddress, user_agent: userAgent,
         created_at: new Date().toISOString()
       });
@@ -330,7 +380,7 @@ beforeEach(() => {
 });
 
 test("SCIM endpoints require a bearer token", async () => {
-  const noToken = await call("GET", "/scim/v2/ServiceProviderConfig");
+  const noToken = await call<{ schemas: string[] }>("GET", "/scim/v2/ServiceProviderConfig");
   assert.equal(noToken.status, 401);
   assert.ok(noToken.payload && noToken.payload.schemas.includes("urn:ietf:params:scim:api:messages:2.0:Error"));
 
@@ -341,14 +391,14 @@ test("SCIM endpoints require a bearer token", async () => {
 test("revoked tokens are rejected", async () => {
   const provider = seedProvider();
   const { token } = seedToken(provider.id, { revoked: true });
-  const result = await call("GET", "/scim/v2/ServiceProviderConfig", { authToken: token });
+  const result = await call<{ patch: { supported: boolean }; authenticationSchemes: unknown[] }>("GET", "/scim/v2/ServiceProviderConfig", { authToken: token });
   assert.equal(result.status, 401);
 });
 
 test("ServiceProviderConfig is bearer-authenticated and advertises PATCH support", async () => {
   const provider = seedProvider();
   const { token } = seedToken(provider.id);
-  const result = await call("GET", "/scim/v2/ServiceProviderConfig", { authToken: token });
+  const result = await call<{ patch: { supported: boolean }; authenticationSchemes: unknown[] }>("GET", "/scim/v2/ServiceProviderConfig", { authToken: token });
   assert.equal(result.status, 200);
   assert.equal(result.payload.patch.supported, true);
   assert.ok(Array.isArray(result.payload.authenticationSchemes));
@@ -358,7 +408,7 @@ test("POST /scim/v2/Users creates a local user, links the identity, and audits",
   const provider = seedProvider();
   const { token } = seedToken(provider.id);
 
-  const result = await call("POST", "/scim/v2/Users", {
+  const result = await call<ScimUserPayload>("POST", "/scim/v2/Users", {
     authToken: token,
     body: {
       schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
@@ -396,7 +446,7 @@ test("POST with the same externalId returns 409 uniqueness", async () => {
   };
   const first = await call("POST", "/scim/v2/Users", { authToken: token, body });
   assert.equal(first.status, 201);
-  const second = await call("POST", "/scim/v2/Users", { authToken: token, body });
+  const second = await call<{ scimType: string }>("POST", "/scim/v2/Users", { authToken: token, body });
   assert.equal(second.status, 409);
   assert.equal(second.payload.scimType, "uniqueness");
 });
@@ -404,7 +454,7 @@ test("POST with the same externalId returns 409 uniqueness", async () => {
 test("PATCH active=false deactivates the user and emits scim.user.deactivated", async () => {
   const provider = seedProvider();
   const { token } = seedToken(provider.id);
-  const created = await call("POST", "/scim/v2/Users", {
+  const created = await call<ScimUserPayload>("POST", "/scim/v2/Users", {
     authToken: token,
     body: {
       schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
@@ -416,7 +466,7 @@ test("PATCH active=false deactivates the user and emits scim.user.deactivated", 
   });
   assert.equal(created.status, 201);
 
-  const patched = await call("PATCH", `/scim/v2/Users/${created.payload.id}`, {
+  const patched = await call<ScimUserPayload>("PATCH", `/scim/v2/Users/${created.payload.id}`, {
     authToken: token,
     body: {
       schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
@@ -433,7 +483,7 @@ test("PATCH /scim/v2/Groups syncs members to the mapped local role", async () =>
   const { token } = seedToken(provider.id);
 
   // Create two SCIM users so we have valid member IDs.
-  const u1 = await call("POST", "/scim/v2/Users", {
+  const u1 = await call<ScimUserPayload>("POST", "/scim/v2/Users", {
     authToken: token,
     body: {
       schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
@@ -441,7 +491,7 @@ test("PATCH /scim/v2/Groups syncs members to the mapped local role", async () =>
       emails: [{ value: "dan@example.com", primary: true }]
     }
   });
-  const u2 = await call("POST", "/scim/v2/Users", {
+  const u2 = await call<ScimUserPayload>("POST", "/scim/v2/Users", {
     authToken: token,
     body: {
       schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,11 +9,9 @@
     "node_modules",
     "dist",
     "frontend",
-    "app/test/accountLinkingApi.test.ts",
     "app/test/adminUsersApi.test.ts",
     "app/test/savedQueriesApi.test.ts",
     "app/test/savedQueryFoldersApi.test.ts",
-    "app/test/savedQuerySchedulesApi.test.ts",
-    "app/test/scimApi.test.ts"
+    "app/test/savedQuerySchedulesApi.test.ts"
   ]
 }

--- a/tsconfig.test.legacy.json
+++ b/tsconfig.test.legacy.json
@@ -10,12 +10,10 @@
     "noUnusedParameters": false
   },
   "include": [
-    "app/test/accountLinkingApi.test.ts",
     "app/test/adminUsersApi.test.ts",
     "app/test/savedQueriesApi.test.ts",
     "app/test/savedQueryFoldersApi.test.ts",
     "app/test/savedQuerySchedulesApi.test.ts",
-    "app/test/scimApi.test.ts",
     "app/src/types/**/*.d.ts"
   ],
   "exclude": ["node_modules", "dist", "frontend"]


### PR DESCRIPTION
## Summary
- type provider, user, linked-identity, audit, and transaction fixtures for account linking
- type SCIM token, provisioning, group-sync, and API response fixtures
- replace external-login provider casts with compatible service types
- move both suites out of the transitional TypeScript config, reducing the legacy allowlist from 6 suites to 4

Part of #148.

## Verification
- `npx tsc --noEmit -p tsconfig.test.json --pretty false`
- `node --import tsx --test app/test/accountLinkingApi.test.ts app/test/scimApi.test.ts` (19 passing)
- `npm run typecheck`
- `npm test` (243 passing)
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)