### PR TITLE
Gate fallback and repair quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ Report outputs:
 - Runner exits with code `2` when one or more MVP release gates fail.
 - Reports include table recall@15, join-path accuracy, repair rate, prompt size,
   schema-size/complexity stratification, and a legacy-global versus hierarchical comparison.
+- The provider-backed MVP release gates also require rule-based fallback on at
+  most 10% of successful runs and successful repair on at least 80% of runs
+  where repair is attempted.
+  A run with no repair attempts reports repair success as `null` and does not
+  fail the repair gate.
 
 Progress tracker:
 

--- a/app/src/benchmark/queryQualityGates.ts
+++ b/app/src/benchmark/queryQualityGates.ts
@@ -1,0 +1,56 @@
+export const MVP_QUERY_QUALITY_THRESHOLDS = {
+  max_rule_based_fallback_rate: 0.1,
+  min_repair_success_rate: 0.8
+} as const;
+
+export interface QueryQualityCase {
+  provider?: string | null;
+  repair_count?: number;
+  run_status: number;
+}
+
+export interface QueryQualitySummary {
+  fallback_eligible_cases: number;
+  fallback_cases: number;
+  fallback_rate: number;
+  repair_attempted_cases: number;
+  repair_succeeded_cases: number;
+  repair_success_rate: number | null;
+  gates: {
+    fallback_rate_le_10pct: boolean;
+    repair_success_rate_ge_80pct: boolean;
+  };
+}
+
+export function summarizeQueryQuality(cases: QueryQualityCase[]): QueryQualitySummary {
+  const successfulCases = cases.filter((item) => item.run_status === 200);
+  const fallbackCases = successfulCases.filter((item) => item.provider === "local-fallback").length;
+  const repairAttempts = cases.filter((item) => Number(item.repair_count || 0) > 0);
+  const repairSuccesses = repairAttempts.filter((item) => item.run_status === 200).length;
+  const fallbackRate = ratio(fallbackCases, successfulCases.length);
+  const repairSuccessRate = repairAttempts.length > 0
+    ? ratio(repairSuccesses, repairAttempts.length)
+    : null;
+
+  return {
+    fallback_eligible_cases: successfulCases.length,
+    fallback_cases: fallbackCases,
+    fallback_rate: round4(fallbackRate),
+    repair_attempted_cases: repairAttempts.length,
+    repair_succeeded_cases: repairSuccesses,
+    repair_success_rate: repairSuccessRate === null ? null : round4(repairSuccessRate),
+    gates: {
+      fallback_rate_le_10pct: fallbackRate <= MVP_QUERY_QUALITY_THRESHOLDS.max_rule_based_fallback_rate,
+      repair_success_rate_ge_80pct: repairSuccessRate === null
+        || repairSuccessRate >= MVP_QUERY_QUALITY_THRESHOLDS.min_repair_success_rate
+    }
+  };
+}
+
+function ratio(numerator: number, denominator: number): number {
+  return denominator > 0 ? numerator / denominator : 0;
+}
+
+function round4(value: number): number {
+  return Number(value.toFixed(4));
+}

--- a/app/src/benchmark/runMvpBenchmark.ts
+++ b/app/src/benchmark/runMvpBenchmark.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { Client } from "pg";
 import { errorMessage } from "../lib/http";
 import type { LargeSchemaBenchmarkResult } from "./largeSchemaBenchmark";
+import { summarizeQueryQuality } from "./queryQualityGates";
 
 const APP_BASE_URL = String(process.env.BENCHMARK_APP_BASE_URL || "http://localhost:8080").replace(/\/$/, "");
 const BENCHMARK_FILE = process.env.BENCHMARK_FILE || path.join(process.cwd(), "docs", "evals", "dvdrental-mvp-benchmark.json");
