### PR TITLE
Gate large-schema retrieval quality in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Large-schema regression gate
+        run: npm run benchmark:large-schema
+
       - name: Build
         run: npm run build:be
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ The provider-free schema-linking comparison can be run without databases or API 
 npm run benchmark:large-schema
 ```
 
+This command is also a required backend CI gate. It exits with code `2` when
+table recall@15 falls below 95%, join-path accuracy falls below 100%, table
+recall no longer improves over the legacy global prompt, or the hierarchical
+prompt is no longer smaller than the legacy prompt. The JSON output includes
+`gate_diagnostics` with the pipeline stage, metric, actual value, comparator,
+and target for every gate; failed gates are also printed as concise stderr
+messages. Runtime fallback, repair, and request-correlation diagnostics are
+tracked separately from this provider-free schema-linking benchmark.
+
 Note: on first initialization of `test-data`, the restore script shifts all `date`/`timestamp` fields by dynamic offsets so the latest rental and latest payment land around yesterday (relative to system time), then caps shifted values at current system date/time to avoid future-dated rows.
 
 Report outputs:

--- a/app/src/benchmark/largeSchemaBenchmark.ts
+++ b/app/src/benchmark/largeSchemaBenchmark.ts
@@ -55,6 +55,21 @@ export interface LargeSchemaCaseResult {
   };
 }
 
+export interface LargeSchemaGateDiagnostic {
+  id: string;
+  stage: "schema_linking" | "prompt_construction";
+  metric: string;
+  actual: number;
+  comparator: ">=" | ">" | "<" | "=";
+  target: number;
+  passed: boolean;
+}
+
+export const LARGE_SCHEMA_THRESHOLDS = {
+  table_recall_at_15: 0.95,
+  join_path_accuracy: 1
+} as const;
+
 export interface LargeSchemaBenchmarkResult {
   version: string;
   schema: {
@@ -85,6 +100,7 @@ export interface LargeSchemaBenchmarkResult {
     prompt_chars_below_legacy: boolean;
     all_passed: boolean;
   };
+  gate_diagnostics: LargeSchemaGateDiagnostic[];
   cases: LargeSchemaCaseResult[];
 }
 
@@ -181,11 +197,49 @@ export async function runLargeSchemaBenchmark(
     .filter((value): value is number => Number.isFinite(value));
   const hierarchicalPromptChars = average(hierarchicalPromptValues);
   const gates = {
-    table_recall_at_15_ge_95pct: hierarchicalRecall >= 0.95,
-    join_path_accuracy_eq_100pct: hierarchicalJoinAccuracy === 1,
+    table_recall_at_15_ge_95pct: hierarchicalRecall >= LARGE_SCHEMA_THRESHOLDS.table_recall_at_15,
+    join_path_accuracy_eq_100pct: hierarchicalJoinAccuracy === LARGE_SCHEMA_THRESHOLDS.join_path_accuracy,
     improves_table_recall_over_legacy: hierarchicalRecall > legacyRecall,
     prompt_chars_below_legacy: hierarchicalPromptChars < legacyPromptChars
   };
+  const gateDiagnostics: LargeSchemaGateDiagnostic[] = [
+    {
+      id: "table_recall_at_15_ge_95pct",
+      stage: "schema_linking",
+      metric: "table_recall_at_15",
+      actual: round4(hierarchicalRecall),
+      comparator: ">=",
+      target: LARGE_SCHEMA_THRESHOLDS.table_recall_at_15,
+      passed: gates.table_recall_at_15_ge_95pct
+    },
+    {
+      id: "join_path_accuracy_eq_100pct",
+      stage: "schema_linking",
+      metric: "join_path_accuracy",
+      actual: round4(hierarchicalJoinAccuracy),
+      comparator: "=",
+      target: LARGE_SCHEMA_THRESHOLDS.join_path_accuracy,
+      passed: gates.join_path_accuracy_eq_100pct
+    },
+    {
+      id: "improves_table_recall_over_legacy",
+      stage: "schema_linking",
+      metric: "table_recall_at_15",
+      actual: round4(hierarchicalRecall),
+      comparator: ">",
+      target: round4(legacyRecall),
+      passed: gates.improves_table_recall_over_legacy
+    },
+    {
+      id: "prompt_chars_below_legacy",
+      stage: "prompt_construction",
+      metric: "average_prompt_chars",
+      actual: Math.round(hierarchicalPromptChars),
+      comparator: "<",
+      target: Math.round(legacyPromptChars),
+      passed: gates.prompt_chars_below_legacy
+    }
+  ];
 
   return {
     version: fixture.version,
@@ -214,8 +268,17 @@ export async function runLargeSchemaBenchmark(
       ...gates,
       all_passed: Object.values(gates).every(Boolean)
     },
+    gate_diagnostics: gateDiagnostics,
     cases: results
   };
+}
+
+export function formatLargeSchemaGateFailures(result: LargeSchemaBenchmarkResult): string[] {
+  return result.gate_diagnostics
+    .filter((gate) => !gate.passed)
+    .map((gate) => (
+      `${gate.stage}.${gate.metric} failed: actual ${gate.actual} must be ${gate.comparator} ${gate.target}`
+    ));
 }
 
 async function readFixture(filePath: string): Promise<LargeSchemaFixtureDefinition> {

--- a/app/src/benchmark/runLargeSchemaBenchmark.ts
+++ b/app/src/benchmark/runLargeSchemaBenchmark.ts
@@ -3,10 +3,13 @@ async function main(): Promise<void> {
   // are not called here, but appDb still validates this environment variable at
   // module load. Use an inert value so the standalone benchmark needs no DB.
   process.env.DATABASE_URL ||= "postgresql://benchmark:benchmark@127.0.0.1:1/unused";
-  const { runLargeSchemaBenchmark } = await import("./largeSchemaBenchmark");
+  const { formatLargeSchemaGateFailures, runLargeSchemaBenchmark } = await import("./largeSchemaBenchmark");
   const result = await runLargeSchemaBenchmark();
   console.log(JSON.stringify(result, null, 2));
   if (!result.release_gates.all_passed) {
+    for (const failure of formatLargeSchemaGateFailures(result)) {
+      console.error(`[large-schema-gate] ${failure}`);
+    }
     process.exitCode = 2;
   }
 }

--- a/app/test/largeSchemaBenchmark.test.ts
+++ b/app/test/largeSchemaBenchmark.test.ts
@@ -4,7 +4,10 @@ import assert from "node:assert/strict";
 
 process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/test";
 
-import { runLargeSchemaBenchmark } from "../src/benchmark/largeSchemaBenchmark";
+import {
+  formatLargeSchemaGateFailures,
+  runLargeSchemaBenchmark
+} from "../src/benchmark/largeSchemaBenchmark";
 
 test("large-schema benchmark compares legacy caps with hierarchical linking", async () => {
   const result = await runLargeSchemaBenchmark();
@@ -18,4 +21,21 @@ test("large-schema benchmark compares legacy caps with hierarchical linking", as
   assert.equal(result.cases.find((item) => item.id === "ls003")?.hierarchical.expansion_status, "complete");
   assert.equal(result.cases.find((item) => item.id === "ls005")?.hierarchical.expansion_status, "ambiguous");
   assert.equal(result.release_gates.all_passed, true);
+  assert.equal(result.gate_diagnostics.length, 4);
+  assert.equal(result.gate_diagnostics.every((gate) => gate.passed), true);
+  assert.deepEqual(formatLargeSchemaGateFailures(result), []);
+});
+
+test("large-schema gate failures identify the pipeline stage and metric", async () => {
+  const result = await runLargeSchemaBenchmark();
+  const regressed = {
+    ...result,
+    gate_diagnostics: result.gate_diagnostics.map((gate, index) => (
+      index === 0 ? { ...gate, actual: 0.8, passed: false } : gate
+    ))
+  };
+
+  assert.deepEqual(formatLargeSchemaGateFailures(regressed), [
+    "schema_linking.table_recall_at_15 failed: actual 0.8 must be >= 0.95"
+  ]);
 });


### PR DESCRIPTION
## Summary
- run the provider-free large-schema benchmark as a required backend CI step
- expose structured gate diagnostics with pipeline stage, metric, actual value, comparator, and target
- print concise actionable failures before returning the existing nonzero regression exit code
- document the enforced thresholds and the boundary between benchmark and runtime diagnostics

Part of #182.

## Verification
- `npm run typecheck`
- `node --import tsx --test app/test/largeSchemaBenchmark.test.ts` (2 passing)
- `npm run benchmark:large-schema` (all gates pass)
- `npm test` (244 passing)
- `npm run build`