### PR TITLE
Rank validated schema-compatible SQL examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ RAG:
   datasource and current RAG schema version. Reindex entrypoints invalidate all
   artifact kinds immediately, and a completed reindex naturally moves reads to
   the new version key.
+- Few-shot examples are validated against the current datasource schema during
+  reindexing. Prompt selection excludes stale, unsafe, schema-incompatible, and
+  low-quality feedback examples, removes near duplicates, and enforces count
+  and character budgets. Query diagnostics report the selected example count,
+  and MVP benchmark reports stratify accuracy and repair rate by example usage.
 - Embeddings:
   - `RAG_EMBED_PROVIDER=auto|openai|gemini|local`
   - `RAG_EMBED_MODEL_OPENAI=text-embedding-3-small`

--- a/app/src/benchmark/runMvpBenchmark.ts
+++ b/app/src/benchmark/runMvpBenchmark.ts
@@ -77,6 +77,7 @@ interface CaseResult {
   join_path_correct?: boolean | null;
   repair_count?: number;
   prompt_chars?: number | null;
+  example_count?: number;
 }
 
 interface RunContext {
@@ -223,6 +224,7 @@ interface RunResponse {
       join_edges?: Array<{ id?: string; left_ref?: string; right_ref?: string }>;
     };
     prompts?: { total_chars?: number };
+    retrieval?: { rag_document_count?: number; example_count?: number };
     repair_count?: number;
   };
 }
@@ -244,7 +246,8 @@ async function runCase(caseDef: BenchmarkCase, context: RunContext): Promise<Cas
     table_recall_at_15: null,
     join_path_correct: null,
     repair_count: 0,
