### PR TITLE
Return structured query clarification options

### DIFF
--- a/app/src/services/queryClarificationService.ts
+++ b/app/src/services/queryClarificationService.ts
@@ -1,0 +1,81 @@
+import { createHash } from "crypto";
+import type { SchemaExpansion, SchemaGraphEdge, SchemaPath } from "./schemaGraphService";
+
+export interface QueryClarificationOption {
+  id: string;
+  label: string;
+  description: string;
+  table_refs: string[];
+}
+
+export interface QueryClarification {
+  kind: "join_path";
+  message: string;
+  options: QueryClarificationOption[];
+}
+
+export function buildJoinPathClarification(expansion: SchemaExpansion): QueryClarification | null {
+  if (expansion.status !== "ambiguous") return null;
+
+  const paths = expansion.ambiguities
+    .flatMap((ambiguity) => ambiguity.alternatives)
+    .sort((left, right) => pathSignature(left).localeCompare(pathSignature(right)));
+  const unique = uniquePaths(paths).slice(0, 8);
+  const options = unique.map((path, index) => toOption(path, index, unique.length));
+  if (options.length < 2) return null;
+
+  return {
+    kind: "join_path",
+    message: "Multiple valid join paths were found. Choose the relationship that matches your reporting intent.",
+    options
+  };
+}
+
+function toOption(path: SchemaPath, index: number, total: number): QueryClarificationOption {
+  const tableRefs = path.object_ids
+    .map((objectId) => refForObject(path.edges, objectId))
+    .filter((ref): ref is string => Boolean(ref));
+  const connectors = tableRefs.slice(1, -1);
+  const sourceLabel = path.edges.every((edge) => edge.source === "approved_policy")
+    ? "approved join policy"
+    : "schema relationship";
+  const baseLabel = connectors.length > 0
+    ? `Join through ${connectors.join(" → ")}`
+    : `Use ${sourceLabel}`;
+  const label = total > 1 && duplicateLabelRisk(path)
+    ? `${baseLabel} (option ${index + 1})`
+    : baseLabel;
+
+  return {
+    id: `join_path_${createHash("sha256").update(pathSignature(path)).digest("hex").slice(0, 12)}`,
+    label,
+    description: `Uses ${path.edges.length} ${path.edges.length === 1 ? "relationship" : "relationships"} across ${tableRefs.join(", ")}.`,
+    table_refs: tableRefs
+  };
+}
+
+function duplicateLabelRisk(path: SchemaPath): boolean {
+  return path.object_ids.length <= 2;
+}
+
+function refForObject(edges: SchemaGraphEdge[], objectId: string): string | null {
+  for (const edge of edges) {
+    if (edge.left_object_id === objectId) return edge.left_ref;
+    if (edge.right_object_id === objectId) return edge.right_ref;
+  }
+  return null;
+}
+
+function uniquePaths(paths: SchemaPath[]): SchemaPath[] {
+  const seen = new Set<string>();
+  return paths.filter((path) => {
+    const signature = pathSignature(path);
+    if (seen.has(signature)) return false;
+    seen.add(signature);
+    return true;
+  });
+}
+
+function pathSignature(path: SchemaPath): string {
+  return `${path.object_ids.join(">")}|${path.edge_ids.join(">")}`;
+}

--- a/app/src/services/queryDiagnosticsService.ts
+++ b/app/src/services/queryDiagnosticsService.ts
@@ -46,6 +46,8 @@ export interface QueryDiagnosticPayload {
     linker_status: string;
     fallback_used: boolean;
     fallback_category: "none" | "no_provider" | "provider_failure";
+    clarification_required: boolean;
+    clarification_option_count: number;
   } | null;
   retrieval: { rag_document_count: number; example_count: number };
   generation: {
@@ -113,7 +115,10 @@ export function buildQueryDiagnostic(input: QueryDiagnosticInput): QueryDiagnost
       fallback_used: linker?.status === "fallback",
       fallback_category: linker?.status !== "fallback"
         ? "none"
-        : linkerAttempts.length === 0 ? "no_provider" : "provider_failure"
+        : linkerAttempts.length === 0 ? "no_provider" : "provider_failure",
+      clarification_required: expansion?.status === "ambiguous",
+      clarification_option_count: (expansion?.ambiguities || [])
+        .reduce((total, ambiguity) => total + ambiguity.alternatives.length, 0)
     } : null,
     retrieval: {
       rag_document_count: Math.max(0, Math.floor(input.ragDocumentCount)),

--- a/app/src/services/queryGenerationContextService.ts
+++ b/app/src/services/queryGenerationContextService.ts
@@ -14,6 +14,10 @@ import {
 import type { QueryContext } from "./queryOrchestrationStore";
 import type { RagRetrievalDoc } from "./ragRetrieval";
 import { rankValidatedExamples } from "./exampleRankingService";
+import {
+  buildJoinPathClarification,
+  type QueryClarification
+} from "./queryClarificationService";
 
 const { retrieveRagContext } = ragRetrieval;
 
@@ -51,6 +55,7 @@ export type PrepareGenerationContextResult =
     ok: false;
     code: "no_schema_candidates" | "schema_linking_ambiguous" | "schema_linking_disconnected";
     message: string;
+    clarification: QueryClarification | null;
     diagnostics: SchemaLinkingDiagnostics;
   };
 
@@ -91,6 +96,7 @@ export async function prepareQueryGenerationContext(
       ok: false,
       code: "no_schema_candidates",
       message: "No relevant schema objects were found for the question",
+      clarification: null,
       diagnostics
     };
   }
