### PR TITLE
Resume query generation from clarifications

### DIFF
--- a/app/src/routes/query.ts
+++ b/app/src/routes/query.ts
@@ -116,6 +116,12 @@ const handleRunSession: RouteHandlerWithId<RunSessionRequest, RunSessionResponse
   const requestedProvider = typeof body.llm_provider === "string" ? body.llm_provider : null;
   const requestedModel = typeof body.model === "string" ? body.model : null;
   const noExecute = body.no_execute === true;
+  const clarificationOptionId = typeof body.clarification_option_id === "string"
+    ? body.clarification_option_id.trim()
+    : null;
+  if (clarificationOptionId && !/^join_path_[a-f0-9]{12}$/.test(clarificationOptionId)) {
+    return badRequest(res, "clarification_option_id is invalid");
+  }
   const sqlOverride = typeof body.sql_override === "string" && body.sql_override.trim() ? body.sql_override.trim() : null;
   const maxRows = clamp(Number(body.max_rows || 1000), 1, 100000);
   const timeoutMs = clamp(Number(body.timeout_ms || 20000), 1000, 120000);
@@ -128,7 +134,8 @@ const handleRunSession: RouteHandlerWithId<RunSessionRequest, RunSessionResponse
     sqlOverride,
     maxRows,
     timeoutMs,
-    noExecute
+    noExecute,
+    clarificationOptionId
   });
 
   return json(res, result.statusCode, result.body);

--- a/app/src/services/queryClarificationService.ts
+++ b/app/src/services/queryClarificationService.ts
@@ -31,6 +31,20 @@ export function buildJoinPathClarification(expansion: SchemaExpansion): QueryCla
   };
 }
 