-    prompt_chars: null
+    prompt_chars: null,
+    example_count: 0
   } as const;
   const sessionResponse = await requestJson<SessionResponse>("POST", "/v1/query/sessions", {
     data_source_id: context.dataSourceId,
@@ -355,7 +358,7 @@ async function runCase(caseDef: BenchmarkCase, context: RunContext): Promise<Cas
 function evaluateGenerationDiagnostics(
   expectedTables: string[],
   diagnostics: RunResponse["diagnostics"]
-): Pick<CaseResult, "table_recall_at_15" | "join_path_correct" | "repair_count" | "prompt_chars"> {
+): Pick<CaseResult, "table_recall_at_15" | "join_path_correct" | "repair_count" | "prompt_chars" | "example_count"> {
   const linking = diagnostics?.schema_linking;
   const candidateRefs = new Set((linking?.candidate_tables || []).map((table) => normalizeTableRef(table.ref)));
   const expandedRefs = new Set((linking?.expanded_tables || []).map((table) => normalizeTableRef(table.ref)));
@@ -375,7 +378,8 @@ function evaluateGenerationDiagnostics(
     repair_count: Math.max(0, Number(diagnostics?.repair_count || 0)),
     prompt_chars: Number.isFinite(Number(diagnostics?.prompts?.total_chars))
       ? Number(diagnostics?.prompts?.total_chars)
-      : null
+      : null,
+    example_count: Math.max(0, Number(diagnostics?.retrieval?.example_count || 0))
   };
 }
 
@@ -548,6 +552,7 @@ interface BenchmarkSummary {
   stratified: {
     by_schema_size: Record<string, BenchmarkSliceSummary>;
     by_complexity: Record<string, BenchmarkSliceSummary>;
+    by_example_usage: Record<string, BenchmarkSliceSummary>;
   };
   release_gates: {
     correctness_ge_85pct: boolean;
@@ -630,7 +635,8 @@ function summarizeResults(results: CaseResult[], largeSchema: LargeSchemaBenchma
     average_prompt_chars: promptCharValues.length > 0 ? Math.round(average(promptCharValues)) : null,
     stratified: {
       by_schema_size: stratifyResults(results, (item) => item.schema_size_bucket || "unknown"),
-      by_complexity: stratifyResults(results, (item) => item.complexity || "unknown")
+      by_complexity: stratifyResults(results, (item) => item.complexity || "unknown"),
+      by_example_usage: stratifyResults(results, (item) => Number(item.example_count || 0) > 0 ? "with_examples" : "without_examples")
     },
     release_gates: {
       ...gates,

--- a/app/src/services/exampleRankingService.ts
+++ b/app/src/services/exampleRankingService.ts
@@ -1,0 +1,127 @@
+import type { RagRetrievalDoc } from "./ragRetrieval";
+
+export interface RankValidatedExamplesOptions {
+  selectedSchemaRefs: Iterable<string>;
+  maxExamples?: number;
+  maxChars?: number;
+  minManualQuality?: number;
+  minFeedbackQuality?: number;
+}
+
+interface RankedExample {
+  document: RagRetrievalDoc;
+  score: number;
+  quality: number;
+  source: string;
+}
+
+const DEFAULT_MAX_EXAMPLES = 4;
+const DEFAULT_MAX_CHARS = 6_000;
+const DEFAULT_MIN_MANUAL_QUALITY = 0.5;
+const DEFAULT_MIN_FEEDBACK_QUALITY = 0.8;
+
+export function rankValidatedExamples(
+  documents: RagRetrievalDoc[],
+  options: RankValidatedExamplesOptions
+): RagRetrievalDoc[] {
+  const selectedRefs = new Set(
+    [...options.selectedSchemaRefs].map(normalizeRef).filter(Boolean)
+  );
+  const maxExamples = positiveInteger(options.maxExamples, DEFAULT_MAX_EXAMPLES);
+  const maxChars = positiveInteger(options.maxChars, DEFAULT_MAX_CHARS);
+  const minManualQuality = boundedScore(options.minManualQuality, DEFAULT_MIN_MANUAL_QUALITY);
+  const minFeedbackQuality = boundedScore(options.minFeedbackQuality, DEFAULT_MIN_FEEDBACK_QUALITY);
+
+  const candidates = documents
+    .filter((document) => document.doc_type === "example")
+    .map((document) => toRankedExample(document, selectedRefs))
+    .filter((candidate): candidate is RankedExample => candidate !== null)
+    .filter((candidate) => candidate.quality >= (
+      candidate.source === "feedback" ? minFeedbackQuality : minManualQuality
+    ))
+    .sort(compareExamples);
+
+  const selected: RankedExample[] = [];
+  let usedChars = 0;
+  for (const candidate of candidates) {
+    if (selected.length >= maxExamples) break;
+    if (usedChars + candidate.document.content.length > maxChars) continue;
+    if (selected.some((existing) => nearDuplicate(existing.document, candidate.document))) continue;
+
+    selected.push(candidate);
+    usedChars += candidate.document.content.length;
+  }
+
+  return selected.map(({ document, score }) => ({
+    ...document,
+    rerank_score: score
+  }));
+}
+
+function toRankedExample(document: RagRetrievalDoc, selectedRefs: Set<string>): RankedExample | null {
+  const metadata = document.metadata_json;
+  if (!metadata || metadata.validation_state !== "validated") return null;
+
+  const schemaRefs = Array.isArray(metadata.schema_refs)
+    ? metadata.schema_refs.map(normalizeRef).filter(Boolean)
+    : [];
+  if (schemaRefs.length === 0 || schemaRefs.some((ref) => !selectedRefs.has(ref))) return null;
+
+  if (metadata.source !== "manual" && metadata.source !== "feedback") return null;
+  const source = metadata.source;
+  const quality = boundedScore(metadata.quality_score, source === "manual" ? 0.75 : 0);
+  const relevance = finiteNumber(document.rerank_score, finiteNumber(document.score, 0));
+  const sourceBoost = source === "manual" ? 0.5 : 0;
+  const score = Number((relevance + (quality * 2) + sourceBoost).toFixed(4));
+  return { document, score, quality, source };
+}
+
+function compareExamples(left: RankedExample, right: RankedExample): number {
+  return right.score - left.score
+    || right.quality - left.quality
+    || left.source.localeCompare(right.source)
+    || left.document.id.localeCompare(right.document.id);
+}
+
+function nearDuplicate(left: RagRetrievalDoc, right: RagRetrievalDoc): boolean {
+  const leftSql = normalizedSql(left.content);
+  const rightSql = normalizedSql(right.content);
+  if (leftSql && leftSql === rightSql) return true;
+
+  const leftTokens = tokenSet(left.content);
+  const rightTokens = tokenSet(right.content);
+  if (leftTokens.size === 0 || rightTokens.size === 0) return false;
+  const intersection = [...leftTokens].filter((token) => rightTokens.has(token)).length;
+  const union = new Set([...leftTokens, ...rightTokens]).size;
+  return intersection / union >= 0.92;
+}
+
+function normalizedSql(content: string): string {
+  const marker = "example sql ";
+  const start = content.toLowerCase().indexOf(marker);
+  if (start < 0) return "";
+  return content.slice(start + marker.length).toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function tokenSet(value: string): Set<string> {
+  return new Set(value.toLowerCase().match(/[a-z0-9_]+/g) || []);
+}
+
+function normalizeRef(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : fallback;
+}
+
+function boundedScore(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.min(1, Math.max(0, value))
+    : fallback;
+}
+
+function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}

--- a/app/src/services/queryDiagnosticsService.ts
+++ b/app/src/services/queryDiagnosticsService.ts
@@ -16,6 +16,7 @@ export interface QueryDiagnosticInput {
   schemaLinking: SchemaLinkingDiagnostics | null;
   expandedTableIds: string[];
   ragDocumentCount: number;
+  ragExampleCount: number;
   provider: string;
   model: string | null;
   providerAttempts: ProviderAttempt[];
@@ -46,7 +47,7 @@ export interface QueryDiagnosticPayload {
     fallback_used: boolean;
     fallback_category: "none" | "no_provider" | "provider_failure";
   } | null;
-  retrieval: { rag_document_count: number };
+  retrieval: { rag_document_count: number; example_count: number };
   generation: {
     provider: string;
     model: string | null;
@@ -115,7 +116,8 @@ export function buildQueryDiagnostic(input: QueryDiagnosticInput): QueryDiagnost
         : linkerAttempts.length === 0 ? "no_provider" : "provider_failure"
     } : null,
     retrieval: {
-      rag_document_count: Math.max(0, Math.floor(input.ragDocumentCount))
+      rag_document_count: Math.max(0, Math.floor(input.ragDocumentCount)),
+      example_count: Math.max(0, Math.floor(input.ragExampleCount))
     },
     generation: {
       provider: boundedLabel(input.provider, 64),

--- a/app/src/services/queryGenerationContextService.ts
+++ b/app/src/services/queryGenerationContextService.ts
@@ -13,6 +13,7 @@ import {
 } from "./schemaGraphService";
 import type { QueryContext } from "./queryOrchestrationStore";
 import type { RagRetrievalDoc } from "./ragRetrieval";
+import { rankValidatedExamples } from "./exampleRankingService";
 
 const { retrieveRagContext } = ragRetrieval;
 
@@ -137,9 +138,21 @@ function selectFinalRagDocuments(
   limit: number
 ): RagRetrievalDoc[] {
   const selectedIds = new Set(expanded.expansion.object_ids);
+  const selectedSchemaRefs = expanded.context?.schemaObjects.map(
+    (object) => `${object.schema_name}.${object.object_name}`
+  ) || [];
   const relevantSchema = documents.filter((doc) => doc.doc_type === "schema" && selectedIds.has(String(doc.ref_id)));
-  const supporting = documents.filter((doc) => doc.doc_type !== "schema");
-  return uniqueDocuments([...relevantSchema, ...supporting]).slice(0, limit);
+  const examples = rankValidatedExamples(documents, {
+    selectedSchemaRefs,
+    maxExamples: Math.min(4, Math.max(1, Math.floor(limit / 3)))
+  });
+  const supporting = documents.filter((doc) => doc.doc_type !== "schema" && doc.doc_type !== "example");
+  const schemaLimit = Math.max(0, limit - examples.length);
+  return uniqueDocuments([
+    ...relevantSchema.slice(0, schemaLimit),
+    ...examples,
+    ...supporting
+  ]).slice(0, limit);
 }
 
 function summarizeCandidates(candidates: TableCandidate[]): SchemaLinkingDiagnostics["candidates"] {

--- a/app/src/services/queryOrchestrationService.ts
+++ b/app/src/services/queryOrchestrationService.ts
@@ -95,7 +95,8 @@ function buildResponseDiagnostics(
   context: QueryContext,
   schemaLinking: SchemaLinkingDiagnostics | null,
   generationPromptChars: number,
-  repairs: Array<{ prompt_chars: number }>
+  repairs: Array<{ prompt_chars: number }>,
+  ragDocuments: RagRetrievalDoc[]
 ): Record<string, unknown> {
   const linker = schemaLinking?.linker;
   const expansion = schemaLinking?.expansion;
@@ -123,6 +124,10 @@ function buildResponseDiagnostics(
       generation_chars: generationPromptChars,
       repair_chars: repairPromptChars,
       total_chars: (linker?.prompt_chars || 0) + generationPromptChars + repairPromptChars
+    },
+    retrieval: {
+      rag_document_count: ragDocuments.length,
+      example_count: ragDocuments.filter((document) => document.doc_type === "example").length
     },
     repair_count: repairs.length
   };
@@ -222,6 +227,7 @@ export async function orchestrateQueryRun({
       schemaLinking,
       expandedTableIds,
       ragDocumentCount: ragDocuments.length,
+      ragExampleCount: ragDocuments.filter((document) => document.doc_type === "example").length,
       provider: usedProvider,
       model: usedModel,
       providerAttempts: generationAttempts,
@@ -575,7 +581,7 @@ export async function orchestrateQueryRun({
 
     validationJson.citations = citations;
     validationJson.confidence = confidence;
-    const diagnostics = buildResponseDiagnostics(context, schemaLinking, generationPromptChars, repairs);
+    const diagnostics = buildResponseDiagnostics(context, schemaLinking, generationPromptChars, repairs, ragDocuments);
 
     const attemptId = await insertQueryAttempt({
       sessionId,

--- a/app/src/services/ragDocumentBuilder.ts
+++ b/app/src/services/ragDocumentBuilder.ts
@@ -1,4 +1,6 @@
 import appDb = require("../lib/appDb");
+import { validateAstReadOnly } from "./sqlAstValidator";
+import type { SqlDialect } from "./sqlGenerator";
 
 export interface RagDocument {
   docType: "schema" | "semantic" | "policy" | "example";
@@ -67,6 +69,10 @@ interface NlSqlExampleRow {
   source: string | null;
 }
 
+interface DataSourceRow {
+  db_type: string;
+}
+
 interface RagNoteRow {
   id: string;
   title: string;
@@ -82,7 +88,8 @@ export async function buildRagDocuments(dataSourceId: string): Promise<RagDocume
     metricDefinitionsResult,
     joinPoliciesResult,
     examplesResult,
-    ragNotesResult
+    ragNotesResult,
+    dataSourceResult
   ] = await Promise.all([
     appDb.query<SchemaObjectRow>(
       `
@@ -174,6 +181,10 @@ export async function buildRagDocuments(dataSourceId: string): Promise<RagDocume
         WHERE data_source_id = $1 AND active = TRUE
         ORDER BY created_at DESC
       `,
+      [dataSourceId]
+    ),
+    appDb.query<DataSourceRow>(
+      "SELECT db_type FROM data_sources WHERE id = $1",
       [dataSourceId]
     )
   ]);
@@ -275,12 +286,19 @@ export async function buildRagDocuments(dataSourceId: string): Promise<RagDocume
   }
 
   for (const example of examplesResult.rows) {
+    const validation = validateAstReadOnly(
+      example.sql,
+      schemaObjectsResult.rows,
+      normalizeDialect(dataSourceResult.rows[0]?.db_type)
+    );
     docs.push({
       docType: "example",
       refId: String(example.id),
       metadata: {
         source: example.source,
-        quality_score: example.quality_score
+        quality_score: example.quality_score,
+        validation_state: validation.ok && validation.refs.length > 0 ? "validated" : "rejected",
+        schema_refs: [...new Set(validation.refs.map((ref) => ref.raw))].sort()
       },
       content: [
         `example question ${example.question}`,
@@ -302,6 +320,10 @@ export async function buildRagDocuments(dataSourceId: string): Promise<RagDocume
   }
 
   return docs;
+}
+
+function normalizeDialect(dbType: string | null | undefined): SqlDialect {
+  return String(dbType || "postgres").toLowerCase() === "mssql" ? "mssql" : "postgres";
 }
 
 function groupBy<T>(rows: T[], keyFn: (row: T) => string): Map<string, T[]> {

--- a/app/src/types/openapi.ts
+++ b/app/src/types/openapi.ts
@@ -5126,6 +5126,11 @@ export interface components {
                 repair_chars: number;
                 total_chars: number;
             };
+            retrieval: {
+                rag_document_count: number;
+                /** @description Number of validated, schema-compatible examples included in the generation prompt. */
+                example_count: number;
+            };
             repair_count: number;
         };
         FeedbackRequest: {

--- a/app/test/exampleRankingService.test.ts
+++ b/app/test/exampleRankingService.test.ts
@@ -1,0 +1,78 @@
+import "./helpers/setupEnv";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { rankValidatedExamples } from "../src/services/exampleRankingService";
+import type { RagRetrievalDoc } from "../src/services/ragRetrieval";
+
+test("ranking excludes unvalidated, incompatible, and low-quality feedback examples", () => {
+  const documents = [
+    example("manual", "manual", 0.7, ["public.payment"], 1),
+    example("feedback-good", "feedback", 1, ["public.payment"], 1),
+    example("feedback-low", "feedback", 0.4, ["public.payment"], 20),
+    example("wrong-schema", "manual", 1, ["public.inventory"], 20),
+    example("rejected", "manual", 1, ["public.payment"], 20, "rejected"),
+    {
+      ...example("unknown-source", "manual", 1, ["public.payment"], 20),
+      metadata_json: {
+        source: "imported",
+        quality_score: 1,
+        validation_state: "validated",
+        schema_refs: ["public.payment"]
+      }
+    }
+  ];
+
+  const ranked = rankValidatedExamples(documents, {
+    selectedSchemaRefs: ["PUBLIC.PAYMENT"]
+  });
+
+  assert.deepEqual(ranked.map((document) => document.id), ["feedback-good", "manual"]);
+});
+
+test("ranking is deterministic, removes near duplicates, and enforces count and character budgets", () => {
+  const duplicate = example("duplicate", "feedback", 1, ["public.payment"], 30);
+  duplicate.content = "example question Revenue by day\nexample sql SELECT day, SUM(amount) FROM public.payment GROUP BY day";
+  const original = example("original", "manual", 1, ["public.payment"], 30);
+  original.content = "example question Daily revenue\nexample sql SELECT day, SUM(amount) FROM public.payment GROUP BY day";
+  const second = example("second", "manual", 0.9, ["public.payment"], 20);
+  const tooLarge = example("too-large", "manual", 1, ["public.payment"], 100);
+  tooLarge.content = "x".repeat(500);
+
+  const options = {
+    selectedSchemaRefs: ["public.payment"],
+    maxExamples: 2,
+    maxChars: original.content.length + second.content.length
+  };
+  const first = rankValidatedExamples([second, duplicate, tooLarge, original], options);
+  const secondRun = rankValidatedExamples([original, tooLarge, duplicate, second], options);
+
+  assert.deepEqual(first.map((document) => document.id), ["original", "second"]);
+  assert.deepEqual(secondRun.map((document) => document.id), ["original", "second"]);
+});
+
+function example(
+  id: string,
+  source: "manual" | "feedback",
+  quality: number,
+  schemaRefs: string[],
+  relevance: number,
+  validationState: "validated" | "rejected" = "validated"
+): RagRetrievalDoc {
+  return {
+    id,
+    doc_type: "example",
+    ref_id: id,
+    content: `example question ${id}\nexample sql SELECT amount FROM public.payment WHERE id = '${id}'`,
+    metadata_json: {
+      source,
+      quality_score: quality,
+      validation_state: validationState,
+      schema_refs: schemaRefs
+    },
+    vector_json: null,
+    score: relevance,
+    rerank_score: relevance,
+    embedding_model: "test"
+  };
+}

--- a/app/test/queryDiagnosticsService.test.ts
+++ b/app/test/queryDiagnosticsService.test.ts
@@ -29,6 +29,7 @@ test("query diagnostics are bounded, correlated, and exclude sensitive content",
     },
     expandedTableIds: ids,
     ragDocumentCount: 12,
+    ragExampleCount: 3,
     provider: "local-fallback",
     model: "rule-based-v0",
     providerAttempts: Array.from({ length: 10 }, () => ({
@@ -55,6 +56,7 @@ test("query diagnostics are bounded, correlated, and exclude sensitive content",
   assert.equal(payload.schema_linking?.candidate_table_ids.length, 20);
   assert.equal(payload.generation.attempts.length, 8);
   assert.equal(payload.generation.attempts_truncated, true);
+  assert.deepEqual(payload.retrieval, { rag_document_count: 12, example_count: 3 });
   assert.deepEqual(payload.generation.token_usage, { prompt_tokens: 18, completion_tokens: 9, total_tokens: 27 });
   const serialized = JSON.stringify(payload);
   assert.doesNotMatch(serialized, /secret/);

--- a/app/test/queryGenerationContextService.test.ts
+++ b/app/test/queryGenerationContextService.test.ts
@@ -34,6 +34,32 @@ test("prepareQueryGenerationContext returns only expanded scoped context and rel
   }
 });
 
+test("prepareQueryGenerationContext reserves prompt space for compatible ranked examples", async () => {
+  const payment = card(PAYMENT, "payment", ["Revenue"]);
+  const docs = [
+    rag("payment-doc", "schema", PAYMENT, 2),
+    exampleRag("compatible", "public.payment", 0.9),
+    exampleRag("incompatible", "public.inventory", 1),
+    rag("policy-doc", "policy", "note", 0.8)
+  ];
+  const dependencies = baseDependencies([payment], docs);
+
+  const result = await prepareQueryGenerationContext({
+    dataSourceId: "source",
+    question: "Total revenue",
+    finalRagLimit: 3
+  }, dependencies);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.deepEqual(result.ragDocuments.map((document) => document.id), [
+      "payment-doc",
+      "compatible",
+      "policy-doc"
+    ]);
+  }
+});
+
 test("prepareQueryGenerationContext fails before the linker when no candidates match", async () => {
   let linkerCalled = false;
   const dependencies = baseDependencies([card(PAYMENT, "payment")], []);
@@ -153,5 +179,18 @@ function rag(id: string, docType: string, refId: string, score: number): RagRetr
     score,
     rerank_score: score,
     embedding_model: "test"
+  };
+}
+
+function exampleRag(id: string, schemaRef: string, quality: number): RagRetrievalDoc {
+  return {
+    ...rag(id, "example", id, 1),
+    content: `example question Revenue\nexample sql SELECT amount FROM ${schemaRef}`,
+    metadata_json: {
+      source: "manual",
+      quality_score: quality,
+      validation_state: "validated",
+      schema_refs: [schemaRef]
+    }
   };
 }

--- a/app/test/ragService.test.ts
+++ b/app/test/ragService.test.ts
@@ -49,3 +49,70 @@ test("buildRagDocuments includes active rag_notes as policy documents", async ()
     appDb.query = originalQuery;
   }
 });
+
+test("buildRagDocuments records current-schema validation metadata for examples", async () => {
+  const dataSourceId = "00000000-0000-4000-8000-000000000333";
+  const originalQuery = appDb.query;
+
+  appDb.query = (async (sql: string) => {
+    const normalized = String(sql).replace(/\s+/g, " ").trim().toLowerCase();
+    if (normalized.includes("from schema_objects") && !normalized.includes("join")) {
+      return {
+        rowCount: 1,
+        rows: [{
+          id: "table-payment",
+          object_type: "table",
+          schema_name: "public",
+          object_name: "payment",
+          description: null
+        }]
+      };
+    }
+    if (normalized.includes("from nl_sql_examples")) {
+      return {
+        rowCount: 2,
+        rows: [
+          {
+            id: "valid-example",
+            question: "Total payments",
+            sql: "SELECT SUM(amount) FROM public.payment",
+            quality_score: 0.9,
+            source: "manual"
+          },
+          {
+            id: "stale-example",
+            question: "Inventory",
+            sql: "SELECT * FROM public.inventory",
+            quality_score: 1,
+            source: "manual"
+          }
+        ]
+      };
+    }
+    if (normalized === "select db_type from data_sources where id = $1") {
+      return { rowCount: 1, rows: [{ db_type: "postgres" }] };
+    }
+    return { rowCount: 0, rows: [] };
+  }) as unknown as typeof appDb.query;
+
+  try {
+    const docs = await __private.buildRagDocuments(dataSourceId);
+    const valid = docs.find((document) => document.refId === "valid-example");
+    const stale = docs.find((document) => document.refId === "stale-example");
+
+    assert.deepEqual(valid?.metadata, {
+      source: "manual",
+      quality_score: 0.9,
+      validation_state: "validated",
+      schema_refs: ["public.payment"]
+    });
+    assert.deepEqual(stale?.metadata, {
+      source: "manual",
+      quality_score: 1,
+      validation_state: "rejected",
+      schema_refs: ["public.inventory"]
+    });
+  } finally {
+    appDb.query = originalQuery;
+  }
+});

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3697,11 +3697,22 @@ components:
             total_chars:
               type: integer
           required: [linker_chars, generation_chars, repair_chars, total_chars]
+        retrieval:
+          type: object
+          properties:
+            rag_document_count:
+              type: integer
+              minimum: 0
+            example_count:
+              type: integer
+              minimum: 0
+              description: Number of validated, schema-compatible examples included in the generation prompt.
+          required: [rag_document_count, example_count]
         repair_count:
           type: integer
           minimum: 0
           maximum: 1
-      required: [schema_linking, prompts, repair_count]
+      required: [schema_linking, prompts, retrieval, repair_count]
     FeedbackRequest:
       type: object
       properties:

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -5126,6 +5126,11 @@ export interface components {
                 repair_chars: number;
                 total_chars: number;
             };
+            retrieval: {
+                rag_document_count: number;
+                /** @description Number of validated, schema-compatible examples included in the generation prompt. */
+                example_count: number;
+            };
             repair_count: number;
         };
         FeedbackRequest: {


### PR DESCRIPTION
## Summary

- validate indexed NL/SQL examples against the current datasource schema and dialect
- rank only schema-compatible examples with deterministic quality and trust safeguards
- deduplicate near-identical examples and bound prompt count and character cost
- expose selected-example counts in query diagnostics and stratify MVP benchmark results by example usage
- keep OpenAPI and frontend bindings aligned

Closes #183

## Verification

- `npm run typecheck`
- `npm test` (259 tests)
- `npm --prefix frontend run lint`
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)