@@ -118,8 +124,9 @@ export async function prepareQueryGenerationContext(
       ok: false,
       code: ambiguous ? "schema_linking_ambiguous" : "schema_linking_disconnected",
       message: ambiguous
-        ? "Multiple equally valid join paths were found; refine the question or approve a join policy"
+        ? "Multiple equally valid join paths were found"
         : "The selected schema objects could not be connected within the configured join-path limit",
+      clarification: ambiguous ? buildJoinPathClarification(expanded.expansion) : null,
       diagnostics
     };
   }

--- a/app/src/services/queryOrchestrationService.ts
+++ b/app/src/services/queryOrchestrationService.ts
@@ -273,6 +273,7 @@ export async function orchestrateQueryRun({
       return failure(422, {
         error: prepared.code,
         message: prepared.message,
+        clarification: prepared.clarification,
         schema_linking: prepared.diagnostics
       });
     }

--- a/app/src/types/openapi.ts
+++ b/app/src/types/openapi.ts
@@ -3146,6 +3146,15 @@ export interface paths {
                         "application/json": components["schemas"]["RunSessionResponse"];
                     };
                 };
+                /** @description Query intent requires clarification before generation can continue */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["QueryClarificationRequiredResponse"];
+                    };
+                };
             };
         };
         delete?: never;
