### PR TITLE
Add query clarification selection UI

### DIFF
--- a/app/src/lib/routePolicy.ts
+++ b/app/src/lib/routePolicy.ts
@@ -86,6 +86,7 @@ export const POLICIES: ReadonlyArray<RoutePolicy> = [
   { method: "POST", pattern: /^\/v1\/query\/sessions$/, permission: "query.run" },
   { method: "GET", pattern: /^\/v1\/query\/prompts\/history$/, permission: "query.run" },
   { method: "POST", pattern: /^\/v1\/query\/sessions\/[^/]+\/run$/, permission: "query.run" },
+  { method: "POST", pattern: /^\/v1\/query\/sessions\/[^/]+\/clarification\/cancel$/, permission: "query.run" },
   { method: "POST", pattern: /^\/v1\/query\/sessions\/[^/]+\/feedback$/, permission: "query.run" },
   { method: "POST", pattern: /^\/v1\/query\/sessions\/[^/]+\/export$/, permission: "query.run" },
   { method: "POST", pattern: /^\/v1\/query\/sessions\/[^/]+\/export\/deliver$/, permission: "query.run" },

--- a/app/src/routes/query.ts
+++ b/app/src/routes/query.ts
@@ -11,6 +11,7 @@ import { clamp, isUuid } from "../lib/validation";
 import { validateAndNormalizeSql } from "../services/sqlSafety";
 import ragService = require("../services/ragService");
 import { orchestrateQueryRun } from "../services/queryOrchestrationService";
+import { cancelPendingClarification } from "../services/queryClarificationStore";
 import { enforceDataSourceAccess, listAccessibleDataSourceIds } from "../lib/authGate";
 import type {
   CreateSessionRequest,
@@ -227,9 +228,32 @@ const handleFeedback: RouteHandlerWithId<FeedbackRequest> = async (req, res, ses
   return json(res, 200, { ok: true, example_saved: exampleSaved, example_reason: exampleReason });
 };
 
+const handleCancelClarification: RouteHandlerWithId = async (req, res, sessionId) => {
+  const sessionLookup = await appDb.query<{ data_source_id: string }>(
+    "SELECT data_source_id FROM query_sessions WHERE id = $1",
+    [sessionId]
+  );
+  if (sessionLookup.rowCount === 0) {
+    return json(res, 404, { error: "not_found", message: "Session not found" });
+  }
+  if (!(await enforceDataSourceAccess(req, res, sessionLookup.rows[0].data_source_id))) {
+    return undefined;
+  }
+
+  const cancelled = await cancelPendingClarification(sessionId);
+  if (!cancelled) {
+    return json(res, 409, {
+      error: "clarification_not_pending",
+      message: "This query session does not have a pending clarification"
+    });
+  }
+  return json(res, 200, { ok: true, status: "cancelled" });
+};
+
 export {
   handleCreateSession,
   handlePromptHistory,
   handleRunSession,
+  handleCancelClarification,
   handleFeedback
 };

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -43,6 +43,7 @@ import {
   handleCreateSession,
   handlePromptHistory,
   handleRunSession,
+  handleCancelClarification,
   handleFeedback
 } from "./routes/query";
 import {
@@ -558,6 +559,11 @@ async function routeRequest(req: AuthedRequest, res: ServerResponse): Promise<vo
   const runMatch = pathname.match(/^\/v1\/query\/sessions\/([^/]+)\/run$/);
   if (req.method === "POST" && runMatch) {
     return handleRunSession(req, res, runMatch[1]);
+  }
+
+  const cancelClarificationMatch = pathname.match(/^\/v1\/query\/sessions\/([^/]+)\/clarification\/cancel$/);
+  if (req.method === "POST" && cancelClarificationMatch) {
+    return handleCancelClarification(req, res, cancelClarificationMatch[1]);
   }
 
   const feedbackMatch = pathname.match(/^\/v1\/query\/sessions\/([^/]+)\/feedback$/);

--- a/app/src/services/queryClarificationStore.ts
+++ b/app/src/services/queryClarificationStore.ts
@@ -87,3 +87,26 @@ export async function resolvePendingClarification(
     return true;
   });
 }
+
+export async function cancelPendingClarification(sessionId: string): Promise<boolean> {
+  return appDb.withTransaction(async (client: PoolClient) => {
+    const result = await client.query(
+      `
+        UPDATE query_clarifications
+        SET status = 'cancelled'
+        WHERE id = (
+          SELECT id
+          FROM query_clarifications
+          WHERE session_id = $1 AND status = 'pending'
+          ORDER BY created_at DESC
+          LIMIT 1
+          FOR UPDATE
+        )
+      `,
+      [sessionId]
+    );
+    if ((result.rowCount ?? 0) === 0) return false;
+    await client.query("UPDATE query_sessions SET status = 'cancelled' WHERE id = $1", [sessionId]);
+    return true;
+  });
+}

--- a/app/src/types/openapi.ts
+++ b/app/src/types/openapi.ts
@@ -3218,6 +3218,55 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/query/sessions/{sessionId}/clarification/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cancel a pending query clarification */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    sessionId: components["parameters"]["SessionId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Clarification cancelled */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            ok: boolean;
+                            /** @enum {string} */
+                            status: "cancelled";
+                        };
+                    };
+                };
+                /** @description The session has no pending clarification */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/query/sessions/{sessionId}/export": {
         parameters: {
             query?: never;

--- a/app/test/queryClarificationStore.test.ts
+++ b/app/test/queryClarificationStore.test.ts
@@ -5,6 +5,7 @@ import type { PoolClient } from "pg";
 
 import appDb = require("../src/lib/appDb");
 import {
+  cancelPendingClarification,
   recordPendingClarification,
   resolvePendingClarification
 } from "../src/services/queryClarificationStore";
@@ -40,6 +41,27 @@ test("clarification store persists pending options and audits their resolution",
     assert.ok(statements.some((entry) => entry.sql.includes("status = 'awaiting_clarification'")));
     assert.ok(statements.some((entry) => entry.sql.includes("selected_option_id = $2")));
     assert.ok(statements.some((entry) => entry.sql.includes("status = 'created'")));
+  } finally {
+    appDb.withTransaction = originalTransaction;
+  }
+});
+
+test("clarification store audits cancellation and updates the session state", async () => {
+  const originalTransaction = appDb.withTransaction;
+  const statements: string[] = [];
+  const client = {
+    query: async (sql: string) => {
+      const normalized = sql.replace(/\s+/g, " ").trim().toLowerCase();
+      statements.push(normalized);
+      return { rowCount: 1, rows: [] };
+    }
+  } as unknown as PoolClient;
+  appDb.withTransaction = (async <T>(callback: (transactionClient: PoolClient) => Promise<T>) => callback(client)) as typeof appDb.withTransaction;
+
+  try {
+    assert.equal(await cancelPendingClarification("session-1"), true);
+    assert.ok(statements.some((statement) => statement.includes("set status = 'cancelled'")));
+    assert.ok(statements.some((statement) => statement.includes("update query_sessions set status = 'cancelled'")));
   } finally {
     appDb.withTransaction = originalTransaction;
   }

--- a/app/test/routePolicy.test.ts
+++ b/app/test/routePolicy.test.ts
@@ -44,6 +44,7 @@ test("findPolicy maps known endpoints to the expected policy", () => {
 
   // Query / run
   assert.equal(requirePolicy("POST", "/v1/query/sessions").permission, "query.run");
+  assert.equal(requirePolicy("POST", "/v1/query/sessions/session-1/clarification/cancel").permission, "query.run");
   assert.equal(requirePolicy("POST", "/v1/saved-queries/00000000-0000-4000-8000-000000000001/run").permission, "query.run");
   assert.equal(requirePolicy("GET", "/v1/exports/00000000-0000-4000-8000-000000000001/status").permission, "query.run");
 });

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1562,6 +1562,28 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OkResponse"
+  /v1/query/sessions/{sessionId}/clarification/cancel:
+    post:
+      tags: [Query]
+      summary: Cancel a pending query clarification
+      parameters:
+        - $ref: "#/components/parameters/SessionId"
+      responses:
+        "200":
+          description: Clarification cancelled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  status:
+                    type: string
+                    enum: [cancelled]
+                required: [ok, status]
+        "409":
+          description: The session has no pending clarification
   /v1/query/sessions/{sessionId}/export:
     post:
       tags: [Export]

--- a/frontend/src/components/Query/ClarificationPanel.tsx
+++ b/frontend/src/components/Query/ClarificationPanel.tsx
@@ -1,0 +1,83 @@
+import { CircleHelp, Loader2, X } from 'lucide-react';
+import type { QueryClarification } from './types';
+
+interface ClarificationPanelProps {
+    clarification: QueryClarification;
+    resolvingOptionId: string | null;
+    selectedOptionId: string | null;
+    isCancelling: boolean;
+    onSelect: (optionId: string) => void;
+    onCancel: () => void;
+}
+
+export function ClarificationPanel({
+    clarification,
+    resolvingOptionId,
+    selectedOptionId,
+    isCancelling,
+    onSelect,
+    onCancel,
+}: ClarificationPanelProps) {
+    const busy = Boolean(resolvingOptionId) || isCancelling;
+
+    return (
+        <section
+            aria-labelledby="query-clarification-title"
+            aria-live="polite"
+            className="mx-4 mt-4 rounded-lg border border-amber-300 bg-amber-50/70 p-4 shadow-sm"
+        >
+            <div className="flex items-start justify-between gap-4">
+                <div className="flex gap-3">
+                    <span className="mt-0.5 rounded-full bg-amber-100 p-2 text-amber-700">
+                        <CircleHelp size={18} aria-hidden="true" />
+                    </span>
+                    <div>
+                        <h2 id="query-clarification-title" className="text-sm font-bold text-slate-900">
+                            Clarify query intent
+                        </h2>
+                        <p className="mt-1 text-xs leading-5 text-slate-600">{clarification.message}</p>
+                    </div>
+                </div>
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    disabled={busy}
+                    className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-slate-500 hover:bg-amber-100 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                    {isCancelling ? <Loader2 size={12} className="animate-spin" /> : <X size={12} />}
+                    Cancel
+                </button>
+            </div>
+
+            <fieldset className="mt-3 grid gap-2">
+                <legend className="sr-only">Query interpretations</legend>
+                {clarification.options.map((option) => {
+                    const isResolving = resolvingOptionId === option.id;
+                    const isSelected = selectedOptionId === option.id;
+                    return (
+                        <button
+                            key={option.id}
+                            type="button"
+                            onClick={() => onSelect(option.id)}
+                            disabled={busy || Boolean(selectedOptionId && !isSelected)}
+                            className="group flex w-full items-start justify-between gap-4 rounded-md border border-amber-200 bg-white px-3 py-3 text-left transition-colors hover:border-amber-400 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                            <span>
+                                <span className="block text-xs font-bold text-slate-800">{option.label}</span>
+                                <span className="mt-1 block text-xs leading-5 text-slate-500">{option.description}</span>
+                                <span className="mt-1.5 block text-[11px] text-slate-400">
+                                    {option.table_refs.join(' · ')}
+                                </span>
+                            </span>
+                            <span className="mt-0.5 shrink-0 text-xs font-semibold text-oxblood">
+                                {isResolving
+                                    ? <Loader2 size={14} className="animate-spin" />
+                                    : isSelected ? 'Retry' : 'Use path'}
+                            </span>
+                        </button>
+                    );
+                })}
+            </fieldset>
+        </section>
+    );
+}

--- a/frontend/src/components/Query/types.ts
+++ b/frontend/src/components/Query/types.ts
@@ -1,6 +1,7 @@
 import type { components } from '../../lib/api/types';
 
 export type RunProvider = NonNullable<components['schemas']['RunSessionRequest']['llm_provider']>;
+export type QueryClarification = components['schemas']['QueryClarification'];
 
 export interface LlmProvider {
     id: string;

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -3218,6 +3218,55 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/query/sessions/{sessionId}/clarification/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cancel a pending query clarification */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    sessionId: components["parameters"]["SessionId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Clarification cancelled */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            ok: boolean;
+                            /** @enum {string} */
+                            status: "cancelled";
+                        };
+                    };
+                };
+                /** @description The session has no pending clarification */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/query/sessions/{sessionId}/export": {
         parameters: {
             query?: never;

--- a/frontend/src/pages/QueryWorkspace.tsx
+++ b/frontend/src/pages/QueryWorkspace.tsx
@@ -6,6 +6,7 @@ import { Calendar, Loader2, Play, Save, Share2, Timer } from 'lucide-react';
 import { format as formatSql } from 'sql-formatter';
 import { toast } from 'sonner';
 import { InspectorPanel } from '../components/Query/InspectorPanel';
+import { ClarificationPanel } from '../components/Query/ClarificationPanel';
 import { PromptSection } from '../components/Query/PromptSection';
 import { ResultSection } from '../components/Query/ResultSection';
 import { SaveQueryDialog, type SaveQueryDialogValues } from '../components/Query/SaveQueryDialog';
@@ -14,6 +15,7 @@ import { SqlSection } from '../components/Query/SqlSection';
 import type {
     LlmProvider,
     PromptHistoryItem,
+    QueryClarification,
     RunResponse,
     RunProvider,
     SavedQuery,
@@ -29,7 +31,27 @@ type QueryRunErrorPayload = {
     message?: string;
     details?: string[];
     sql?: string;
+    clarification?: QueryClarification;
 };
+
+function parseClarification(value: unknown): QueryClarification | undefined {
+    if (!value || typeof value !== 'object') return undefined;
+    const candidate = value as Record<string, unknown>;
+    if (candidate.kind !== 'join_path' || typeof candidate.message !== 'string' || !Array.isArray(candidate.options)) {
+        return undefined;
+    }
+    const options = candidate.options.filter((option): option is QueryClarification['options'][number] => {
+        if (!option || typeof option !== 'object') return false;
+        const item = option as Record<string, unknown>;
+        return typeof item.id === 'string'
+            && typeof item.label === 'string'
+            && typeof item.description === 'string'
+            && Array.isArray(item.table_refs)
+            && item.table_refs.every((ref) => typeof ref === 'string');
+    });
+    if (options.length < 2 || options.length !== candidate.options.length) return undefined;
+    return { kind: 'join_path', message: candidate.message, options };
+}
 
 function parseRunErrorPayload(error: unknown): QueryRunErrorPayload | null {
     if (!error || typeof error !== 'object') {
@@ -44,6 +66,7 @@ function parseRunErrorPayload(error: unknown): QueryRunErrorPayload | null {
         message: typeof payload.message === 'string' ? payload.message : undefined,
         details,
         sql: typeof payload.sql === 'string' ? payload.sql : undefined,
+        clarification: parseClarification(payload.clarification),
     };
 }
 
@@ -86,6 +109,10 @@ export const QueryWorkspace = () => {
     const [paramErrors, setParamErrors] = useState<Record<string, string> | null>(null);
     const [saveDialogOpen, setSaveDialogOpen] = useState(false);
     const [isSubmittingSave, setIsSubmittingSave] = useState(false);
+    const [clarification, setClarification] = useState<QueryClarification | null>(null);
+    const [resolvingOptionId, setResolvingOptionId] = useState<string | null>(null);
+    const [selectedClarificationOptionId, setSelectedClarificationOptionId] = useState<string | null>(null);
+    const [isCancellingClarification, setIsCancellingClarification] = useState(false);
 
     const sqlEditorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
     const selectedDataSource = dataSources.find((dataSource) => dataSource.id === selectedDataSourceId) || null;
@@ -125,16 +152,23 @@ export const QueryWorkspace = () => {
 
     const applyRunError = (error: unknown, options?: { updateOriginalSql?: boolean }) => {
         const payload = parseRunErrorPayload(error);
-        if (!payload?.sql) {
-            return;
+        if (payload?.clarification) {
+            setClarification(payload.clarification);
         }
-        setGeneratedSql(payload.sql);
-        if (options?.updateOriginalSql) {
-            setOriginalSql(payload.sql);
+        if (payload?.sql) {
+            setGeneratedSql(payload.sql);
+            if (options?.updateOriginalSql) {
+                setOriginalSql(payload.sql);
+            }
         }
+        return payload;
     };
 
-    const generateSql = async (nextSessionId: string, sqlOverride?: string) => {
+    const generateSql = async (
+        nextSessionId: string,
+        sqlOverride?: string,
+        clarificationOptionId?: string,
+    ): Promise<boolean> => {
         const { data, error } = await client.POST('/v1/query/sessions/{sessionId}/run', {
             params: { path: { sessionId: nextSessionId } },
             body: {
@@ -144,6 +178,7 @@ export const QueryWorkspace = () => {
                 max_rows: maxRows,
                 timeout_ms: Math.max(1000, Math.round(timeout * 1000)),
                 ...(sqlOverride ? { sql_override: sqlOverride } : {}),
+                ...(clarificationOptionId ? { clarification_option_id: clarificationOptionId } : {}),
             },
         });
 
@@ -151,13 +186,29 @@ export const QueryWorkspace = () => {
             setGeneratedSql(data.sql);
             setOriginalSql(data.sql);
             setQueryResult(data as RunResponse);
-            return;
+            setClarification(null);
+            setSelectedClarificationOptionId(null);
+            return true;
         }
 
         if (error) {
             setQueryResult(null);
-            applyRunError(error, { updateOriginalSql: true });
+            const payload = applyRunError(error, { updateOriginalSql: true });
+            if (payload?.clarification) {
+                setSelectedClarificationOptionId(null);
+                toast.info('Choose an interpretation to continue.');
+            } else if (clarificationOptionId) {
+                setSelectedClarificationOptionId(clarificationOptionId);
+                if (payload?.error === 'clarification_not_pending') {
+                    setClarification(null);
+                    setSessionId(null);
+                }
+                toast.error(payload?.message || 'Generation failed. Retry this interpretation.');
+            } else {
+                toast.error(payload?.message || 'Failed to generate SQL');
+            }
         }
+        return false;
     };
 
     const handleAsk = async () => {
@@ -170,6 +221,8 @@ export const QueryWorkspace = () => {
         setIsGenerating(true);
         setGeneratedSql('');
         setQueryResult(null);
+        setClarification(null);
+        setSelectedClarificationOptionId(null);
         setLoadedSavedQuery(null);
 
         try {
@@ -197,6 +250,48 @@ export const QueryWorkspace = () => {
             toast.error('An error occurred');
         } finally {
             setIsGenerating(false);
+        }
+    };
+
+    const handleClarificationSelect = async (optionId: string) => {
+        if (!sessionId || resolvingOptionId || isCancellingClarification) return;
+        setResolvingOptionId(optionId);
+        setIsGenerating(true);
+        try {
+            const succeeded = await generateSql(sessionId, undefined, optionId);
+            if (succeeded) {
+                toast.success(isDryRun ? 'Preview generated successfully' : 'Query executed successfully');
+                void fetchPromptHistory(false);
+            }
+        } catch (error) {
+            console.error(error);
+            toast.error('Failed to apply this interpretation. You can retry or choose another.');
+        } finally {
+            setResolvingOptionId(null);
+            setIsGenerating(false);
+        }
+    };
+
+    const handleClarificationCancel = async () => {
+        if (!sessionId || resolvingOptionId || isCancellingClarification) return;
+        setIsCancellingClarification(true);
+        try {
+            const { data, error } = await client.POST('/v1/query/sessions/{sessionId}/clarification/cancel', {
+                params: { path: { sessionId } },
+            });
+            if (error || !data) {
+                toast.error('Could not cancel this clarification.');
+                return;
+            }
+            setClarification(null);
+            setSelectedClarificationOptionId(null);
+            setSessionId(null);
+            toast.info('Clarification cancelled. Refine the question and ask again.');
+        } catch (error) {
+            console.error(error);
+            toast.error('Could not cancel this clarification.');
+        } finally {
+            setIsCancellingClarification(false);
         }
     };
 
@@ -336,6 +431,8 @@ export const QueryWorkspace = () => {
         setGeneratedSql(savedQuery.sql);
         setOriginalSql(savedQuery.sql);
         setQueryResult(null);
+        setClarification(null);
+        setSelectedClarificationOptionId(null);
         setLoadedSavedQuery(savedQuery);
 
         const seededParams: ParamValues = {};
@@ -583,6 +680,17 @@ export const QueryWorkspace = () => {
                     onPromptHistorySelect={handlePromptHistorySelect}
                     onAsk={handleAsk}
                 />
+
+                {clarification && (
+                    <ClarificationPanel
+                        clarification={clarification}
+                        resolvingOptionId={resolvingOptionId}
+                        selectedOptionId={selectedClarificationOptionId}
+                        isCancelling={isCancellingClarification}
+                        onSelect={handleClarificationSelect}
+                        onCancel={handleClarificationCancel}
+                    />
+                )}
 
                 {loadedSavedQuery && loadedSavedQuery.parameter_schema?.length > 0 && (
                     <SavedQueryParamsPanel


### PR DESCRIPTION
## Summary

- render structured clarification options inline in the query workspace
- resume the same session with the selected opaque interpretation
- preserve a committed interpretation for safe retries after downstream failures
- add an audited cancellation transition and workspace Cancel action
- validate clarification error payloads before rendering and keep generated API bindings aligned
- cover cancellation persistence and route authorization

Part of #180

## Verification

- `npm run typecheck`
- focused clarification, route policy, orchestration, and context tests (16 tests)
- `npm test` (269 tests)
- `npm --prefix frontend run lint`
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)