### PR TITLE
Cache versioned schema-linking artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ RAG:
   filtered by datasource, current RAG schema version, and optional document
   type; recent current-version documents provide a deterministic local
   fallback when lexical search has too few matches.
+- Table-card and schema-graph artifacts use a bounded in-memory cache keyed by
+  datasource and current RAG schema version. Reindex entrypoints invalidate all
+  artifact kinds immediately, and a completed reindex naturally moves reads to
+  the new version key.
 - Embeddings:
   - `RAG_EMBED_PROVIDER=auto|openai|gemini|local`
   - `RAG_EMBED_MODEL_OPENAI=text-embedding-3-small`

--- a/app/src/services/ragService.ts
+++ b/app/src/services/ragService.ts
@@ -3,6 +3,7 @@ import type { PoolClient } from "pg";
 import appDb = require("../lib/appDb");
 import { embedTextsForIndexing } from "./embeddingRouter";
 import { buildRagDocuments } from "./ragDocumentBuilder";
+import { invalidateSchemaArtifacts } from "./schemaArtifactCache";
 
 interface ReindexResult {
   data_source_id: string;
@@ -12,6 +13,7 @@ interface ReindexResult {
 }
 
 async function reindexRagDocuments(dataSourceId: string): Promise<ReindexResult> {
+  invalidateSchemaArtifacts(dataSourceId);
   const docs = await buildRagDocuments(dataSourceId);
   const embedResponse = await embedTextsForIndexing(docs.map((doc) => doc.content));
   const vectors = embedResponse.vectors || [];
@@ -84,6 +86,8 @@ function triggerRagReindexAsync(dataSourceId: string | null | undefined): void {
   if (!dataSourceId) {
     return;
   }
+
+  invalidateSchemaArtifacts(dataSourceId);
 
   setImmediate(() => {
     // Read through the export object so test monkey-patches of

--- a/app/src/services/schemaArtifactCache.ts
+++ b/app/src/services/schemaArtifactCache.ts
@@ -1,0 +1,71 @@
+import appDb = require("../lib/appDb");
+
+export type SchemaArtifactKind = "table_cards" | "schema_graph";
+
+interface CacheEntry {
+  dataSourceId: string;
+  value: Promise<unknown>;
+}
+
+const MAX_CACHE_ENTRIES = 128;
+const cache = new Map<string, CacheEntry>();
+
+export async function loadCurrentSchemaVersion(dataSourceId: string): Promise<number> {
+  const result = await appDb.query<{ schema_version: number | string }>(
+    "SELECT schema_version FROM rag_index_state WHERE data_source_id = $1",
+    [dataSourceId]
+  );
+  return Number(result.rows[0]?.schema_version || 0);
+}
+
+export async function getOrLoadSchemaArtifact<T>(
+  kind: SchemaArtifactKind,
+  dataSourceId: string,
+  schemaVersion: number,
+  loader: () => Promise<T>
+): Promise<T> {
+  const key = cacheKey(kind, dataSourceId, schemaVersion);
+  const existing = cache.get(key);
+  if (existing) {
+    cache.delete(key);
+    cache.set(key, existing);
+    return existing.value as Promise<T>;
+  }
+
+  const value = loader();
+  cache.set(key, { dataSourceId, value });
+  evictOldestEntries();
+  try {
+    return await value;
+  } catch (err) {
+    if (cache.get(key)?.value === value) cache.delete(key);
+    throw err;
+  }
+}
+
+export function invalidateSchemaArtifacts(dataSourceId: string): number {
+  let removed = 0;
+  for (const [key, entry] of cache) {
+    if (entry.dataSourceId === dataSourceId) {
+      cache.delete(key);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+export function clearSchemaArtifactCache(): void {
+  cache.clear();
+}
+
+function cacheKey(kind: SchemaArtifactKind, dataSourceId: string, schemaVersion: number): string {
+  return `${kind}:${dataSourceId}:${schemaVersion}`;
+}
+
+function evictOldestEntries(): void {
+  while (cache.size > MAX_CACHE_ENTRIES) {
+    const oldestKey = cache.keys().next().value as string | undefined;
+    if (!oldestKey) return;
+    cache.delete(oldestKey);
+  }
+}

--- a/app/src/services/schemaGraphService.ts
+++ b/app/src/services/schemaGraphService.ts
@@ -1,5 +1,6 @@
 import appDb = require("../lib/appDb");
 import { loadScopedQueryContext, type QueryContext } from "./queryOrchestrationStore";
+import { getOrLoadSchemaArtifact, loadCurrentSchemaVersion } from "./schemaArtifactCache";
 
 export interface SchemaGraphNode {
   id: string;
@@ -89,6 +90,11 @@ interface JoinPolicyRow {
 }
 
 export async function loadSchemaGraph(dataSourceId: string): Promise<SchemaGraph> {
+  const schemaVersion = await loadCurrentSchemaVersion(dataSourceId);
+  return getOrLoadSchemaArtifact("schema_graph", dataSourceId, schemaVersion, () => buildSchemaGraph(dataSourceId));
+}
+
+async function buildSchemaGraph(dataSourceId: string): Promise<SchemaGraph> {
   const [objectsResult, relationshipsResult, policiesResult] = await Promise.all([
     appDb.query<SchemaObjectRow>(
       `

--- a/app/src/services/schemaLinkingService.ts
+++ b/app/src/services/schemaLinkingService.ts
@@ -1,6 +1,7 @@
 import appDb = require("../lib/appDb");
 import ragRetrieval = require("./ragRetrieval");
 import type { RagRetrievalDoc } from "./ragRetrieval";
+import { getOrLoadSchemaArtifact, loadCurrentSchemaVersion } from "./schemaArtifactCache";
 
 const { retrieveRagContext } = ragRetrieval;
 
@@ -100,6 +101,11 @@ export async function retrieveTableCandidates(
 }
 
 export async function loadTableCards(dataSourceId: string): Promise<TableCard[]> {
+  const schemaVersion = await loadCurrentSchemaVersion(dataSourceId);
+  return getOrLoadSchemaArtifact("table_cards", dataSourceId, schemaVersion, () => buildTableCards(dataSourceId));
+}
+
+async function buildTableCards(dataSourceId: string): Promise<TableCard[]> {
   const [objectsResult, primaryKeysResult, relationshipsResult, semanticResult, synonymsResult, joinsResult] =
     await Promise.all([
       appDb.query<SchemaObjectRow>(

--- a/app/test/schemaArtifactCache.test.ts
+++ b/app/test/schemaArtifactCache.test.ts
@@ -1,0 +1,74 @@
+import "./helpers/setupEnv";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  clearSchemaArtifactCache,
+  getOrLoadSchemaArtifact,
+  invalidateSchemaArtifacts
+} from "../src/services/schemaArtifactCache";
+import ragService = require("../src/services/ragService");
+
+const DATA_SOURCE_ID = "00000000-0000-4000-8000-000000000111";
+
+test("schema artifacts are reused only within the same datasource version", async () => {
+  clearSchemaArtifactCache();
+  let loads = 0;
+  const load = async () => ({ load: ++loads });
+
+  const first = await getOrLoadSchemaArtifact("table_cards", DATA_SOURCE_ID, 1, load);
+  const cached = await getOrLoadSchemaArtifact("table_cards", DATA_SOURCE_ID, 1, load);
+  const nextVersion = await getOrLoadSchemaArtifact("table_cards", DATA_SOURCE_ID, 2, load);
+
+  assert.equal(first, cached);
+  assert.equal(first.load, 1);
+  assert.equal(nextVersion.load, 2);
+});
+
+test("explicit datasource invalidation removes all artifact kinds", async () => {
+  clearSchemaArtifactCache();
+  let loads = 0;
+  const load = async () => ({ load: ++loads });
+  await getOrLoadSchemaArtifact("table_cards", DATA_SOURCE_ID, 1, load);
+  await getOrLoadSchemaArtifact("schema_graph", DATA_SOURCE_ID, 1, load);
+
+  assert.equal(invalidateSchemaArtifacts(DATA_SOURCE_ID), 2);
+  const reloaded = await getOrLoadSchemaArtifact("table_cards", DATA_SOURCE_ID, 1, load);
+  assert.equal(reloaded.load, 3);
+});
+
+test("reindex triggers invalidate artifacts before background work starts", async () => {
+  clearSchemaArtifactCache();
+  let loads = 0;
+  const load = async () => ({ load: ++loads });
+  await getOrLoadSchemaArtifact("schema_graph", DATA_SOURCE_ID, 1, load);
+  const originalReindex = ragService.reindexRagDocuments;
+  ragService.reindexRagDocuments = async () => ({
+    data_source_id: DATA_SOURCE_ID,
+    documents_indexed: 0,
+    embedding_model: "test",
+    schema_version: 2
+  });
+
+  try {
+    ragService.triggerRagReindexAsync(DATA_SOURCE_ID);
+    const reloaded = await getOrLoadSchemaArtifact("schema_graph", DATA_SOURCE_ID, 1, load);
+    assert.equal(reloaded.load, 2);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  } finally {
+    ragService.reindexRagDocuments = originalReindex;
+  }
+});
+
+test("failed artifact loads are not cached", async () => {
+  clearSchemaArtifactCache();
+  let attempts = 0;
+  const load = async () => {
+    attempts += 1;
+    throw new Error("load failed");
+  };
+
+  await assert.rejects(getOrLoadSchemaArtifact("table_cards", DATA_SOURCE_ID, 1, load));
+  await assert.rejects(getOrLoadSchemaArtifact("table_cards", DATA_SOURCE_ID, 1, load));
+  assert.equal(attempts, 2);
+});

--- a/app/test/schemaGraphService.test.ts
+++ b/app/test/schemaGraphService.test.ts
@@ -12,6 +12,7 @@ import {
   type SchemaGraphEdge,
   type SchemaGraphNode
 } from "../src/services/schemaGraphService";
+import { clearSchemaArtifactCache } from "../src/services/schemaArtifactCache";
 
 const DATA_SOURCE_ID = "00000000-0000-4000-8000-000000000111";
 const A = "00000000-0000-4000-8000-000000000201";
@@ -107,9 +108,13 @@ test("expandSchemaGraph handles cycles without revisiting objects", () => {
 });
 
 test("loadExpandedSchemaContext loads full columns for core and connector tables", async () => {
+  clearSchemaArtifactCache();
   const scopedColumnCalls: unknown[][] = [];
   appDb.query = (async (sql: string, params: unknown[] = []) => {
     const normalized = normalizeSql(sql);
+    if (normalized.includes("from rag_index_state")) {
+      return result([{ schema_version: 1 }]);
+    }
     if (normalized.includes("from schema_objects") && normalized.includes("object_type in")) {
       return result([
         { id: A, schema_name: "public", object_name: "payment", object_type: "table" },

--- a/app/test/schemaLinkingService.test.ts
+++ b/app/test/schemaLinkingService.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../src/services/schemaLinkingService";
 import { loadScopedQueryContext } from "../src/services/queryOrchestrationStore";
 import type { RagRetrievalDoc } from "../src/services/ragRetrieval";
+import { clearSchemaArtifactCache } from "../src/services/schemaArtifactCache";
 
 const DATA_SOURCE_ID = "00000000-0000-4000-8000-000000000111";
 const PAYMENT_ID = "00000000-0000-4000-8000-000000000201";
@@ -66,8 +67,12 @@ test("rankTableCards returns no weak fill candidates for an empty or unmatched q
 });
 
 test("loadTableCards retains keys, both relationship directions, aliases, synonyms, and approved endpoints", async () => {
+  clearSchemaArtifactCache();
   appDb.query = (async (sql: string) => {
     const normalized = normalizeSql(sql);
+    if (normalized.includes("from rag_index_state")) {
+      return result([{ schema_version: 1 }]);
+    }
     if (normalized.includes("from schema_objects") && normalized.includes("object_type in")) {
       return result([
         {


### PR DESCRIPTION
## Summary
- add a bounded LRU-style cache for schema-linking artifacts keyed by datasource and persisted RAG schema version
- coalesce concurrent table-card and schema-graph loads and evict failed loads
- reuse table cards and schema graphs only within the same version
- invalidate every artifact kind immediately at manual and background reindex entrypoints
- document cache/version behavior and cover version changes, explicit invalidation, trigger invalidation, and failed loads

Part of #181.

## Verification
- `npm run typecheck`
- focused cache/schema-linking/schema-graph/RAG tests (20 passing)
- `npm test` (255 passing)
- `npm run build`
- `npm run benchmark:large-schema` (all gates pass)