@@ -5091,6 +5100,25 @@ export interface components {
             /** @description True when the request was handled as a dry-run and no query was executed. */
             preview: boolean;
             diagnostics: components["schemas"]["QueryGenerationDiagnostics"];
+        };
+        QueryClarificationOption: {
+            /** @description Stable opaque identifier for this interpretation. */
+            id: string;
+            label: string;
+            description: string;
+            table_refs: string[];
+        };
+        QueryClarification: {
+            /** @enum {string} */
+            kind: "join_path";
+            message: string;
+            options: components["schemas"]["QueryClarificationOption"][];
+        };
+        QueryClarificationRequiredResponse: {
+            /** @enum {string} */
+            error: "schema_linking_ambiguous";
+            message: string;
+            clarification: components["schemas"]["QueryClarification"];
         };
         /** @description Compact generation metadata for debugging and benchmark measurement. Prompt contents are never included. */
         QueryGenerationDiagnostics: {

--- a/app/test/queryClarificationService.test.ts
+++ b/app/test/queryClarificationService.test.ts
@@ -1,0 +1,82 @@
+import "./helpers/setupEnv";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildJoinPathClarification } from "../src/services/queryClarificationService";
+import type { SchemaExpansion, SchemaGraphEdge, SchemaPath } from "../src/services/schemaGraphService";
+
+test("join-path clarification produces stable, concise, and prompt-safe options", () => {
+  const directEdge = edge("direct", "orders", "customers", "public.orders", "public.customers");
+  const orderAccount = edge("order-account", "orders", "accounts", "public.orders", "public.accounts");
+  const accountCustomer = edge("account-customer", "accounts", "customers", "public.accounts", "public.customers");
+  const direct = path(["orders", "customers"], [directEdge]);
+  const viaAccount = path(["orders", "accounts", "customers"], [orderAccount, accountCustomer]);
+  const expansion = ambiguousExpansion([viaAccount, direct]);
+
+  const clarification = buildJoinPathClarification(expansion);
+  const reversed = buildJoinPathClarification(ambiguousExpansion([direct, viaAccount]));
+
+  assert.ok(clarification);
+  assert.deepEqual(clarification, reversed);
+  assert.equal(clarification.kind, "join_path");
+  assert.equal(clarification.options.length, 2);
+  assert.deepEqual(clarification.options.map((option) => option.label), [
+    "Join through public.accounts",
+    "Use schema relationship (option 2)"
+  ]);
+  assert.deepEqual(clarification.options[0].table_refs, [
+    "public.orders",
+    "public.accounts",
+    "public.customers"
+  ]);
+  assert.doesNotMatch(JSON.stringify(clarification), /orders\.account_id|customers\.id/);
+});
+
+test("clarification is absent when expansion is not ambiguous", () => {
+  assert.equal(buildJoinPathClarification({
+    ...ambiguousExpansion([]),
+    status: "complete"
+  }), null);
+});
+
+function ambiguousExpansion(alternatives: SchemaPath[]): SchemaExpansion {
+  return {
+    status: "ambiguous",
+    core_object_ids: ["orders", "customers"],
+    object_ids: ["orders", "customers"],
+    connector_object_ids: [],
+    edges: [],
+    paths: [],
+    ambiguities: [{ target_object_id: "customers", alternatives }],
+    unresolved_object_ids: []
+  };
+}
+
+function path(objectIds: string[], edges: SchemaGraphEdge[]): SchemaPath {
+  return {
+    object_ids: objectIds,
+    edge_ids: edges.map((item) => item.id),
+    edges,
+    approved_policy_count: 0
+  };
+}
+
+function edge(
+  id: string,
+  leftObjectId: string,
+  rightObjectId: string,
+  leftRef: string,
+  rightRef: string
+): SchemaGraphEdge {
+  return {
+    id,
+    left_object_id: leftObjectId,
+    right_object_id: rightObjectId,
+    left_ref: leftRef,
+    right_ref: rightRef,
+    source: "relationship",
+    join_type: "INNER",
+    on_clause: "orders.account_id = customers.id",
+    relationship_type: "many_to_one"
+  };
+}

--- a/app/test/queryDiagnosticsService.test.ts
+++ b/app/test/queryDiagnosticsService.test.ts
@@ -25,7 +25,22 @@ test("query diagnostics are bounded, correlated, and exclude sensitive content",
         prompt_version: "v3-schema-linker",
         prompt_chars: 500
       },
-      expansion: null
+      expansion: {
+        status: "ambiguous",
+        core_object_ids: [ids[0], ids[1]],
+        object_ids: [ids[0]],
+        connector_object_ids: [],
+        edges: [],
+        paths: [],
+        ambiguities: [{
+          target_object_id: ids[1],
+          alternatives: [
+            { object_ids: [ids[0], ids[1]], edge_ids: ["edge-1"], edges: [], approved_policy_count: 0 },
+            { object_ids: [ids[0], ids[1]], edge_ids: ["edge-2"], edges: [], approved_policy_count: 0 }
+          ]
+        }],
+        unresolved_object_ids: []
+      }
     },
     expandedTableIds: ids,
     ragDocumentCount: 12,
@@ -57,6 +72,8 @@ test("query diagnostics are bounded, correlated, and exclude sensitive content",
   assert.equal(payload.generation.attempts.length, 8);
   assert.equal(payload.generation.attempts_truncated, true);
   assert.deepEqual(payload.retrieval, { rag_document_count: 12, example_count: 3 });
+  assert.equal(payload.schema_linking?.clarification_required, true);
+  assert.equal(payload.schema_linking?.clarification_option_count, 2);
   assert.deepEqual(payload.generation.token_usage, { prompt_tokens: 18, completion_tokens: 9, total_tokens: 27 });
   const serialized = JSON.stringify(payload);
   assert.doesNotMatch(serialized, /secret/);

--- a/app/test/queryGenerationContextService.test.ts
+++ b/app/test/queryGenerationContextService.test.ts
@@ -91,7 +91,13 @@ test("prepareQueryGenerationContext surfaces graph ambiguity instead of generati
       connector_object_ids: [],
       edges: [],
       paths: [],
-      ambiguities: [{ target_object_id: CUSTOMER, alternatives: [] }],
+      ambiguities: [{
+        target_object_id: CUSTOMER,
+        alternatives: [
+          ambiguityPath("edge-a"),
+          ambiguityPath("edge-b")
+        ]
+      }],
       unresolved_object_ids: []
     },
     context: null
@@ -105,6 +111,8 @@ test("prepareQueryGenerationContext surfaces graph ambiguity instead of generati
   assert.equal(result.ok, false);
   if (result.ok === false) {
     assert.equal(result.code, "schema_linking_ambiguous");
+    assert.equal(result.clarification?.kind, "join_path");
+    assert.equal(result.clarification?.options.length, 2);
   }
 });
 