+export function findJoinPathByOptionId(
+  expansion: SchemaExpansion,
+  optionId: string
+): SchemaPath | null {
+  const normalized = String(optionId || "").trim();
+  if (!normalized) return null;
+  for (const ambiguity of expansion.ambiguities) {
+    for (const path of ambiguity.alternatives) {
+      if (optionIdForPath(path) === normalized) return path;
+    }
+  }
+  return null;
+}
+
 function toOption(path: SchemaPath, index: number, total: number): QueryClarificationOption {
   const tableRefs = path.object_ids
     .map((objectId) => refForObject(path.edges, objectId))
@@ -47,11 +61,15 @@ function toOption(path: SchemaPath, index: number, total: number): QueryClarific
     : baseLabel;
 
   return {
-    id: `join_path_${createHash("sha256").update(pathSignature(path)).digest("hex").slice(0, 12)}`,
+    id: optionIdForPath(path),
     label,
     description: `Uses ${path.edges.length} ${path.edges.length === 1 ? "relationship" : "relationships"} across ${tableRefs.join(", ")}.`,
     table_refs: tableRefs
   };
+}
+
+function optionIdForPath(path: SchemaPath): string {
+  return `join_path_${createHash("sha256").update(pathSignature(path)).digest("hex").slice(0, 12)}`;
 }
 
 function duplicateLabelRisk(path: SchemaPath): boolean {

--- a/app/src/services/queryClarificationStore.ts
+++ b/app/src/services/queryClarificationStore.ts
@@ -1,0 +1,89 @@
+import type { PoolClient } from "pg";
+import appDb = require("../lib/appDb");
+import type { QueryClarification } from "./queryClarificationService";
+
+export async function recordPendingClarification(
+  sessionId: string,
+  clarification: QueryClarification
+): Promise<void> {
+  await appDb.withTransaction(async (client: PoolClient) => {
+    await client.query("SELECT id FROM query_sessions WHERE id = $1 FOR UPDATE", [sessionId]);
+    await client.query(
+      `
+        UPDATE query_clarifications
+        SET status = 'superseded'
+        WHERE session_id = $1
+          AND status = 'pending'
+          AND options_json <> $2::jsonb
+      `,
+      [sessionId, JSON.stringify(clarification)]
+    );
+    await client.query(
+      `
+        INSERT INTO query_clarifications (session_id, kind, status, options_json)
+        SELECT $1, $2, 'pending', $3::jsonb
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM query_clarifications
+          WHERE session_id = $1
+            AND status = 'pending'
+            AND options_json = $3::jsonb
+        )
+      `,
+      [sessionId, clarification.kind, JSON.stringify(clarification)]
+    );
+    await client.query(
+      "UPDATE query_sessions SET status = 'awaiting_clarification' WHERE id = $1",
+      [sessionId]
+    );
+  });
+}
+
+export async function resolvePendingClarification(
+  sessionId: string,
+  optionId: string
+): Promise<boolean> {
+  return appDb.withTransaction(async (client: PoolClient) => {
+    const result = await client.query(
+      `
+        UPDATE query_clarifications
+        SET status = 'resolved',
+            selected_option_id = $2,
+            resolved_at = NOW()
+        WHERE id = (
+          SELECT id
+          FROM query_clarifications
+          WHERE session_id = $1
+            AND status = 'pending'
+            AND options_json @> jsonb_build_object(
+              'options',
+              jsonb_build_array(jsonb_build_object('id', $2::text))
+            )
+          ORDER BY created_at DESC
+          LIMIT 1
+          FOR UPDATE
+        )
+      `,
+      [sessionId, optionId]
+    );
+    let accepted = (result.rowCount ?? 0) > 0;
+    if (!accepted) {
+      const existing = await client.query(
+        `
+          SELECT 1
+          FROM query_clarifications
+          WHERE session_id = $1
+            AND status = 'resolved'
+            AND selected_option_id = $2
+          ORDER BY resolved_at DESC
+          LIMIT 1
+        `,
+        [sessionId, optionId]
+      );
+      accepted = (existing.rowCount ?? 0) > 0;
+    }
+    if (!accepted) return false;
+    await client.query("UPDATE query_sessions SET status = 'created' WHERE id = $1", [sessionId]);
+    return true;
+  });
+}

--- a/app/src/services/queryGenerationContextService.ts
+++ b/app/src/services/queryGenerationContextService.ts
@@ -8,6 +8,7 @@ import {
 import { linkTablesWithRouting, type LinkTablesResult } from "./llmSchemaLinkerService";
 import {
   loadExpandedSchemaContext,
+  loadResolvedSchemaContext,
   type ExpandedSchemaContext,
   type SchemaExpansion
 } from "./schemaGraphService";
@@ -16,6 +17,7 @@ import type { RagRetrievalDoc } from "./ragRetrieval";
 import { rankValidatedExamples } from "./exampleRankingService";
 import {
   buildJoinPathClarification,
+  findJoinPathByOptionId,
   type QueryClarification
 } from "./queryClarificationService";
 
@@ -29,6 +31,7 @@ export interface PrepareGenerationContextInput {
   requestId?: string | null;
   candidateLimit?: number;
   finalRagLimit?: number;
+  clarificationOptionId?: string | null;
 }
 
 export interface SchemaLinkingDiagnostics {
@@ -53,7 +56,7 @@ export type PrepareGenerationContextResult =
   }
   | {
     ok: false;
-    code: "no_schema_candidates" | "schema_linking_ambiguous" | "schema_linking_disconnected";
+    code: "no_schema_candidates" | "schema_linking_ambiguous" | "schema_linking_disconnected" | "clarification_option_invalid";
     message: string;
     clarification: QueryClarification | null;
     diagnostics: SchemaLinkingDiagnostics;
@@ -64,13 +67,15 @@ export interface GenerationContextDependencies {
   retrieveRagContext: typeof retrieveRagContext;
   linkTablesWithRouting: typeof linkTablesWithRouting;
   loadExpandedSchemaContext: typeof loadExpandedSchemaContext;
+  loadResolvedSchemaContext: typeof loadResolvedSchemaContext;
 }
 
 const defaultDependencies: GenerationContextDependencies = {
   loadTableCards,
   retrieveRagContext,
   linkTablesWithRouting,
-  loadExpandedSchemaContext
+  loadExpandedSchemaContext,
+  loadResolvedSchemaContext
 };
 
 export async function prepareQueryGenerationContext(
@@ -111,12 +116,27 @@ export async function prepareQueryGenerationContext(
   });
   diagnostics.linker = linker;
 
-  const expanded = await dependencies.loadExpandedSchemaContext(
+  let expanded = await dependencies.loadExpandedSchemaContext(
     input.dataSourceId,
     linker.selection.table_ids,
     { maxIntermediateHops: 2, maxAlternativePaths: 4 }
   );
   diagnostics.expansion = expanded.expansion;
+
+  if (expanded.expansion.status === "ambiguous" && input.clarificationOptionId) {
+    const selectedPath = findJoinPathByOptionId(expanded.expansion, input.clarificationOptionId);
+    if (!selectedPath) {
+      return {
+        ok: false,
+        code: "clarification_option_invalid",
+        message: "The selected clarification option is no longer valid",
+        clarification: buildJoinPathClarification(expanded.expansion),
+        diagnostics
+      };
+    }
+    expanded = await dependencies.loadResolvedSchemaContext(input.dataSourceId, expanded, selectedPath);
+    diagnostics.expansion = expanded.expansion;
+  }
 
   if (expanded.expansion.status !== "complete" || !expanded.context) {
     const ambiguous = expanded.expansion.status === "ambiguous";

--- a/app/src/services/queryOrchestrationService.ts
+++ b/app/src/services/queryOrchestrationService.ts
@@ -27,6 +27,10 @@ import {
   emitQueryDiagnostic,
   type QueryDiagnosticInput
 } from "./queryDiagnosticsService";
+import {
+  recordPendingClarification,
+  resolvePendingClarification
+} from "./queryClarificationStore";
 
 const { extractForbiddenColumnsFromRagNotes, validateSqlAgainstForbiddenColumns } = columnPolicyService;
 const { retrieveRagContext } = ragRetrieval;
@@ -44,6 +48,7 @@ export interface OrchestrateInput {
   maxRows: number;
   timeoutMs?: number;
   noExecute?: boolean;
+  clarificationOptionId?: string | null;
 }
 
 export interface OrchestrateResult<T = unknown> {
@@ -57,13 +62,17 @@ export interface QueryOrchestrationDependencies {
   generateSqlWithRouting: typeof generateSqlWithRouting;
   createDatabaseAdapter: typeof createDatabaseAdapter;
   emitQueryDiagnostic: typeof emitQueryDiagnostic;
+  recordPendingClarification: typeof recordPendingClarification;
+  resolvePendingClarification: typeof resolvePendingClarification;
 }
 
 const defaultDependencies: QueryOrchestrationDependencies = {
   prepareQueryGenerationContext,
   generateSqlWithRouting,
   createDatabaseAdapter,
-  emitQueryDiagnostic
+  emitQueryDiagnostic,
+  recordPendingClarification,
+  resolvePendingClarification
 };
 
 function success<T>(body: T, statusCode = 200): OrchestrateResult<T> {
@@ -163,11 +172,18 @@ export async function orchestrateQueryRun({
   sqlOverride,
   maxRows,
   timeoutMs,
-  noExecute
+  noExecute,
+  clarificationOptionId
 }: OrchestrateInput, dependencies: QueryOrchestrationDependencies = defaultDependencies): Promise<OrchestrateResult> {
   const providerIsValid = await validateRequestedProvider(requestedProvider);
   if (!providerIsValid) {
     return failure(400, { error: "bad_request", message: "Unsupported llm_provider" });
+  }
+  if (sqlOverride && clarificationOptionId) {
+    return failure(400, {
+      error: "bad_request",
+      message: "sql_override and clarification_option_id cannot be used together"
+    });
   }
 
   const session = await resolveSession({
@@ -254,7 +270,8 @@ export async function orchestrateQueryRun({
         question: session.question,
         requestedProvider,
         requestedModel,
-        requestId
+        requestId,
+        clarificationOptionId
       });
     } catch (err) {
       schemaLinkingDurationMs = Date.now() - schemaLinkingStartedAt;
@@ -268,7 +285,11 @@ export async function orchestrateQueryRun({
     schemaLinkingDurationMs = Date.now() - schemaLinkingStartedAt;
     schemaLinking = prepared.diagnostics;
     if (prepared.ok === false) {
-      await markSessionStatus(sessionId, "failed");
+      if (prepared.clarification) {
+        await dependencies.recordPendingClarification(sessionId, prepared.clarification);
+      } else {
+        await markSessionStatus(sessionId, "failed");
+      }
       emitTerminalDiagnostic("failed", "schema_linking", prepared.code);
       return failure(422, {
         error: prepared.code,
@@ -276,6 +297,16 @@ export async function orchestrateQueryRun({
         clarification: prepared.clarification,
         schema_linking: prepared.diagnostics
       });
+    }
+    if (clarificationOptionId) {
+      const resolved = await dependencies.resolvePendingClarification(sessionId, clarificationOptionId);
+      if (!resolved) {
+        emitTerminalDiagnostic("failed", "schema_linking", "clarification_not_pending");
+        return failure(409, {
+          error: "clarification_not_pending",
+          message: "This query session does not have a pending clarification"
+        });
+      }
     }
     context = prepared.context;
     ragDocuments = prepared.ragDocuments;

--- a/app/src/services/schemaGraphService.ts
+++ b/app/src/services/schemaGraphService.ts
@@ -273,6 +273,51 @@ export async function loadExpandedSchemaContext(
   return { graph, expansion, context };
 }
 
+export async function loadResolvedSchemaContext(
+  dataSourceId: string,
+  expanded: ExpandedSchemaContext,
+  selectedPath: SchemaPath
+): Promise<ExpandedSchemaContext> {
+  const selectedSignature = pathSignature(selectedPath);
+  const remainingAmbiguities = expanded.expansion.ambiguities.filter((ambiguity) =>
+    !ambiguity.alternatives.some((path) => pathSignature(path) === selectedSignature)
+  );
+  const edges = new Map(expanded.expansion.edges.map((edge) => [edge.id, edge]));
+  for (const edge of selectedPath.edges) edges.set(edge.id, edge);
+  const objectIds = unique([...expanded.expansion.object_ids, ...selectedPath.object_ids]);
+  const coreSet = new Set(expanded.expansion.core_object_ids);
+  const expansion: SchemaExpansion = {
+    ...expanded.expansion,
+    status: remainingAmbiguities.length > 0
+      ? "ambiguous"
+      : expanded.expansion.unresolved_object_ids.length > 0 ? "disconnected" : "complete",
+    object_ids: objectIds,
+    connector_object_ids: objectIds.filter((id) => !coreSet.has(id)),
+    edges: [...edges.values()].sort(compareEdges),
+    paths: [...expanded.expansion.paths, selectedPath],
+    ambiguities: remainingAmbiguities
+  };
+  if (expansion.status !== "complete") {
+    return { graph: expanded.graph, expansion, context: null };
+  }
+
+  const scopedContext = await loadScopedQueryContext(dataSourceId, expansion.object_ids);
+  return {
+    graph: expanded.graph,
+    expansion,
+    context: {
+      ...scopedContext,
+      joinPolicies: expansion.edges.map((edge) => ({
+        id: edge.id,
+        left_ref: edge.left_ref,
+        right_ref: edge.right_ref,
+        join_type: edge.join_type,
+        on_clause: edge.on_clause
+      }))
+    }
+  };
+}
+
 function findBestPaths(
   adjacency: Map<string, SchemaGraphEdge[]>,
   sourceIds: Set<string>,

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -3,7 +3,7 @@
  *
  * These types describe the shapes of rows persisted in the metadata
  * Postgres database (defined by `db/migrations/0001_*.sql` through
- * `db/migrations/0027_*.sql`) plus a handful of in-process config
+ * `db/migrations/0029_*.sql`) plus a handful of in-process config
  * shapes (provider configs, routing) that are not exposed through the
  * OpenAPI spec.
  *

--- a/app/src/types/openapi.ts
+++ b/app/src/types/openapi.ts
@@ -3146,6 +3146,19 @@ export interface paths {
                         "application/json": components["schemas"]["RunSessionResponse"];
                     };
                 };
+                /** @description The clarification is no longer pending for this session */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "clarification_not_pending";
+                            message: string;
+                        };
+                    };
+                };
                 /** @description Query intent requires clarification before generation can continue */
                 422: {
                     headers: {
@@ -5084,6 +5097,8 @@ export interface components {
             sql_override?: string;
             /** @description When true, generate and validate SQL without connecting to or executing against the source database. */
             no_execute?: boolean;
+            /** @description Opaque option ID returned by a prior 422 clarification response for this session. */
+            clarification_option_id?: string;
             max_rows?: number;
             timeout_ms?: number;
         };
@@ -5116,7 +5131,7 @@ export interface components {
         };
         QueryClarificationRequiredResponse: {
             /** @enum {string} */
-            error: "schema_linking_ambiguous";
+            error: "schema_linking_ambiguous" | "clarification_option_invalid";
             message: string;
             clarification: components["schemas"]["QueryClarification"];
         };

--- a/app/test/queryClarificationStore.test.ts
+++ b/app/test/queryClarificationStore.test.ts
@@ -1,0 +1,65 @@
+import "./helpers/setupEnv";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { PoolClient } from "pg";
+
+import appDb = require("../src/lib/appDb");
+import {
+  recordPendingClarification,
+  resolvePendingClarification
+} from "../src/services/queryClarificationStore";
+
+test("clarification store persists pending options and audits their resolution", async () => {
+  const originalTransaction = appDb.withTransaction;
+  const statements: Array<{ sql: string; params: unknown[] }> = [];
+  const client = {
+    query: async (sql: string, params: unknown[] = []) => {
+      const normalized = sql.replace(/\s+/g, " ").trim().toLowerCase();
+      statements.push({ sql: normalized, params });
+      return {
+        rowCount: normalized.startsWith("update query_clarifications") ? 1 : 0,
+        rows: []
+      };
+    }
+  } as unknown as PoolClient;
+  appDb.withTransaction = (async <T>(callback: (transactionClient: PoolClient) => Promise<T>) => callback(client)) as typeof appDb.withTransaction;
+
+  try {
+    await recordPendingClarification("session-1", {
+      kind: "join_path",
+      message: "Choose a path",
+      options: [
+        { id: "join_path_111111111111", label: "One", description: "First", table_refs: ["public.a"] },
+        { id: "join_path_222222222222", label: "Two", description: "Second", table_refs: ["public.b"] }
+      ]
+    });
+    const resolved = await resolvePendingClarification("session-1", "join_path_111111111111");
+
+    assert.equal(resolved, true);
+    assert.ok(statements.some((entry) => entry.sql.includes("insert into query_clarifications")));
+    assert.ok(statements.some((entry) => entry.sql.includes("status = 'awaiting_clarification'")));
+    assert.ok(statements.some((entry) => entry.sql.includes("selected_option_id = $2")));
+    assert.ok(statements.some((entry) => entry.sql.includes("status = 'created'")));
+  } finally {
+    appDb.withTransaction = originalTransaction;
+  }
+});
+
+test("clarification store accepts retrying an already resolved option", async () => {
+  const originalTransaction = appDb.withTransaction;
+  const client = {
+    query: async (sql: string) => {
+      const normalized = sql.replace(/\s+/g, " ").trim().toLowerCase();
+      if (normalized.startsWith("update query_clarifications")) return { rowCount: 0, rows: [] };
+      if (normalized.startsWith("select 1 from query_clarifications")) return { rowCount: 1, rows: [{ "?column?": 1 }] };
+      return { rowCount: 1, rows: [] };
+    }
+  } as unknown as PoolClient;
+  appDb.withTransaction = (async <T>(callback: (transactionClient: PoolClient) => Promise<T>) => callback(client)) as typeof appDb.withTransaction;
+
+  try {
+    assert.equal(await resolvePendingClarification("session-1", "join_path_111111111111"), true);
+  } finally {
+    appDb.withTransaction = originalTransaction;
+  }
+});

--- a/app/test/queryClarificationsMigration.test.ts
+++ b/app/test/queryClarificationsMigration.test.ts
@@ -1,0 +1,16 @@
+import "./helpers/setupEnv";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+test("0029 creates durable query clarification state and a single pending constraint", () => {
+  const migrationPath = path.resolve(__dirname, "../../db/migrations/0029_query_clarifications.sql");
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS query_clarifications/i);
+  assert.match(sql, /status IN \('pending', 'resolved', 'cancelled', 'superseded'\)/i);
+  assert.match(sql, /selected_option_id TEXT/i);
+  assert.match(sql, /WHERE status = 'pending'/i);
+  assert.match(sql, /REFERENCES query_sessions\(id\) ON DELETE CASCADE/i);
+});

--- a/app/test/queryGenerationContextService.test.ts
+++ b/app/test/queryGenerationContextService.test.ts
@@ -81,12 +81,15 @@ test("prepareQueryGenerationContext fails before the linker when no candidates m
 });
 
 test("prepareQueryGenerationContext surfaces graph ambiguity instead of generating", async () => {
-  const dependencies = baseDependencies([card(PAYMENT, "payment", ["Revenue"])], []);
+  const dependencies = baseDependencies([
+    card(PAYMENT, "payment", ["Revenue"]),
+    card(CUSTOMER, "customer")
+  ], []);
   dependencies.loadExpandedSchemaContext = async () => ({
     graph: { nodes: [], edges: [] },
     expansion: {
       status: "ambiguous",
-      core_object_ids: [PAYMENT],
+      core_object_ids: [PAYMENT, CUSTOMER],
       object_ids: [PAYMENT],
       connector_object_ids: [],
       edges: [],
@@ -112,6 +115,48 @@ test("prepareQueryGenerationContext surfaces graph ambiguity instead of generati
   if (result.ok === false) {
     assert.equal(result.code, "schema_linking_ambiguous");
     assert.equal(result.clarification?.kind, "join_path");
+    assert.equal(result.clarification?.options.length, 2);
+    const resumed = await prepareQueryGenerationContext({
+      dataSourceId: "source",
+      question: "Revenue",
+      clarificationOptionId: result.clarification!.options[0].id
+    }, dependencies);
+    assert.equal(resumed.ok, true);
+  }
+});
+
+test("prepareQueryGenerationContext rejects stale clarification option IDs", async () => {
+  const dependencies = baseDependencies([
+    card(PAYMENT, "payment", ["Revenue"]),
+    card(CUSTOMER, "customer")
+  ], []);
+  dependencies.loadExpandedSchemaContext = async () => ({
+    graph: { nodes: [], edges: [] },
+    expansion: {
+      status: "ambiguous",
+      core_object_ids: [PAYMENT, CUSTOMER],
+      object_ids: [PAYMENT],
+      connector_object_ids: [],
+      edges: [],
+      paths: [],
+      ambiguities: [{
+        target_object_id: CUSTOMER,
+        alternatives: [ambiguityPath("edge-a"), ambiguityPath("edge-b")]
+      }],
+      unresolved_object_ids: []
+    },
+    context: null
+  });
+
+  const result = await prepareQueryGenerationContext({
+    dataSourceId: "source",
+    question: "Revenue",
+    clarificationOptionId: "join_path_000000000000"
+  }, dependencies);
+
+  assert.equal(result.ok, false);
+  if (result.ok === false) {
+    assert.equal(result.code, "clarification_option_invalid");
     assert.equal(result.clarification?.options.length, 2);
   }
 });
@@ -156,7 +201,38 @@ function baseDependencies(cards: TableCard[], docs: RagRetrievalDoc[]): Generati
         joinPolicies: [],
         ragNotes: []
       }
-    })
+    }),
+    loadResolvedSchemaContext: async (_dataSourceId, expanded, selectedPath) => {
+      const objectIds = [...new Set([...expanded.expansion.object_ids, ...selectedPath.object_ids])];
+      return {
+        graph: expanded.graph,
+        expansion: {
+          ...expanded.expansion,
+          status: "complete" as const,
+          object_ids: objectIds,
+          connector_object_ids: objectIds.filter((id) => !expanded.expansion.core_object_ids.includes(id)),
+          edges: selectedPath.edges,
+          paths: [selectedPath],
+          ambiguities: []
+        },
+        context: {
+          schemaObjects: cards
+            .filter((item) => objectIds.includes(item.id))
+            .map((item) => ({ id: item.id, schema_name: item.schema_name, object_name: item.object_name, object_type: item.object_type })),
+          columns: [{ schema_name: "public", object_name: "payment", column_name: "amount", data_type: "numeric" }],
+          semanticEntities: [],
+          metricDefinitions: [],
+          joinPolicies: selectedPath.edges.map((edge) => ({
+            id: edge.id,
+            left_ref: edge.left_ref,
+            right_ref: edge.right_ref,
+            join_type: edge.join_type,
+            on_clause: edge.on_clause
+          })),
+          ragNotes: []
+        }
+      };
+    }
   };
 }
 

--- a/app/test/queryOrchestrationRepair.test.ts
+++ b/app/test/queryOrchestrationRepair.test.ts
@@ -142,6 +142,52 @@ test("orchestrateQueryRun repairs adapter validation errors before EXPLAIN and e
   assert.equal(closed, true);
 });
 
+test("ambiguous generation persists clarification and returns the structured 422 response", async () => {
+  let recorded = false;
+  const dependencies = dependenciesWithGenerator(async () => generation("SELECT 1", "generation"));
+  dependencies.prepareQueryGenerationContext = async () => ({
+    ok: false,
+    code: "schema_linking_ambiguous",
+    message: "Multiple equally valid join paths were found",
+    clarification: {
+      kind: "join_path",
+      message: "Choose a relationship",
+      options: [
+        { id: "join_path_111111111111", label: "Path one", description: "First path", table_refs: ["public.a", "public.b"] },
+        { id: "join_path_222222222222", label: "Path two", description: "Second path", table_refs: ["public.a", "public.b"] }
+      ]
+    },
+    diagnostics: { candidates: [], linker: null, expansion: null }
+  });
+  dependencies.recordPendingClarification = async () => {
+    recorded = true;
+  };
+
+  const result = await orchestrateQueryRun(baseInput(), dependencies);
+
+  assert.equal(result.statusCode, 422);
+  assert.equal(recorded, true);
+  assert.equal((result.body as { clarification: { options: unknown[] } }).clarification.options.length, 2);
+});
+
+test("resume refuses a valid current option when the session has no pending clarification", async () => {
+  let generationCalled = false;
+  const dependencies = dependenciesWithGenerator(async () => {
+    generationCalled = true;
+    return generation("SELECT 1", "generation");
+  });
+  dependencies.resolvePendingClarification = async () => false;
+
+  const result = await orchestrateQueryRun({
+    ...baseInput(),
+    clarificationOptionId: "join_path_111111111111"
+  }, dependencies);
+
+  assert.equal(result.statusCode, 409);
+  assert.equal((result.body as { error: string }).error, "clarification_not_pending");
+  assert.equal(generationCalled, false);
+});
+
 function baseInput() {
   return {
     sessionId: SESSION_ID,
@@ -190,6 +236,8 @@ function dependenciesWithGenerator(
     emitQueryDiagnostic: (diagnostic) => {
       emittedDiagnostics.push(diagnostic);
     },
+    recordPendingClarification: async () => undefined,
+    resolvePendingClarification: async () => true,
     createDatabaseAdapter: () => {
       throw new Error("Adapter must not be created for no_execute tests");
     }

--- a/app/test/schemaGraphService.test.ts
+++ b/app/test/schemaGraphService.test.ts
@@ -8,6 +8,7 @@ import appDb = require("../src/lib/appDb");
 import {
   expandSchemaGraph,
   loadExpandedSchemaContext,
+  loadResolvedSchemaContext,
   type SchemaGraph,
   type SchemaGraphEdge,
   type SchemaGraphNode
@@ -165,6 +166,43 @@ test("loadExpandedSchemaContext loads full columns for core and connector tables
       "public.rental.inventory_id = public.inventory.inventory_id"
     ]
   );
+});
+
+test("loadResolvedSchemaContext applies the selected path and scopes its join policies", async () => {
+  const graph = makeGraph(
+    [node(A, "orders"), node(B, "customer_bridge"), node(C, "account_bridge"), node(D, "customer")],
+    [edge("ab", A, B), edge("bd", B, D), edge("ac", A, C), edge("cd", C, D)]
+  );
+  const expansion = expandSchemaGraph(graph, [A, D], { maxIntermediateHops: 1 });
+  const selectedPath = expansion.ambiguities[0].alternatives[1];
+  appDb.query = (async (sql: string, params: unknown[] = []) => {
+    const normalized = normalizeSql(sql);
+    if (normalized.includes("from schema_objects") && normalized.includes("object_type in")) {
+      return result(graph.nodes
+        .filter((item) => (params[1] as string[]).includes(item.id))
+        .map((item) => ({
+          id: item.id,
+          schema_name: item.schema_name,
+          object_name: item.object_name,
+          object_type: item.object_type
+        })));
+    }
+    if (normalized.includes("from columns c")
+      || normalized.includes("from semantic_entities")
+      || normalized.includes("from metric_definitions")
+      || normalized.includes("from join_policies")
+      || normalized.includes("from rag_notes")) {
+      return result([]);
+    }
+    throw new Error(`Unexpected SQL: ${normalized}`);
+  }) as typeof appDb.query;
+
+  const resolved = await loadResolvedSchemaContext(DATA_SOURCE_ID, { graph, expansion, context: null }, selectedPath);
+
+  assert.equal(resolved.expansion.status, "complete");
+  assert.deepEqual(resolved.expansion.object_ids, [A, C, D]);
+  assert.deepEqual(resolved.expansion.connector_object_ids, [C]);
+  assert.deepEqual(resolved.context?.joinPolicies.map((policy) => policy.id), ["ac", "cd"]);
 });
 
 function node(id: string, objectName: string): SchemaGraphNode {

--- a/db/migrations/0029_query_clarifications.sql
+++ b/db/migrations/0029_query_clarifications.sql
@@ -1,0 +1,23 @@
+-- AIQ-008: durable, auditable clarification state for ambiguous query intent.
+
+CREATE TABLE IF NOT EXISTS query_clarifications (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  session_id UUID NOT NULL REFERENCES query_sessions(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL CHECK (kind IN ('join_path')),
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'resolved', 'cancelled', 'superseded')),
+  options_json JSONB NOT NULL,
+  selected_option_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_at TIMESTAMPTZ,
+  CHECK (
+    (status = 'resolved' AND selected_option_id IS NOT NULL AND resolved_at IS NOT NULL)
+    OR status <> 'resolved'
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_query_clarifications_one_pending
+  ON query_clarifications (session_id)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_query_clarifications_session_created
+  ON query_clarifications (session_id, created_at DESC);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1530,6 +1530,19 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/QueryClarificationRequiredResponse"
+        "409":
+          description: The clarification is no longer pending for this session
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum: [clarification_not_pending]
+                  message:
+                    type: string
+                required: [error, message]
   /v1/query/sessions/{sessionId}/feedback:
     post:
       tags: [Query]
@@ -3587,6 +3600,10 @@ components:
         no_execute:
           type: boolean
           description: When true, generate and validate SQL without connecting to or executing against the source database.
+        clarification_option_id:
+          type: string
+          pattern: '^join_path_[a-f0-9]{12}$'
+          description: Opaque option ID returned by a prior 422 clarification response for this session.
         max_rows:
           type: integer
           minimum: 1
@@ -3658,7 +3675,7 @@ components:
       properties:
         error:
           type: string
-          enum: [schema_linking_ambiguous]
+          enum: [schema_linking_ambiguous, clarification_option_invalid]
         message:
           type: string
         clarification:

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -3146,6 +3146,19 @@ export interface paths {
                         "application/json": components["schemas"]["RunSessionResponse"];
                     };
                 };
+                /** @description The clarification is no longer pending for this session */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "clarification_not_pending";
+                            message: string;
+                        };
+                    };
+                };
                 /** @description Query intent requires clarification before generation can continue */
                 422: {
                     headers: {
@@ -5084,6 +5097,8 @@ export interface components {
             sql_override?: string;
             /** @description When true, generate and validate SQL without connecting to or executing against the source database. */
             no_execute?: boolean;
+            /** @description Opaque option ID returned by a prior 422 clarification response for this session. */
+            clarification_option_id?: string;
             max_rows?: number;
             timeout_ms?: number;
         };
@@ -5116,7 +5131,7 @@ export interface components {
         };
         QueryClarificationRequiredResponse: {
             /** @enum {string} */
-            error: "schema_linking_ambiguous";
+            error: "schema_linking_ambiguous" | "clarification_option_invalid";
             message: string;
             clarification: components["schemas"]["QueryClarification"];
         };


### PR DESCRIPTION
## Summary

- persist pending, resolved, cancelled, and superseded clarification state for auditability
- accept an opaque clarification option on the existing session run endpoint
- revalidate the option against both the current schema graph and the session’s stored choices
- rebuild scoped schema and join-policy context from the selected path before generation
- preserve retry support for already resolved selections and reject stale or cross-session choices
- add migration, OpenAPI bindings, and focused orchestration/store/graph tests

Part of #180

## Verification

- `npm run typecheck`
- focused clarification, orchestration, migration, and schema-graph tests (22 tests)
- `npm test` (268 tests)
- `npm --prefix frontend run lint`
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)