### PR TITLE
Add versioned indexed RAG retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ RAG:
 - `POST /v1/rag/reindex?data_source_id=...`
 - RAG reindex also runs automatically after introspection, semantic changes, and saved feedback examples.
 - `/v1/query/sessions/{id}/run` uses retrieved RAG chunks in prompt context and returns `citations.rag_documents`.
-- Retrieval is hybrid: lexical token matching + embeddings + reranking.
+- Retrieval is hybrid: PostgreSQL GIN-indexed lexical candidate selection,
+  embeddings, and deterministic reranking. Candidate work is bounded and
+  filtered by datasource, current RAG schema version, and optional document
+  type; recent current-version documents provide a deterministic local
+  fallback when lexical search has too few matches.
 - Embeddings:
   - `RAG_EMBED_PROVIDER=auto|openai|gemini|local`
   - `RAG_EMBED_MODEL_OPENAI=text-embedding-3-small`

--- a/app/src/services/ragRetrieval.ts
+++ b/app/src/services/ragRetrieval.ts
@@ -16,6 +16,9 @@ export interface RagRetrievalDoc {
 
 export interface RetrieveRagContextOptions {
   limit?: number;
+  docTypes?: Array<"schema" | "semantic" | "example" | "policy">;
+  candidateLimit?: number;
+  fallbackLimit?: number;
 }
 
 export async function retrieveRagContext(
@@ -24,6 +27,9 @@ export async function retrieveRagContext(
   opts: RetrieveRagContextOptions = {}
 ): Promise<RagRetrievalDoc[]> {
   const limit = Number(opts.limit || 12);
+  const candidateLimit = positiveInteger(opts.candidateLimit, Math.max(64, limit * 8), 200);
+  const fallbackLimit = positiveInteger(opts.fallbackLimit, Math.max(16, limit * 2), 64);
+  const docTypes = normalizeDocTypes(opts.docTypes);
   const q = String(question || "").trim();
 
   if (!q) {
@@ -40,6 +46,45 @@ export async function retrieveRagContext(
     vector_json: number[] | null;
   }>(
     `
+      WITH current_index AS (
+        SELECT schema_version
+        FROM rag_index_state
+        WHERE data_source_id = $1
+      ),
+      query_terms AS (
+        SELECT websearch_to_tsquery('simple', $3) AS query
+      ),
+      lexical_candidates AS (
+        SELECT
+          rd.id,
+          ts_rank_cd(rd.search_vector, qt.query) AS lexical_rank
+        FROM rag_documents rd
+        JOIN current_index ci ON ci.schema_version = rd.schema_version
+        CROSS JOIN query_terms qt
+        WHERE rd.data_source_id = $1
+          AND ($4::text[] IS NULL OR rd.doc_type = ANY($4::text[]))
+          AND rd.search_vector @@ qt.query
+        ORDER BY lexical_rank DESC, rd.created_at DESC
+        LIMIT $5
+      ),
+      fallback_candidates AS (
+        SELECT rd.id, 0::real AS lexical_rank
+        FROM rag_documents rd
+        JOIN current_index ci ON ci.schema_version = rd.schema_version
+        WHERE rd.data_source_id = $1
+          AND ($4::text[] IS NULL OR rd.doc_type = ANY($4::text[]))
+        ORDER BY rd.created_at DESC
+        LIMIT $6
+      ),
+      candidates AS (
+        SELECT id, MAX(lexical_rank) AS lexical_rank
+        FROM (
+          SELECT * FROM lexical_candidates
+          UNION ALL
+          SELECT * FROM fallback_candidates
+        ) candidate_pool
+        GROUP BY id
+      )
       SELECT
         rd.id,
         rd.doc_type,
@@ -47,15 +92,15 @@ export async function retrieveRagContext(
         rd.content,
         rd.metadata_json,
         re.vector_json
-      FROM rag_documents rd
+      FROM candidates candidate
+      JOIN rag_documents rd ON rd.id = candidate.id
       LEFT JOIN rag_embeddings re
         ON re.rag_document_id = rd.id
        AND re.embedding_model = $2
-      WHERE rd.data_source_id = $1
-      ORDER BY rd.created_at DESC
-      LIMIT 400
+      ORDER BY candidate.lexical_rank DESC, rd.created_at DESC
+      LIMIT $7
     `,
-    [dataSourceId, embeddingModel]
+    [dataSourceId, embeddingModel, q, docTypes, candidateLimit, fallbackLimit, candidateLimit + fallbackLimit]
   );
 
   const tokens = tokenize(q);
@@ -90,6 +135,9 @@ async function selectEmbeddingModel(dataSourceId: string): Promise<string> {
       FROM rag_embeddings re
       JOIN rag_documents rd ON rd.id = re.rag_document_id
       WHERE rd.data_source_id = $1
+        AND rd.schema_version = (
+          SELECT schema_version FROM rag_index_state WHERE data_source_id = $1
+        )
       GROUP BY re.embedding_model
       ORDER BY doc_count DESC
       LIMIT 1
@@ -98,6 +146,17 @@ async function selectEmbeddingModel(dataSourceId: string): Promise<string> {
   );
 
   return result.rows[0]?.embedding_model || LOCAL_EMBEDDING_MODEL;
+}
+
+function normalizeDocTypes(value: RetrieveRagContextOptions["docTypes"]): string[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  return [...new Set(value)];
+}
+
+function positiveInteger(value: unknown, fallback: number, max: number): number {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) return Math.min(fallback, max);
+  return Math.min(number, max);
 }
 
 function tokenize(text: unknown): string[] {

--- a/app/src/services/ragService.ts
+++ b/app/src/services/ragService.ts
@@ -8,6 +8,7 @@ interface ReindexResult {
   data_source_id: string;
   documents_indexed: number;
   embedding_model: string;
+  schema_version: number;
 }
 
 async function reindexRagDocuments(dataSourceId: string): Promise<ReindexResult> {
@@ -16,7 +17,8 @@ async function reindexRagDocuments(dataSourceId: string): Promise<ReindexResult>
   const vectors = embedResponse.vectors || [];
   const embeddingModel = embedResponse.embeddingModel;
 
-  await appDb.withTransaction(async (client: PoolClient) => {
+  const schemaVersion = await appDb.withTransaction(async (client: PoolClient) => {
+    const nextVersion = await advanceRagSchemaVersion(client, dataSourceId);
     await client.query("DELETE FROM rag_documents WHERE data_source_id = $1", [dataSourceId]);
 
     for (let idx = 0; idx < docs.length; idx += 1) {
@@ -30,11 +32,12 @@ async function reindexRagDocuments(dataSourceId: string): Promise<ReindexResult>
             ref_id,
             content,
             metadata_json,
-            content_hash
-          ) VALUES ($1, $2, $3, $4, $5, $6)
+            content_hash,
+            schema_version
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7)
           RETURNING id
         `,
-        [dataSourceId, doc.docType, doc.refId, doc.content, JSON.stringify(doc.metadata || {}), contentHash]
+        [dataSourceId, doc.docType, doc.refId, doc.content, JSON.stringify(doc.metadata || {}), contentHash, nextVersion]
       );
 
       const ragDocumentId = insertResult.rows[0].id;
@@ -51,13 +54,30 @@ async function reindexRagDocuments(dataSourceId: string): Promise<ReindexResult>
         [ragDocumentId, embeddingModel, JSON.stringify(vector)]
       );
     }
+    return nextVersion;
   });
 
   return {
     data_source_id: dataSourceId,
     documents_indexed: docs.length,
-    embedding_model: embeddingModel
+    embedding_model: embeddingModel,
+    schema_version: schemaVersion
   };
+}
+
+async function advanceRagSchemaVersion(client: PoolClient, dataSourceId: string): Promise<number> {
+  const versionResult = await client.query<{ schema_version: number | string }>(
+    `
+      INSERT INTO rag_index_state (data_source_id, schema_version, updated_at)
+      VALUES ($1, 1, NOW())
+      ON CONFLICT (data_source_id) DO UPDATE
+        SET schema_version = rag_index_state.schema_version + 1,
+            updated_at = NOW()
+      RETURNING schema_version
+    `,
+    [dataSourceId]
+  );
+  return Number(versionResult.rows[0].schema_version);
 }
 
 function triggerRagReindexAsync(dataSourceId: string | null | undefined): void {
@@ -90,7 +110,8 @@ const moduleExports = {
   reindexRagDocuments,
   triggerRagReindexAsync,
   __private: {
-    buildRagDocuments
+    buildRagDocuments,
+    advanceRagSchemaVersion
   }
 };
 export = moduleExports;

--- a/app/src/types/openapi.ts
+++ b/app/src/types/openapi.ts
@@ -3946,7 +3946,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["JobAcceptedResponse"];
+                        "application/json": components["schemas"]["RagReindexResponse"];
                     };
                 };
             };
@@ -5163,6 +5163,15 @@ export interface components {
             job_id: string;
             /** @enum {string} */
             status: "queued";
+        };
+        RagReindexResponse: {
+            job_id: string;
+            /** @enum {string} */
+            status: "succeeded";
+            data_source_id: string;
+            documents_indexed: number;
+            embedding_model: string;
+            schema_version: number;
         };
         SchemaObject: {
             id: string;

--- a/app/test/ragNotesApi.test.ts
+++ b/app/test/ragNotesApi.test.ts
@@ -196,7 +196,8 @@ before(async () => {
     return {
       data_source_id: dataSourceId,
       documents_indexed: 0,
-      embedding_model: "test"
+      embedding_model: "test",
+      schema_version: 1
     };
   };
 

--- a/app/test/ragRetrieval.test.ts
+++ b/app/test/ragRetrieval.test.ts
@@ -1,0 +1,63 @@
+import "./helpers/setupEnv";
+import { after, before, test } from "node:test";
+import assert from "node:assert/strict";
+
+import appDb = require("../src/lib/appDb");
+import { retrieveRagContext } from "../src/services/ragRetrieval";
+
+let originalQuery: typeof appDb.query;
+let capturedSql = "";
+let capturedParams: unknown[] = [];
+
+before(() => {
+  originalQuery = appDb.query;
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
+    const normalized = sql.replace(/\s+/g, " ").trim().toLowerCase();
+    if (normalized.includes("group by re.embedding_model")) {
+      return { rowCount: 1, rows: [{ embedding_model: "local-hash-v1", doc_count: 2 }] };
+    }
+    capturedSql = normalized;
+    capturedParams = params;
+    return {
+      rowCount: 2,
+      rows: [
+        {
+          id: "doc-revenue",
+          doc_type: "schema",
+          ref_id: "table-revenue",
+          content: "schema object public.payment revenue amount",
+          metadata_json: {},
+          vector_json: null
+        },
+        {
+          id: "doc-recent",
+          doc_type: "schema",
+          ref_id: "table-recent",
+          content: "schema object public.inventory",
+          metadata_json: {},
+          vector_json: null
+        }
+      ]
+    };
+  }) as typeof appDb.query;
+});
+
+after(() => {
+  appDb.query = originalQuery;
+});
+
+test("retrieval uses the current version and indexed bounded candidates", async () => {
+  const docs = await retrieveRagContext("source-1", "total revenue", {
+    limit: 2,
+    docTypes: ["schema"],
+    candidateLimit: 25,
+    fallbackLimit: 5
+  });
+
+  assert.equal(docs[0].id, "doc-revenue");
+  assert.match(capturedSql, /websearch_to_tsquery\('simple', \$3\)/);
+  assert.match(capturedSql, /rd\.search_vector @@ qt\.query/);
+  assert.match(capturedSql, /ci\.schema_version = rd\.schema_version/);
+  assert.doesNotMatch(capturedSql, /limit 400/);
+  assert.deepEqual(capturedParams, ["source-1", "local-hash-v1", "total revenue", ["schema"], 25, 5, 30]);
+});

--- a/app/test/ragVersionInvalidation.test.ts
+++ b/app/test/ragVersionInvalidation.test.ts
@@ -1,0 +1,25 @@
+import "./helpers/setupEnv";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { PoolClient } from "pg";
+
+import ragService = require("../src/services/ragService");
+
+test("RAG reindex invalidation atomically advances the datasource schema version", async () => {
+  let sql = "";
+  let params: unknown[] = [];
+  const client = {
+    query: async (text: string, values: unknown[]) => {
+      sql = text.replace(/\s+/g, " ").trim().toLowerCase();
+      params = values;
+      return { rowCount: 1, rows: [{ schema_version: "7" }] };
+    }
+  } as unknown as PoolClient;
+
+  const version = await ragService.__private.advanceRagSchemaVersion(client, "source-1");
+
+  assert.equal(version, 7);
+  assert.match(sql, /on conflict \(data_source_id\) do update/);
+  assert.match(sql, /schema_version = rag_index_state\.schema_version \+ 1/);
+  assert.deepEqual(params, ["source-1"]);
+});

--- a/app/test/versionedRagSearchMigration.test.ts
+++ b/app/test/versionedRagSearchMigration.test.ts
@@ -1,0 +1,15 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "fs";
+import * as path from "path";
+
+test("0028 adds versioned GIN-indexed RAG retrieval storage", () => {
+  const migrationPath = path.resolve(__dirname, "../../db/migrations/0028_versioned_rag_search.sql");
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS rag_index_state/i);
+  assert.match(sql, /schema_version BIGINT NOT NULL/i);
+  assert.match(sql, /GENERATED ALWAYS AS \(to_tsvector\('simple', content\)\) STORED/i);
+  assert.match(sql, /USING GIN \(search_vector\)/i);
+  assert.match(sql, /data_source_id, schema_version, doc_type, created_at DESC/i);
+});

--- a/db/migrations/0028_versioned_rag_search.sql
+++ b/db/migrations/0028_versioned_rag_search.sql
@@ -1,0 +1,29 @@
+-- AIQ-007: versioned, indexed retrieval for large RAG corpora.
+
+CREATE TABLE IF NOT EXISTS rag_index_state (
+  data_source_id UUID PRIMARY KEY REFERENCES data_sources(id) ON DELETE CASCADE,
+  schema_version BIGINT NOT NULL DEFAULT 1 CHECK (schema_version > 0),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE rag_documents
+  ADD COLUMN IF NOT EXISTS schema_version BIGINT NOT NULL DEFAULT 1;
+
+ALTER TABLE rag_documents
+  ADD COLUMN IF NOT EXISTS search_vector TSVECTOR
+  GENERATED ALWAYS AS (to_tsvector('simple', content)) STORED;
+
+INSERT INTO rag_index_state (data_source_id, schema_version)
+SELECT DISTINCT data_source_id, COALESCE(MAX(schema_version), 1)
+FROM rag_documents
+GROUP BY data_source_id
+ON CONFLICT (data_source_id) DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS idx_rag_documents_search
+  ON rag_documents USING GIN (search_vector);
+
+CREATE INDEX IF NOT EXISTS idx_rag_documents_version_type_created
+  ON rag_documents (data_source_id, schema_version, doc_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_rag_embeddings_document_model
+  ON rag_embeddings (rag_document_id, embedding_model);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1952,7 +1952,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobAcceptedResponse"
+                $ref: "#/components/schemas/RagReindexResponse"
   /v1/rag/notes:
     get:
       tags: [Admin]
@@ -3775,6 +3775,23 @@ components:
           type: string
           enum: [queued]
       required: [job_id, status]
+    RagReindexResponse:
+      type: object
+      properties:
+        job_id:
+          type: string
+        status:
+          type: string
+          enum: [succeeded]
+        data_source_id:
+          type: string
+        documents_indexed:
+          type: integer
+        embedding_model:
+          type: string
+        schema_version:
+          type: integer
+      required: [job_id, status, data_source_id, documents_indexed, embedding_model, schema_version]
     SchemaObject:
       type: object
       properties:

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -3946,7 +3946,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["JobAcceptedResponse"];
+                        "application/json": components["schemas"]["RagReindexResponse"];
                     };
                 };
             };
@@ -5163,6 +5163,15 @@ export interface components {
             job_id: string;
             /** @enum {string} */
             status: "queued";
+        };
+        RagReindexResponse: {
+            job_id: string;
+            /** @enum {string} */
+            status: "succeeded";
+            data_source_id: string;
+            documents_indexed: number;
+            embedding_model: string;
+            schema_version: number;
         };
         SchemaObject: {
             id: string;


### PR DESCRIPTION
## Summary
- add datasource-scoped RAG schema versions and generated PostgreSQL search vectors
- index lexical search with GIN plus current-version/document-type lookup indexes
- replace the 400-document in-process scan with bounded indexed candidates and deterministic recent fallback
- retain embedding scoring and reranking behind the existing retrieval interface
- advance the schema version atomically on every reindex and return it from the reindex API
- align OpenAPI/backend/frontend response types and document retrieval behavior

Part of #181.

## Verification
- `npm run typecheck`
- focused RAG migration/retrieval/invalidation/API/context tests (10 passing)
- `npm test` (251 passing)
- `npm run build`
- `npm --prefix frontend run lint`
- `npm run benchmark:large-schema` (all gates pass)
- all migrations plus the exact indexed retrieval query executed successfully against fresh PostgreSQL 16