@@ -192,5 +200,25 @@ function exampleRag(id: string, schemaRef: string, quality: number): RagRetrieva
       validation_state: "validated",
       schema_refs: [schemaRef]
     }
+  };
+}
+
+function ambiguityPath(edgeId: string) {
+  const edge = {
+    id: edgeId,
+    left_object_id: PAYMENT,
+    right_object_id: CUSTOMER,
+    left_ref: "public.payment",
+    right_ref: "public.customer",
+    source: "relationship" as const,
+    join_type: "INNER",
+    on_clause: "public.payment.customer_id = public.customer.id",
+    relationship_type: "many_to_one"
+  };
+  return {
+    object_ids: [PAYMENT, CUSTOMER],
+    edge_ids: [edge.id],
+    edges: [edge],
+    approved_policy_count: 0
   };
 }

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1524,6 +1524,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RunSessionResponse"
+        "422":
+          description: Query intent requires clarification before generation can continue
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QueryClarificationRequiredResponse"
   /v1/query/sessions/{sessionId}/feedback:
     post:
       tags: [Query]
@@ -3617,6 +3623,47 @@ components:
         diagnostics:
           $ref: "#/components/schemas/QueryGenerationDiagnostics"
       required: [attempt_id, sql, columns, rows, row_count, duration_ms, confidence, preview, diagnostics]
+    QueryClarificationOption:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Stable opaque identifier for this interpretation.
+        label:
+          type: string
+        description:
+          type: string
+        table_refs:
+          type: array
+          items:
+            type: string
+      required: [id, label, description, table_refs]
+    QueryClarification:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [join_path]
+        message:
+          type: string
+        options:
+          type: array
+          minItems: 2
+          maxItems: 8
+          items:
+            $ref: "#/components/schemas/QueryClarificationOption"
+      required: [kind, message, options]
+    QueryClarificationRequiredResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          enum: [schema_linking_ambiguous]
+        message:
+          type: string
+        clarification:
+          $ref: "#/components/schemas/QueryClarification"
+      required: [error, message, clarification]
     QueryGenerationDiagnostics:
       type: object
       description: Compact generation metadata for debugging and benchmark measurement. Prompt contents are never included.

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -3146,6 +3146,15 @@ export interface paths {
                         "application/json": components["schemas"]["RunSessionResponse"];
                     };
                 };
+                /** @description Query intent requires clarification before generation can continue */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["QueryClarificationRequiredResponse"];
+                    };
+                };
             };
         };
         delete?: never;
@@ -5091,6 +5100,25 @@ export interface components {
             /** @description True when the request was handled as a dry-run and no query was executed. */
             preview: boolean;
             diagnostics: components["schemas"]["QueryGenerationDiagnostics"];
+        };
+        QueryClarificationOption: {
+            /** @description Stable opaque identifier for this interpretation. */
+            id: string;
+            label: string;
+            description: string;
+            table_refs: string[];
+        };
+        QueryClarification: {
+            /** @enum {string} */
+            kind: "join_path";
+            message: string;
+            options: components["schemas"]["QueryClarificationOption"][];
+        };
+        QueryClarificationRequiredResponse: {
+            /** @enum {string} */
+            error: "schema_linking_ambiguous";
+            message: string;
+            clarification: components["schemas"]["QueryClarification"];
         };
         /** @description Compact generation metadata for debugging and benchmark measurement. Prompt contents are never included. */
         QueryGenerationDiagnostics: {


### PR DESCRIPTION
## Summary

- translate ambiguous join paths into deterministic user-facing clarification choices
- use stable opaque option IDs and concise affected-table descriptions without exposing prompts or join SQL
- return a documented 422 clarification contract from query execution
- record clarification-required state and bounded option counts in query diagnostics
- keep backend OpenAPI and frontend generated types aligned

Part of #180

## Verification

- `npm run typecheck`
- `npm test` (261 tests)
- `npm --prefix frontend run lint`
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)