@@ -214,6 +215,7 @@ interface RunResponse {
   sql?: string;
   rows?: Array<Record<string, unknown>>;
   provider?: string | { name?: string; model?: string };
+  repair_exhausted?: boolean;
   diagnostics?: {
     schema_linking?: null | {
       candidate_tables?: Array<{ id?: string; ref?: string }>;
@@ -301,7 +303,8 @@ async function runCase(caseDef: BenchmarkCase, context: RunContext): Promise<Cas
       critical_safety_violation: false,
       e2e_latency_ms: e2eLatencyMs,
       generated_sql: runResponse.payload?.sql || null,
-      ...metadata
+      ...metadata,
+      repair_count: runResponse.payload?.repair_exhausted === true ? 1 : 0
     };
   }
 
@@ -535,6 +538,12 @@ interface BenchmarkSummary {
   table_recall_at_15: number;
   join_path_accuracy: number;
   repair_rate: number;
+  fallback_eligible_cases: number;
+  fallback_cases: number;
+  fallback_rate: number;
+  repair_attempted_cases: number;
+  repair_succeeded_cases: number;
+  repair_success_rate: number | null;
   average_prompt_chars: number | null;
   stratified: {
     by_schema_size: Record<string, BenchmarkSliceSummary>;
@@ -547,6 +556,8 @@ interface BenchmarkSummary {
     sql_validation_pass_rate_ge_98pct: boolean;
     table_recall_at_15_ge_95pct: boolean;
     join_path_accuracy_ge_95pct: boolean;
+    fallback_rate_le_10pct: boolean;
+    repair_success_rate_ge_80pct: boolean;
     large_schema_comparison_passed: boolean;
     all_passed: boolean;
   };
@@ -583,6 +594,7 @@ function summarizeResults(results: CaseResult[], largeSchema: LargeSchemaBenchma
   const tableRecall = average(tableRecallValues);
   const joinPathAccuracy = ratio(joinPathValues.filter(Boolean).length, joinPathValues.length);
   const repairRate = ratio(results.filter((item) => Number(item.repair_count || 0) > 0).length, total);
+  const queryQuality = summarizeQueryQuality(results);
 
   const gates = {
     correctness_ge_85pct: correctnessRate >= 0.85,
@@ -591,6 +603,7 @@ function summarizeResults(results: CaseResult[], largeSchema: LargeSchemaBenchma
     sql_validation_pass_rate_ge_98pct: sqlValidityRate >= 0.98,
     table_recall_at_15_ge_95pct: tableRecall >= 0.95,
     join_path_accuracy_ge_95pct: joinPathAccuracy >= 0.95,
+    ...queryQuality.gates,
     large_schema_comparison_passed: largeSchema.release_gates.all_passed
   };
 
@@ -608,6 +621,12 @@ function summarizeResults(results: CaseResult[], largeSchema: LargeSchemaBenchma
     table_recall_at_15: round4(tableRecall),
     join_path_accuracy: round4(joinPathAccuracy),
     repair_rate: round4(repairRate),
+    fallback_eligible_cases: queryQuality.fallback_eligible_cases,
+    fallback_cases: queryQuality.fallback_cases,
+    fallback_rate: queryQuality.fallback_rate,
+    repair_attempted_cases: queryQuality.repair_attempted_cases,
+    repair_succeeded_cases: queryQuality.repair_succeeded_cases,
+    repair_success_rate: queryQuality.repair_success_rate,
     average_prompt_chars: promptCharValues.length > 0 ? Math.round(average(promptCharValues)) : null,
     stratified: {
       by_schema_size: stratifyResults(results, (item) => item.schema_size_bucket || "unknown"),
@@ -748,6 +767,8 @@ function buildMarkdownReport(payload: BenchmarkReport): string {
     `- Table recall@15: ${(summary.table_recall_at_15 * 100).toFixed(2)}%`,
     `- Join-path accuracy: ${(summary.join_path_accuracy * 100).toFixed(2)}%`,
     `- Repair rate: ${(summary.repair_rate * 100).toFixed(2)}%`,
+    `- Rule-based fallback rate: ${(summary.fallback_rate * 100).toFixed(2)}% (${summary.fallback_cases}/${summary.fallback_eligible_cases} successful runs)`,
+    `- Repair success rate: ${summary.repair_success_rate === null ? "n/a (no repairs attempted)" : `${(summary.repair_success_rate * 100).toFixed(2)}% (${summary.repair_succeeded_cases}/${summary.repair_attempted_cases})`}`,
     `- Average prompt size: ${summary.average_prompt_chars === null ? "n/a" : `${summary.average_prompt_chars} chars`}`,
     "",
     "## Release Gates",
@@ -757,6 +778,8 @@ function buildMarkdownReport(payload: BenchmarkReport): string {
     `- SQL validation pass rate >= 98%: ${gateMark(gates.sql_validation_pass_rate_ge_98pct)}`,
     `- Table recall@15 >= 95%: ${gateMark(gates.table_recall_at_15_ge_95pct)}`,
     `- Join-path accuracy >= 95%: ${gateMark(gates.join_path_accuracy_ge_95pct)}`,
+    `- Rule-based fallback rate <= 10%: ${gateMark(gates.fallback_rate_le_10pct)}`,
+    `- Repair success rate >= 80% (when attempted): ${gateMark(gates.repair_success_rate_ge_80pct)}`,
     `- Large-schema comparison passed: ${gateMark(gates.large_schema_comparison_passed)}`,
     `- All gates passed: ${gateMark(gates.all_passed)}`,
     "",

--- a/app/test/queryQualityGates.test.ts
+++ b/app/test/queryQualityGates.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { summarizeQueryQuality } from "../src/benchmark/queryQualityGates";
+
+test("query quality gates pass within fallback and repair thresholds", () => {
+  const summary = summarizeQueryQuality([
+    ...Array.from({ length: 9 }, () => ({ provider: "openai", repair_count: 0, run_status: 200 })),
+    { provider: "local-fallback", repair_count: 0, run_status: 200 },
+    { provider: "openai", repair_count: 1, run_status: 200 },
+    { provider: "openai", repair_count: 1, run_status: 200 },
+    { provider: "openai", repair_count: 1, run_status: 200 },
+    { provider: "openai", repair_count: 1, run_status: 200 },
+    { provider: "openai", repair_count: 1, run_status: 400 }
+  ]);
+
+  assert.equal(summary.fallback_rate, 0.0714);
+  assert.equal(summary.repair_success_rate, 0.8);
+  assert.deepEqual(summary.gates, {
+    fallback_rate_le_10pct: true,
+    repair_success_rate_ge_80pct: true
+  });
+});
+
+test("query quality gates fail excessive fallback and unsuccessful repair", () => {
+  const summary = summarizeQueryQuality([
+    { provider: "local-fallback", repair_count: 0, run_status: 200 },
+    { provider: "local-fallback", repair_count: 1, run_status: 400 },
+    { provider: "openai", repair_count: 1, run_status: 400 },
+    { provider: "openai", repair_count: 1, run_status: 200 }
+  ]);
+
+  assert.equal(summary.fallback_rate, 0.5);
+  assert.equal(summary.repair_success_rate, 0.3333);
+  assert.equal(summary.gates.fallback_rate_le_10pct, false);
+  assert.equal(summary.gates.repair_success_rate_ge_80pct, false);
+});
+
+test("query quality repair gate is neutral when no repairs were attempted", () => {
+  const summary = summarizeQueryQuality([
+    { provider: "openai", repair_count: 0, run_status: 200 }
+  ]);
+
+  assert.equal(summary.repair_success_rate, null);
+  assert.equal(summary.gates.repair_success_rate_ge_80pct, true);
+});


### PR DESCRIPTION
## Summary
- measure rule-based fallback among successful benchmark runs and enforce a maximum 10% rate
- measure successful outcomes among attempted repairs and enforce a minimum 80% success rate
- treat runs with no repair attempts as neutral instead of failing an unobservable gate
- include fallback and repair counts, rates, and gate outcomes in JSON and Markdown benchmark reports
- preserve repair attempts from failed terminal responses for accurate aggregation
- document the thresholds and denominator semantics

Closes #182.

## Verification
- `npm run typecheck`
- `node --import tsx --test app/test/queryQualityGates.test.ts app/test/largeSchemaBenchmark.test.ts` (5 passing)
- `npm run benchmark:large-schema` (all CI gates pass)
- `npm test` (248 passing)
- `npm run build`