### PR TITLE
Add bounded query-generation diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ Observability:
 - `GET /v1/observability/release-gates`
 - `GET /v1/observability/benchmark-command`
 - `POST /v1/observability/release-gates/report`
+- Each query run emits one `query_generation_diagnostics` JSON event correlated
+  by `request_id` and `session_id`. It contains bounded table IDs/counts,
+  expansion and fallback status, provider outcomes, stage latency, repair count,
+  prompt-size estimates, and token totals. It never includes the question,
+  prompt or SQL contents, query parameters, connection details, or raw provider
+  errors.
 
 RAG:
 

--- a/app/src/services/queryDiagnosticsService.ts
+++ b/app/src/services/queryDiagnosticsService.ts
@@ -1,0 +1,194 @@
+import { logEvent } from "../lib/observability";
+import type { ProviderAttempt } from "./llmSqlService";
+import type { SchemaLinkingDiagnostics } from "./queryGenerationContextService";
+
+const MAX_TABLE_IDS = 20;
+const MAX_PROVIDER_ATTEMPTS = 8;
+
+export interface QueryDiagnosticInput {
+  requestId?: string | null;
+  sessionId: string;
+  outcome: "succeeded" | "failed";
+  terminalStage: "schema_linking" | "generation" | "validation" | "budget" | "execution";
+  errorCode?: string | null;
+  durationMs: number;
+  schemaLinkingDurationMs: number;
+  schemaLinking: SchemaLinkingDiagnostics | null;
+  expandedTableIds: string[];
+  ragDocumentCount: number;
+  provider: string;
+  model: string | null;
+  providerAttempts: ProviderAttempt[];
+  repairCount: number;
+  linkerPromptChars: number;
+  generationPromptChars: number;
+  repairPromptChars: number;
+  tokenUsage: unknown;
+  executionDurationMs?: number | null;
+}
+
+export interface QueryDiagnosticPayload {
+  request_id: string | null;
+  session_id: string;
+  outcome: "succeeded" | "failed";
+  terminal_stage: QueryDiagnosticInput["terminalStage"];
+  error_code: string | null;
+  duration_ms: number;
+  schema_linking: {
+    candidate_count: number;
+    candidate_table_ids: string[];
+    selected_core_table_ids: string[];
+    expanded_table_ids: string[];
+    connector_table_ids: string[];
+    join_edge_count: number;
+    expansion_status: string;
+    linker_status: string;
+    fallback_used: boolean;
+    fallback_category: "none" | "no_provider" | "provider_failure";
+  } | null;
+  retrieval: { rag_document_count: number };
+  generation: {
+    provider: string;
+    model: string | null;
+    attempts: Array<{
+      provider: string;
+      model: string | null;
+      stage: string;
+      status: string;
+      status_code: number | null;
+      latency_ms: number;
+    }>;
+    attempts_truncated: boolean;
+    fallback_used: boolean;
+    repair_count: number;
+    prompt_chars: {
+      linker: number;
+      generation: number;
+      repair: number;
+      total: number;
+    };
+    token_usage: {
+      prompt_tokens: number;
+      completion_tokens: number;
+      total_tokens: number;
+    };
+  };
+  stage_latency_ms: {
+    schema_linking: number;
+    generation: number;
+    repair: number;
+    execution: number;
+  };
+}
+
+export function buildQueryDiagnostic(input: QueryDiagnosticInput): QueryDiagnosticPayload {
+  const linker = input.schemaLinking?.linker;
+  const expansion = input.schemaLinking?.expansion;
+  const attempts = input.providerAttempts.slice(0, MAX_PROVIDER_ATTEMPTS);
+  const linkerAttempts = linker?.attempts || [];
+  const generationLatency = input.providerAttempts
+    .filter((attempt) => attempt.stage !== "repair")
+    .reduce((total, attempt) => total + boundedNumber(attempt.latency_ms), 0);
+  const repairLatency = input.providerAttempts
+    .filter((attempt) => attempt.stage === "repair")
+    .reduce((total, attempt) => total + boundedNumber(attempt.latency_ms), 0);
+
+  return {
+    request_id: input.requestId || null,
+    session_id: input.sessionId,
+    outcome: input.outcome,
+    terminal_stage: input.terminalStage,
+    error_code: input.errorCode ? boundedLabel(input.errorCode, 80) : null,
+    duration_ms: boundedNumber(input.durationMs),
+    schema_linking: input.schemaLinking ? {
+      candidate_count: input.schemaLinking.candidates.length,
+      candidate_table_ids: boundIds(input.schemaLinking.candidates.map((candidate) => candidate.id)),
+      selected_core_table_ids: boundIds(linker?.selection.table_ids || []),
+      expanded_table_ids: boundIds(input.expandedTableIds),
+      connector_table_ids: boundIds(expansion?.connector_object_ids || []),
+      join_edge_count: expansion?.edges.length || 0,
+      expansion_status: expansion?.status || "not_run",
+      linker_status: linker?.status || "not_run",
+      fallback_used: linker?.status === "fallback",
+      fallback_category: linker?.status !== "fallback"
+        ? "none"
+        : linkerAttempts.length === 0 ? "no_provider" : "provider_failure"
+    } : null,
+    retrieval: {
+      rag_document_count: Math.max(0, Math.floor(input.ragDocumentCount))
+    },
+    generation: {
+      provider: boundedLabel(input.provider, 64),
+      model: input.model ? boundedLabel(input.model, 120) : null,
+      attempts: attempts.map((attempt) => ({
+        provider: boundedLabel(attempt.provider, 64),
+        model: attempt.model ? boundedLabel(attempt.model, 120) : null,
+        stage: attempt.stage || "generation",
+        status: attempt.status,
+        status_code: attempt.status_code,
+        latency_ms: boundedNumber(attempt.latency_ms)
+      })),
+      attempts_truncated: input.providerAttempts.length > MAX_PROVIDER_ATTEMPTS,
+      fallback_used: input.provider === "local-fallback",
+      repair_count: Math.max(0, Math.floor(input.repairCount)),
+      prompt_chars: {
+        linker: boundedNumber(input.linkerPromptChars),
+        generation: boundedNumber(input.generationPromptChars),
+        repair: boundedNumber(input.repairPromptChars),
+        total: boundedNumber(input.linkerPromptChars + input.generationPromptChars + input.repairPromptChars)
+      },
+      token_usage: sumTokenUsage(input.tokenUsage)
+    },
+    stage_latency_ms: {
+      schema_linking: boundedNumber(input.schemaLinkingDurationMs),
+      generation: generationLatency,
+      repair: repairLatency,
+      execution: boundedNumber(input.executionDurationMs || 0)
+    }
+  };
+}
+
+export function emitQueryDiagnostic(input: QueryDiagnosticInput): void {
+  logEvent(
+    "query_generation_diagnostics",
+    { ...buildQueryDiagnostic(input) },
+    input.outcome === "failed" ? "warn" : "info"
+  );
+}
+
+function boundIds(ids: string[]): string[] {
+  return ids.slice(0, MAX_TABLE_IDS).map(String);
+}
+
+function boundedNumber(value: unknown): number {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.round(number) : 0;
+}
+
+function boundedLabel(value: unknown, maxLength: number): string {
+  return String(value || "unknown").slice(0, maxLength);
+}
+
+function sumTokenUsage(value: unknown): QueryDiagnosticPayload["generation"]["token_usage"] {
+  const totals = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+  collectTokenUsage(value, totals, 0);
+  if (totals.total_tokens === 0) {
+    totals.total_tokens = totals.prompt_tokens + totals.completion_tokens;
+  }
+  return totals;
+}
+
+function collectTokenUsage(value: unknown, totals: QueryDiagnosticPayload["generation"]["token_usage"], depth: number): void {
+  if (!value || typeof value !== "object" || depth > 2) return;
+  const record = value as Record<string, unknown>;
+  const hasUsage = "prompt_tokens" in record || "completion_tokens" in record || "total_tokens" in record;
+  if (hasUsage) {
+    totals.prompt_tokens += boundedNumber(record.prompt_tokens);
+    totals.completion_tokens += boundedNumber(record.completion_tokens);
+    totals.total_tokens += boundedNumber(record.total_tokens);
+    return;
+  }
+  for (const child of Object.values(record)) {
+    collectTokenUsage(child, totals, depth + 1);
+  }
+}

--- a/app/src/services/queryOrchestrationService.ts
+++ b/app/src/services/queryOrchestrationService.ts
@@ -23,6 +23,10 @@ import type { DbAdapter } from "../adapters/types";
 import { prepareQueryGenerationContext, type SchemaLinkingDiagnostics } from "./queryGenerationContextService";
 import type { QueryContext } from "./queryOrchestrationStore";
 import type { RagRetrievalDoc } from "./ragRetrieval";
+import {
+  emitQueryDiagnostic,
+  type QueryDiagnosticInput
+} from "./queryDiagnosticsService";
 
 const { extractForbiddenColumnsFromRagNotes, validateSqlAgainstForbiddenColumns } = columnPolicyService;
 const { retrieveRagContext } = ragRetrieval;
@@ -52,12 +56,14 @@ export interface QueryOrchestrationDependencies {
   prepareQueryGenerationContext: typeof prepareQueryGenerationContext;
   generateSqlWithRouting: typeof generateSqlWithRouting;
   createDatabaseAdapter: typeof createDatabaseAdapter;
+  emitQueryDiagnostic: typeof emitQueryDiagnostic;
 }
 
 const defaultDependencies: QueryOrchestrationDependencies = {
   prepareQueryGenerationContext,
   generateSqlWithRouting,
-  createDatabaseAdapter
+  createDatabaseAdapter,
+  emitQueryDiagnostic
 };
 
 function success<T>(body: T, statusCode = 200): OrchestrateResult<T> {
@@ -181,8 +187,52 @@ export async function orchestrateQueryRun({
   const sqlDialect: "postgres" | "mssql" = session.db_type === "mssql" ? "mssql" : "postgres";
   const generationStartedAt = Date.now();
   let context: QueryContext;
-  let ragDocuments: RagRetrievalDoc[];
+  let ragDocuments: RagRetrievalDoc[] = [];
   let schemaLinking: SchemaLinkingDiagnostics | null = null;
+  let expandedTableIds: string[] = [];
+  let usedProvider = "unknown";
+  let usedModel: string | null = requestedModel || "unknown";
+  let generationAttempts: ProviderAttempt[] = [];
+  let generationTokenUsage: unknown = null;
+  let promptVersion = "v3-scoped-generation";
+  let generationPromptChars = 0;
+  let schemaLinkingDurationMs = 0;
+  let executionDurationMs = 0;
+  const repairs: Array<{
+    errors: string[];
+    provider: string;
+    model: string | null;
+    prompt_version: string;
+    prompt_chars: number;
+  }> = [];
+
+  const emitTerminalDiagnostic = (
+    outcome: QueryDiagnosticInput["outcome"],
+    terminalStage: QueryDiagnosticInput["terminalStage"],
+    errorCode: string | null = null
+  ): void => {
+    dependencies.emitQueryDiagnostic({
+      requestId,
+      sessionId,
+      outcome,
+      terminalStage,
+      errorCode,
+      durationMs: Date.now() - generationStartedAt,
+      schemaLinkingDurationMs,
+      schemaLinking,
+      expandedTableIds,
+      ragDocumentCount: ragDocuments.length,
+      provider: usedProvider,
+      model: usedModel,
+      providerAttempts: generationAttempts,
+      repairCount: repairs.length,
+      linkerPromptChars: schemaLinking?.linker?.prompt_chars || 0,
+      generationPromptChars,
+      repairPromptChars: repairs.reduce((total, repair) => total + repair.prompt_chars, 0),
+      tokenUsage: generationTokenUsage,
+      executionDurationMs
+    });
+  };
 
   if (sqlOverride) {
     [context, ragDocuments] = await Promise.all([
@@ -191,6 +241,7 @@ export async function orchestrateQueryRun({
     ]);
   } else {
     let prepared;
+    const schemaLinkingStartedAt = Date.now();
     try {
       prepared = await dependencies.prepareQueryGenerationContext({
         dataSourceId: session.data_source_id,
@@ -200,15 +251,19 @@ export async function orchestrateQueryRun({
         requestId
       });
     } catch (err) {
+      schemaLinkingDurationMs = Date.now() - schemaLinkingStartedAt;
       await markSessionStatus(sessionId, "failed");
+      emitTerminalDiagnostic("failed", "schema_linking", "schema_linking_failed");
       return failure(502, {
         error: "schema_linking_failed",
         message: (err as Error).message
       });
     }
+    schemaLinkingDurationMs = Date.now() - schemaLinkingStartedAt;
     schemaLinking = prepared.diagnostics;
     if (prepared.ok === false) {
       await markSessionStatus(sessionId, "failed");
+      emitTerminalDiagnostic("failed", "schema_linking", prepared.code);
       return failure(422, {
         error: prepared.code,
         message: prepared.message,
@@ -218,15 +273,10 @@ export async function orchestrateQueryRun({
     context = prepared.context;
     ragDocuments = prepared.ragDocuments;
   }
+  expandedTableIds = context.schemaObjects.map((object) => object.id);
   const forbiddenColumns = extractForbiddenColumnsFromRagNotes(context.ragNotes, context.columns);
 
   let generatedSql: string;
-  let usedProvider = "unknown";
-  let usedModel: string = requestedModel || "unknown";
-  let generationAttempts: ProviderAttempt[] = [];
-  let generationTokenUsage: unknown = null;
-  let promptVersion = "v3-scoped-generation";
-  let generationPromptChars = 0;
 
   if (sqlOverride) {
     generatedSql = sqlOverride;
@@ -260,6 +310,7 @@ export async function orchestrateQueryRun({
       generationPromptChars = generation.promptChars || 0;
     } catch (err) {
       await markSessionStatus(sessionId, "failed");
+      emitTerminalDiagnostic("failed", "generation", "llm_generation_failed");
       return failure(502, {
         error: "llm_generation_failed",
         message: (err as Error).message
@@ -268,14 +319,6 @@ export async function orchestrateQueryRun({
   }
 
   let adapter: DbAdapter | null = null;
-  const repairs: Array<{
-    errors: string[];
-    provider: string;
-    model: string | null;
-    prompt_version: string;
-    prompt_chars: number;
-  }> = [];
-
   try {
     let safeSql = generatedSql;
     let safety = validateAndNormalizeSql(generatedSql, {
@@ -313,6 +356,7 @@ export async function orchestrateQueryRun({
             try {
               adapter = dependencies.createDatabaseAdapter(session.db_type, session.connection_ref);
             } catch (err) {
+              emitTerminalDiagnostic("failed", "execution", "unsupported_database_adapter");
               return failure(400, { error: "bad_request", message: (err as Error).message });
             }
           }
@@ -368,6 +412,7 @@ export async function orchestrateQueryRun({
             });
           } catch (err) {
             await markSessionStatus(sessionId, "failed");
+            emitTerminalDiagnostic("failed", "generation", "llm_repair_failed");
             return failure(502, {
               error: "llm_repair_failed",
               message: (err as Error).message,
@@ -405,6 +450,7 @@ export async function orchestrateQueryRun({
           generationTokenUsage
         });
         await markSessionStatus(sessionId, "failed");
+        emitTerminalDiagnostic("failed", "validation", "invalid_sql");
         return failure(400, {
           error: "invalid_sql",
           details: validationErrors,
@@ -456,6 +502,7 @@ export async function orchestrateQueryRun({
               });
             } catch (err) {
               await markSessionStatus(sessionId, "failed");
+              emitTerminalDiagnostic("failed", "generation", "llm_repair_failed");
               return failure(502, {
                 error: "llm_repair_failed",
                 message: (err as Error).message,
@@ -489,6 +536,7 @@ export async function orchestrateQueryRun({
             generationTokenUsage
           });
           await markSessionStatus(sessionId, "failed");
+          emitTerminalDiagnostic("failed", "budget", "query_budget_exceeded");
           return failure(400, {
             error: "query_budget_exceeded",
             details: budget.errors,
@@ -543,6 +591,7 @@ export async function orchestrateQueryRun({
 
     if (noExecute) {
       await markSessionStatus(sessionId, "completed");
+      emitTerminalDiagnostic("succeeded", "validation");
       return success({
         attempt_id: attemptId,
         sql: safeSql,
@@ -562,6 +611,7 @@ export async function orchestrateQueryRun({
     }
 
     const execution = await adapter!.executeReadOnly(safeSql, { timeoutMs, maxRows });
+    executionDurationMs = execution.durationMs;
     await insertQueryResultMeta({
       attemptId: attemptId as string,
       rowCount: execution.rowCount,
@@ -570,6 +620,7 @@ export async function orchestrateQueryRun({
     });
 
     await markSessionStatus(sessionId, "completed");
+    emitTerminalDiagnostic("succeeded", "execution");
 
     return success({
       attempt_id: attemptId,
@@ -591,6 +642,7 @@ export async function orchestrateQueryRun({
     await markSessionStatus(sessionId, "failed");
 
     if (isLikelyInvalidSqlExecutionError(err, sqlDialect)) {
+      emitTerminalDiagnostic("failed", "execution", "invalid_sql");
       return failure(400, {
         error: "invalid_sql",
         details: [(err as Error).message],
@@ -598,6 +650,7 @@ export async function orchestrateQueryRun({
       });
     }
 
+    emitTerminalDiagnostic("failed", "execution", "query_execution_failed");
     return failure(500, {
       error: "query_execution_failed",
       message: (err as Error).message,

--- a/app/test/queryDiagnosticsService.test.ts
+++ b/app/test/queryDiagnosticsService.test.ts
@@ -1,0 +1,62 @@
+import "./helpers/setupEnv";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildQueryDiagnostic } from "../src/services/queryDiagnosticsService";
+
+test("query diagnostics are bounded, correlated, and exclude sensitive content", () => {
+  const ids = Array.from({ length: 25 }, (_, index) => `table-${index}`);
+  const payload = buildQueryDiagnostic({
+    requestId: "request-1",
+    sessionId: "session-1",
+    outcome: "succeeded",
+    terminalStage: "execution",
+    durationMs: 120.4,
+    schemaLinkingDurationMs: 30,
+    schemaLinking: {
+      candidates: ids.map((id) => ({ id, ref: `public.${id}`, score: 1, lexical_score: 1, rag_score: 0, matched_terms: ["secret-question-term"] })),
+      linker: {
+        selection: { table_ids: ids, concepts: ["secret-concept"], reason: "secret reason" },
+        status: "fallback",
+        provider: "candidate-fallback",
+        model: null,
+        attempts: [],
+        fallback_reason: "secret provider error",
+        prompt_version: "v3-schema-linker",
+        prompt_chars: 500
+      },
+      expansion: null
+    },
+    expandedTableIds: ids,
+    ragDocumentCount: 12,
+    provider: "local-fallback",
+    model: "rule-based-v0",
+    providerAttempts: Array.from({ length: 10 }, () => ({
+      provider: "openai",
+      model: "model",
+      status: "failed" as const,
+      status_code: 500,
+      latency_ms: 7,
+      error: "secret provider response",
+      stage: "generation" as const
+    })),
+    repairCount: 1,
+    linkerPromptChars: 500,
+    generationPromptChars: 800,
+    repairPromptChars: 600,
+    tokenUsage: {
+      generation: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      repair: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 }
+    },
+    executionDurationMs: 20
+  });
+
+  assert.equal(payload.request_id, "request-1");
+  assert.equal(payload.schema_linking?.candidate_table_ids.length, 20);
+  assert.equal(payload.generation.attempts.length, 8);
+  assert.equal(payload.generation.attempts_truncated, true);
+  assert.deepEqual(payload.generation.token_usage, { prompt_tokens: 18, completion_tokens: 9, total_tokens: 27 });
+  const serialized = JSON.stringify(payload);
+  assert.doesNotMatch(serialized, /secret/);
+  assert.doesNotMatch(serialized, /question|sql|connection|parameter/i);
+});

--- a/app/test/queryOrchestrationRepair.test.ts
+++ b/app/test/queryOrchestrationRepair.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/services/queryOrchestrationService";
 import type { GenerateSqlWithRoutingInput, GenerateSqlWithRoutingResult } from "../src/services/llmSqlService";
 import type { DbAdapter } from "../src/adapters/types";
+import type { QueryDiagnosticInput } from "../src/services/queryDiagnosticsService";
 
 const SESSION_ID = "00000000-0000-4000-8000-000000000101";
 const DATA_SOURCE_ID = "00000000-0000-4000-8000-000000000111";
@@ -20,6 +21,7 @@ const ATTEMPT_ID = "00000000-0000-4000-8000-000000000301";
 let originalQuery: typeof appDb.query;
 let insertedSql: string[];
 let statuses: string[];
+let emittedDiagnostics: QueryDiagnosticInput[];
 
 before(() => {
   originalQuery = appDb.query;
@@ -45,6 +47,7 @@ before(() => {
 beforeEach(() => {
   insertedSql = [];
   statuses = [];
+  emittedDiagnostics = [];
 });
 
 after(() => {
@@ -80,6 +83,11 @@ test("orchestrateQueryRun repairs invalid SQL once and reruns the safety pipelin
     repair_chars: 800,
     total_chars: 1400
   });
+  assert.equal(emittedDiagnostics.length, 1);
+  assert.equal(emittedDiagnostics[0].requestId, "request-1");
+  assert.equal(emittedDiagnostics[0].outcome, "succeeded");
+  assert.equal(emittedDiagnostics[0].terminalStage, "validation");
+  assert.equal(emittedDiagnostics[0].repairCount, 1);
 });
 
 test("orchestrateQueryRun stops after one failed repair and marks it exhausted", async () => {
@@ -100,6 +108,9 @@ test("orchestrateQueryRun stops after one failed repair and marks it exhausted",
   assert.deepEqual(stages, ["generation", "repair"]);
   assert.equal(insertedSql.length, 2);
   assert.deepEqual(statuses, ["failed"]);
+  assert.equal(emittedDiagnostics.length, 1);
+  assert.equal(emittedDiagnostics[0].outcome, "failed");
+  assert.equal(emittedDiagnostics[0].errorCode, "invalid_sql");
 });
 
 test("orchestrateQueryRun repairs adapter validation errors before EXPLAIN and execution", async () => {
@@ -136,6 +147,7 @@ function baseInput() {
     sessionId: SESSION_ID,
     question: "What is total revenue?",
     dataSourceId: DATA_SOURCE_ID,
+    requestId: "request-1",
     connectionRef: "postgresql://unused",
     dbType: "postgres",
     maxRows: 100,
@@ -175,6 +187,9 @@ function dependenciesWithGenerator(
       }
     }),
     generateSqlWithRouting: generate,
+    emitQueryDiagnostic: (diagnostic) => {
+      emittedDiagnostics.push(diagnostic);
+    },
     createDatabaseAdapter: () => {
       throw new Error("Adapter must not be created for no_execute tests");
     }


### PR DESCRIPTION
## Summary
- emit one request- and session-correlated diagnostic event for terminal query-generation outcomes
- record bounded candidate, selected, expanded, connector, provider, fallback, repair, prompt-size, token, and stage-latency metadata
- cover successful preview/execution plus schema-linking, generation, validation, budget, repair, and execution failures
- exclude question text, prompts, SQL, parameters, connection details, raw provider errors, and unbounded arrays or labels
- document the `query_generation_diagnostics` operational event

Part of #182.

## Verification
- `npm run typecheck`
- focused diagnostics/orchestration/context tests (7 passing)
- `npm test` (245 passing)
- `npm run build`
- `npm run benchmark:large-schema` (all gates pass)