### PR TITLE
Clarify competing table and metric intent

### DIFF
--- a/app/src/routes/query.ts
+++ b/app/src/routes/query.ts
@@ -120,7 +120,7 @@ const handleRunSession: RouteHandlerWithId<RunSessionRequest, RunSessionResponse
   const clarificationOptionId = typeof body.clarification_option_id === "string"
     ? body.clarification_option_id.trim()
     : null;
-  if (clarificationOptionId && !/^join_path_[a-f0-9]{12}$/.test(clarificationOptionId)) {
+  if (clarificationOptionId && !/^(?:join_path|table|metric)_[a-f0-9]{12}$/.test(clarificationOptionId)) {
     return badRequest(res, "clarification_option_id is invalid");
   }
   const sqlOverride = typeof body.sql_override === "string" && body.sql_override.trim() ? body.sql_override.trim() : null;

--- a/app/src/services/queryClarificationService.ts
+++ b/app/src/services/queryClarificationService.ts
@@ -1,5 +1,6 @@
 import { createHash } from "crypto";
 import type { SchemaExpansion, SchemaGraphEdge, SchemaPath } from "./schemaGraphService";
+import type { TableCandidate } from "./schemaLinkingService";
 
 export interface QueryClarificationOption {
   id: string;
@@ -9,9 +10,30 @@ export interface QueryClarificationOption {
 }
 
 export interface QueryClarification {
-  kind: "join_path";
+  kind: "join_path" | "table" | "metric";
   message: string;
   options: QueryClarificationOption[];
+}
+
+export interface CandidateClarification {
+  clarification: QueryClarification;
+  candidate_ids: string[];
+}
+
+export function buildCandidateClarification(
+  question: string,
+  candidates: TableCandidate[]
+): CandidateClarification | null {
+  return buildMetricClarification(question, candidates)
+    || buildTableClarification(question, candidates);
+}
+
+export function findCandidateIdByOptionId(
+  ambiguity: CandidateClarification,
+  optionId: string
+): string | null {
+  const index = ambiguity.clarification.options.findIndex((option) => option.id === optionId);
+  return index >= 0 ? ambiguity.candidate_ids[index] : null;
 }
 
 export function buildJoinPathClarification(expansion: SchemaExpansion): QueryClarification | null {
@@ -70,6 +92,109 @@ function toOption(path: SchemaPath, index: number, total: number): QueryClarific
 
 function optionIdForPath(path: SchemaPath): string {
   return `join_path_${createHash("sha256").update(pathSignature(path)).digest("hex").slice(0, 12)}`;
+}
+
+function buildMetricClarification(question: string, candidates: TableCandidate[]): CandidateClarification | null {
+  const normalizedQuestion = normalizePhrase(question);
+  const aliases = new Map<string, { label: string; candidates: TableCandidate[] }>();
+  for (const candidate of candidates) {
+    for (const alias of candidate.semantic_aliases) {
+      const normalizedAlias = normalizePhrase(alias);
+      if (!normalizedAlias || !phraseMatches(normalizedQuestion, normalizedAlias)) continue;
+      const group = aliases.get(normalizedAlias) || { label: alias, candidates: [] };
+      group.candidates.push(candidate);
+      aliases.set(normalizedAlias, group);
+    }
+  }
+
+  const competing = [...aliases.entries()]
+    .filter(([, group]) => uniqueCandidates(group.candidates).length > 1)
+    .filter(([, group]) => !group.candidates.some((candidate) => questionNamesCandidate(normalizedQuestion, candidate)))
+    .sort(([left], [right]) => right.length - left.length || left.localeCompare(right))[0]?.[1];
+  if (!competing) return null;
+  const options = uniqueCandidates(competing.candidates).sort(compareCandidateRefs);
+  return candidateClarification(
+    "metric",
+    `“${competing.label}” maps to multiple reporting entities. Choose the intended source.`,
+    options,
+    (candidate) => `Use ${competing.label} from ${candidate.schema_name}.${candidate.object_name}`
+  );
+}
+
+function buildTableClarification(question: string, candidates: TableCandidate[]): CandidateClarification | null {
+  const normalizedQuestion = normalizePhrase(question);
+  const groups = new Map<string, TableCandidate[]>();
+  for (const candidate of candidates) {
+    const objectName = normalizePhrase(candidate.object_name.replace(/_/g, " "));
+    if (!objectName || !phraseMatches(normalizedQuestion, objectName)) continue;
+    if (phraseMatches(normalizedQuestion, normalizePhrase(`${candidate.schema_name} ${candidate.object_name}`.replace(/_/g, " ")))) {
+      continue;
+    }
+    const group = groups.get(candidate.object_name.toLowerCase()) || [];
+    group.push(candidate);
+    groups.set(candidate.object_name.toLowerCase(), group);
+  }
+
+  const competing = [...groups.values()]
+    .filter((group) => uniqueCandidates(group).length > 1)
+    .sort((left, right) => compareCandidateRefs(left[0], right[0]))[0];
+  if (!competing) return null;
+  const options = uniqueCandidates(competing).sort(compareCandidateRefs);
+  return candidateClarification(
+    "table",
+    `“${options[0].object_name}” exists in multiple schemas. Choose the intended table.`,
+    options,
+    (candidate) => `Use ${candidate.schema_name}.${candidate.object_name}`
+  );
+}
+
+function candidateClarification(
+  kind: "table" | "metric",
+  message: string,
+  candidates: TableCandidate[],
+  label: (candidate: TableCandidate) => string
+): CandidateClarification {
+  return {
+    clarification: {
+      kind,
+      message,
+      options: candidates.slice(0, 8).map((candidate) => ({
+        id: `${kind}_${createHash("sha256").update(candidate.id).digest("hex").slice(0, 12)}`,
+        label: label(candidate),
+        description: `Uses the reporting object ${candidate.schema_name}.${candidate.object_name}.`,
+        table_refs: [`${candidate.schema_name}.${candidate.object_name}`]
+      }))
+    },
+    candidate_ids: candidates.slice(0, 8).map((candidate) => candidate.id)
+  };
+}
+
+function questionNamesCandidate(question: string, candidate: TableCandidate): boolean {
+  return phraseMatches(question, normalizePhrase(candidate.object_name.replace(/_/g, " ")))
+    || phraseMatches(question, normalizePhrase(`${candidate.schema_name} ${candidate.object_name}`.replace(/_/g, " ")));
+}
+
+function uniqueCandidates(candidates: TableCandidate[]): TableCandidate[] {
+  const seen = new Set<string>();
+  return candidates.filter((candidate) => {
+    if (seen.has(candidate.id)) return false;
+    seen.add(candidate.id);
+    return true;
+  });
+}
+
+function compareCandidateRefs(left: TableCandidate, right: TableCandidate): number {
+  return left.schema_name.localeCompare(right.schema_name)
+    || left.object_name.localeCompare(right.object_name)
+    || left.id.localeCompare(right.id);
+}
+
+function normalizePhrase(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function phraseMatches(question: string, phrase: string): boolean {
+  return Boolean(phrase) && ` ${question} `.includes(` ${phrase} `);
 }
 
 function duplicateLabelRisk(path: SchemaPath): boolean {

--- a/app/src/services/queryClarificationStore.ts
+++ b/app/src/services/queryClarificationStore.ts
@@ -110,3 +110,18 @@ export async function cancelPendingClarification(sessionId: string): Promise<boo
     return true;
   });
 }
+
+export async function loadResolvedClarificationOptionIds(sessionId: string): Promise<string[]> {
+  const result = await appDb.query<{ selected_option_id: string }>(
+    `
+      SELECT selected_option_id
+      FROM query_clarifications
+      WHERE session_id = $1
+        AND status = 'resolved'
+        AND selected_option_id IS NOT NULL
+      ORDER BY resolved_at ASC
+    `,
+    [sessionId]
+  );
+  return [...new Set(result.rows.map((row) => row.selected_option_id).filter(Boolean))];
+}

--- a/app/src/services/queryDiagnosticsService.ts
+++ b/app/src/services/queryDiagnosticsService.ts
@@ -1,6 +1,7 @@
 import { logEvent } from "../lib/observability";
 import type { ProviderAttempt } from "./llmSqlService";
 import type { SchemaLinkingDiagnostics } from "./queryGenerationContextService";
+import type { QueryClarification } from "./queryClarificationService";
 
 const MAX_TABLE_IDS = 20;
 const MAX_PROVIDER_ATTEMPTS = 8;
@@ -26,6 +27,8 @@ export interface QueryDiagnosticInput {
   repairPromptChars: number;
   tokenUsage: unknown;
   executionDurationMs?: number | null;
+  clarificationKind?: QueryClarification["kind"] | null;
+  clarificationOptionCount?: number;
 }
 
 export interface QueryDiagnosticPayload {
@@ -48,6 +51,7 @@ export interface QueryDiagnosticPayload {
     fallback_category: "none" | "no_provider" | "provider_failure";
     clarification_required: boolean;
     clarification_option_count: number;
+    clarification_kind: QueryClarification["kind"] | null;
   } | null;
   retrieval: { rag_document_count: number; example_count: number };
   generation: {
@@ -116,9 +120,11 @@ export function buildQueryDiagnostic(input: QueryDiagnosticInput): QueryDiagnost
       fallback_category: linker?.status !== "fallback"
         ? "none"
         : linkerAttempts.length === 0 ? "no_provider" : "provider_failure",
-      clarification_required: expansion?.status === "ambiguous",
-      clarification_option_count: (expansion?.ambiguities || [])
-        .reduce((total, ambiguity) => total + ambiguity.alternatives.length, 0)
+      clarification_required: Boolean(input.clarificationKind) || expansion?.status === "ambiguous",
+      clarification_option_count: input.clarificationOptionCount === undefined
+        ? (expansion?.ambiguities || []).reduce((total, ambiguity) => total + ambiguity.alternatives.length, 0)
+        : Math.max(0, Math.floor(input.clarificationOptionCount)),
+      clarification_kind: input.clarificationKind || (expansion?.status === "ambiguous" ? "join_path" : null)
     } : null,
     retrieval: {
       rag_document_count: Math.max(0, Math.floor(input.ragDocumentCount)),

--- a/app/src/services/queryGenerationContextService.ts
+++ b/app/src/services/queryGenerationContextService.ts
@@ -10,13 +10,16 @@ import {
   loadExpandedSchemaContext,
   loadResolvedSchemaContext,
   type ExpandedSchemaContext,
-  type SchemaExpansion
+  type SchemaExpansion,
+  type SchemaPath
 } from "./schemaGraphService";
 import type { QueryContext } from "./queryOrchestrationStore";
 import type { RagRetrievalDoc } from "./ragRetrieval";
 import { rankValidatedExamples } from "./exampleRankingService";
 import {
   buildJoinPathClarification,
+  buildCandidateClarification,
+  findCandidateIdByOptionId,
   findJoinPathByOptionId,
   type QueryClarification
 } from "./queryClarificationService";
@@ -32,6 +35,7 @@ export interface PrepareGenerationContextInput {
   candidateLimit?: number;
   finalRagLimit?: number;
   clarificationOptionId?: string | null;
+  resolvedClarificationOptionIds?: string[];
 }
 
 export interface SchemaLinkingDiagnostics {
@@ -106,10 +110,36 @@ export async function prepareQueryGenerationContext(
     };
   }
 
+  let linkerCandidates = candidates;
+  const candidateAmbiguity = buildCandidateClarification(input.question, candidates);
+  if (candidateAmbiguity) {
+    const optionIds = clarificationOptionIds(input);
+    const selectedCandidateId = optionIds
+      .map((optionId) => findCandidateIdByOptionId(candidateAmbiguity, optionId))
+      .find((candidateId): candidateId is string => Boolean(candidateId));
+    if (!selectedCandidateId) {
+      const invalidForKind = Boolean(input.clarificationOptionId)
+        && input.clarificationOptionId!.startsWith(`${candidateAmbiguity.clarification.kind}_`);
+      return {
+        ok: false,
+        code: invalidForKind ? "clarification_option_invalid" : "schema_linking_ambiguous",
+        message: invalidForKind
+          ? "The selected clarification option is no longer valid"
+          : "Multiple table or metric interpretations were found",
+        clarification: candidateAmbiguity.clarification,
+        diagnostics
+      };
+    }
+    const competingIds = new Set(candidateAmbiguity.candidate_ids);
+    linkerCandidates = candidates.filter((candidate) =>
+      !competingIds.has(candidate.id) || candidate.id === selectedCandidateId
+    );
+  }
+
   const linker = await dependencies.linkTablesWithRouting({
     dataSourceId: input.dataSourceId,
     question: input.question,
-    candidates,
+    candidates: linkerCandidates,
     requestedProvider: input.requestedProvider,
     requestedModel: input.requestedModel,
     requestId: input.requestId
@@ -123,8 +153,11 @@ export async function prepareQueryGenerationContext(
   );
   diagnostics.expansion = expanded.expansion;
 
-  if (expanded.expansion.status === "ambiguous" && input.clarificationOptionId) {
-    const selectedPath = findJoinPathByOptionId(expanded.expansion, input.clarificationOptionId);
+  const joinPathOptionIds = clarificationOptionIds(input).filter((optionId) => optionId.startsWith("join_path_"));
+  if (expanded.expansion.status === "ambiguous" && joinPathOptionIds.length > 0) {
+    const selectedPath = joinPathOptionIds
+      .map((optionId) => findJoinPathByOptionId(expanded.expansion, optionId))
+      .find((path): path is SchemaPath => Boolean(path));
     if (!selectedPath) {
       return {
         ok: false,
@@ -157,6 +190,13 @@ export async function prepareQueryGenerationContext(
     ragDocuments: selectFinalRagDocuments(retrievedDocuments, expanded, finalRagLimit),
     diagnostics
   };
+}
+
+function clarificationOptionIds(input: PrepareGenerationContextInput): string[] {
+  return [...new Set([
+    input.clarificationOptionId,
+    ...(input.resolvedClarificationOptionIds || [])
+  ].map((value) => String(value || "").trim()).filter(Boolean))];
 }
 
 function selectFinalRagDocuments(

--- a/app/src/services/queryOrchestrationService.ts
+++ b/app/src/services/queryOrchestrationService.ts
@@ -29,8 +29,10 @@ import {
 } from "./queryDiagnosticsService";
 import {
   recordPendingClarification,
-  resolvePendingClarification
+  resolvePendingClarification,
+  loadResolvedClarificationOptionIds
 } from "./queryClarificationStore";
+import type { QueryClarification } from "./queryClarificationService";
 
 const { extractForbiddenColumnsFromRagNotes, validateSqlAgainstForbiddenColumns } = columnPolicyService;
 const { retrieveRagContext } = ragRetrieval;
@@ -64,6 +66,7 @@ export interface QueryOrchestrationDependencies {
   emitQueryDiagnostic: typeof emitQueryDiagnostic;
   recordPendingClarification: typeof recordPendingClarification;
   resolvePendingClarification: typeof resolvePendingClarification;
+  loadResolvedClarificationOptionIds: typeof loadResolvedClarificationOptionIds;
 }
 
 const defaultDependencies: QueryOrchestrationDependencies = {
@@ -72,7 +75,8 @@ const defaultDependencies: QueryOrchestrationDependencies = {
   createDatabaseAdapter,
   emitQueryDiagnostic,
   recordPendingClarification,
-  resolvePendingClarification
+  resolvePendingClarification,
+  loadResolvedClarificationOptionIds
 };
 
 function success<T>(body: T, statusCode = 200): OrchestrateResult<T> {
@@ -219,6 +223,7 @@ export async function orchestrateQueryRun({
   let generationPromptChars = 0;
   let schemaLinkingDurationMs = 0;
   let executionDurationMs = 0;
+  let activeClarification: QueryClarification | null = null;
   const repairs: Array<{
     errors: string[];
     provider: string;
@@ -252,7 +257,9 @@ export async function orchestrateQueryRun({
       generationPromptChars,
       repairPromptChars: repairs.reduce((total, repair) => total + repair.prompt_chars, 0),
       tokenUsage: generationTokenUsage,
-      executionDurationMs
+      executionDurationMs,
+      clarificationKind: activeClarification?.kind || null,
+      clarificationOptionCount: activeClarification?.options.length
     });
   };
 
@@ -265,13 +272,17 @@ export async function orchestrateQueryRun({
     let prepared;
     const schemaLinkingStartedAt = Date.now();
     try {
+      const resolvedClarificationOptionIds = clarificationOptionId
+        ? await dependencies.loadResolvedClarificationOptionIds(sessionId)
+        : [];
       prepared = await dependencies.prepareQueryGenerationContext({
         dataSourceId: session.data_source_id,
         question: session.question,
         requestedProvider,
         requestedModel,
         requestId,
-        clarificationOptionId
+        clarificationOptionId,
+        resolvedClarificationOptionIds
       });
     } catch (err) {
       schemaLinkingDurationMs = Date.now() - schemaLinkingStartedAt;
@@ -285,6 +296,7 @@ export async function orchestrateQueryRun({
     schemaLinkingDurationMs = Date.now() - schemaLinkingStartedAt;
     schemaLinking = prepared.diagnostics;
     if (prepared.ok === false) {
+      activeClarification = prepared.clarification;
       if (prepared.clarification) {
         await dependencies.recordPendingClarification(sessionId, prepared.clarification);
       } else {

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -3,7 +3,7 @@
  *
  * These types describe the shapes of rows persisted in the metadata
  * Postgres database (defined by `db/migrations/0001_*.sql` through
- * `db/migrations/0029_*.sql`) plus a handful of in-process config
+ * `db/migrations/0030_*.sql`) plus a handful of in-process config
  * shapes (provider configs, routing) that are not exposed through the
  * OpenAPI spec.
  *

--- a/app/src/types/openapi.ts
+++ b/app/src/types/openapi.ts
@@ -5174,7 +5174,7 @@ export interface components {
         };
         QueryClarification: {
             /** @enum {string} */
-            kind: "join_path";
+            kind: "join_path" | "table" | "metric";
             message: string;
             options: components["schemas"]["QueryClarificationOption"][];
         };

--- a/app/test/queryClarificationKindsMigration.test.ts
+++ b/app/test/queryClarificationKindsMigration.test.ts
@@ -1,0 +1,13 @@
+import "./helpers/setupEnv";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+test("0030 enables table and metric clarification kinds", () => {
+  const migrationPath = path.resolve(__dirname, "../../db/migrations/0030_clarification_intent_kinds.sql");
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /DROP CONSTRAINT IF EXISTS query_clarifications_kind_check/i);
+  assert.match(sql, /kind IN \('join_path', 'table', 'metric'\)/i);
+});

--- a/app/test/queryClarificationService.test.ts
+++ b/app/test/queryClarificationService.test.ts
@@ -2,8 +2,13 @@ import "./helpers/setupEnv";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { buildJoinPathClarification } from "../src/services/queryClarificationService";
+import {
+  buildCandidateClarification,
+  buildJoinPathClarification,
+  findCandidateIdByOptionId
+} from "../src/services/queryClarificationService";
 import type { SchemaExpansion, SchemaGraphEdge, SchemaPath } from "../src/services/schemaGraphService";
+import type { TableCandidate } from "../src/services/schemaLinkingService";
 
 test("join-path clarification produces stable, concise, and prompt-safe options", () => {
   const directEdge = edge("direct", "orders", "customers", "public.orders", "public.customers");
@@ -37,6 +42,42 @@ test("clarification is absent when expansion is not ambiguous", () => {
     ...ambiguousExpansion([]),
     status: "complete"
   }), null);
+});
+
+test("duplicate unqualified table names produce deterministic table choices", () => {
+  const candidates = [
+    candidate("sales-orders", "sales", "orders"),
+    candidate("archive-orders", "archive", "orders")
+  ];
+
+  const ambiguity = buildCandidateClarification("Orders last month", candidates);
+
+  assert.equal(ambiguity?.clarification.kind, "table");
+  assert.deepEqual(ambiguity?.clarification.options.map((option) => option.label), [
+    "Use archive.orders",
+    "Use sales.orders"
+  ]);
+  assert.equal(
+    findCandidateIdByOptionId(ambiguity!, ambiguity!.clarification.options[1].id),
+    "sales-orders"
+  );
+  assert.equal(buildCandidateClarification("Sales orders last month", candidates), null);
+});
+
+test("an exact business alias across tables produces metric choices unless the table is named", () => {
+  const candidates = [
+    candidate("payments", "finance", "payment", ["Net Revenue"]),
+    candidate("invoices", "sales", "invoice", ["Net Revenue"])
+  ];
+
+  const ambiguity = buildCandidateClarification("Show net revenue", candidates);
+
+  assert.equal(ambiguity?.clarification.kind, "metric");
+  assert.deepEqual(ambiguity?.clarification.options.map((option) => option.label), [
+    "Use Net Revenue from finance.payment",
+    "Use Net Revenue from sales.invoice"
+  ]);
+  assert.equal(buildCandidateClarification("Show payment net revenue", candidates), null);
 });
 
 function ambiguousExpansion(alternatives: SchemaPath[]): SchemaExpansion {
@@ -78,5 +119,30 @@ function edge(
     join_type: "INNER",
     on_clause: "orders.account_id = customers.id",
     relationship_type: "many_to_one"
+  };
+}
+
+function candidate(
+  id: string,
+  schemaName: string,
+  objectName: string,
+  aliases: string[] = []
+): TableCandidate {
+  return {
+    id,
+    schema_name: schemaName,
+    object_name: objectName,
+    object_type: "table",
+    description: null,
+    primary_keys: [],
+    join_columns: [],
+    relationships: [],
+    approved_join_refs: [],
+    semantic_aliases: aliases,
+    synonyms: [],
+    score: 10,
+    lexical_score: 10,
+    rag_score: 0,
+    matched_terms: []
   };
 }

--- a/app/test/queryClarificationStore.test.ts
+++ b/app/test/queryClarificationStore.test.ts
@@ -6,6 +6,7 @@ import type { PoolClient } from "pg";
 import appDb = require("../src/lib/appDb");
 import {
   cancelPendingClarification,
+  loadResolvedClarificationOptionIds,
   recordPendingClarification,
   resolvePendingClarification
 } from "../src/services/queryClarificationStore";
@@ -43,6 +44,27 @@ test("clarification store persists pending options and audits their resolution",
     assert.ok(statements.some((entry) => entry.sql.includes("status = 'created'")));
   } finally {
     appDb.withTransaction = originalTransaction;
+  }
+});
+
+test("clarification store loads prior resolved choices for multi-step clarification", async () => {
+  const originalQuery = appDb.query;
+  appDb.query = (async () => ({
+    rowCount: 3,
+    rows: [
+      { selected_option_id: "table_111111111111" },
+      { selected_option_id: "join_path_222222222222" },
+      { selected_option_id: "table_111111111111" }
+    ]
+  })) as unknown as typeof appDb.query;
+
+  try {
+    assert.deepEqual(await loadResolvedClarificationOptionIds("session-1"), [
+      "table_111111111111",
+      "join_path_222222222222"
+    ]);
+  } finally {
+    appDb.query = originalQuery;
   }
 });
 

--- a/app/test/queryDiagnosticsService.test.ts
+++ b/app/test/queryDiagnosticsService.test.ts
@@ -74,6 +74,7 @@ test("query diagnostics are bounded, correlated, and exclude sensitive content",
   assert.deepEqual(payload.retrieval, { rag_document_count: 12, example_count: 3 });
   assert.equal(payload.schema_linking?.clarification_required, true);
   assert.equal(payload.schema_linking?.clarification_option_count, 2);
+  assert.equal(payload.schema_linking?.clarification_kind, "join_path");
   assert.deepEqual(payload.generation.token_usage, { prompt_tokens: 18, completion_tokens: 9, total_tokens: 27 });
   const serialized = JSON.stringify(payload);
   assert.doesNotMatch(serialized, /secret/);

--- a/app/test/queryGenerationContextService.test.ts
+++ b/app/test/queryGenerationContextService.test.ts
@@ -161,6 +161,33 @@ test("prepareQueryGenerationContext rejects stale clarification option IDs", asy
   }
 });
 
+test("prepareQueryGenerationContext scopes linking to the selected duplicate table", async () => {
+  const archiveOrders = { ...card("archive-orders", "orders"), schema_name: "archive" };
+  const salesOrders = { ...card("sales-orders", "orders"), schema_name: "sales" };
+  const dependencies = baseDependencies([archiveOrders, salesOrders], []);
+
+  const ambiguous = await prepareQueryGenerationContext({
+    dataSourceId: "source",
+    question: "Orders last month"
+  }, dependencies);
+
+  assert.equal(ambiguous.ok, false);
+  if (ambiguous.ok === false) {
+    assert.equal(ambiguous.clarification?.kind, "table");
+    const salesOption = ambiguous.clarification!.options.find((option) => option.label === "Use sales.orders");
+    assert.ok(salesOption);
+    const resolved = await prepareQueryGenerationContext({
+      dataSourceId: "source",
+      question: "Orders last month",
+      clarificationOptionId: salesOption.id
+    }, dependencies);
+    assert.equal(resolved.ok, true);
+    if (resolved.ok) {
+      assert.deepEqual(resolved.context.schemaObjects.map((object) => object.id), ["sales-orders"]);
+    }
+  }
+});
+
 function baseDependencies(cards: TableCard[], docs: RagRetrievalDoc[]): GenerationContextDependencies {
   return {
     loadTableCards: async () => cards,

--- a/app/test/queryOrchestrationRepair.test.ts
+++ b/app/test/queryOrchestrationRepair.test.ts
@@ -238,6 +238,7 @@ function dependenciesWithGenerator(
     },
     recordPendingClarification: async () => undefined,
     resolvePendingClarification: async () => true,
+    loadResolvedClarificationOptionIds: async () => [],
     createDatabaseAdapter: () => {
       throw new Error("Adapter must not be created for no_execute tests");
     }

--- a/db/migrations/0030_clarification_intent_kinds.sql
+++ b/db/migrations/0030_clarification_intent_kinds.sql
@@ -1,0 +1,8 @@
+-- AIQ-008: support table and metric intent clarifications.
+
+ALTER TABLE query_clarifications
+  DROP CONSTRAINT IF EXISTS query_clarifications_kind_check;
+
+ALTER TABLE query_clarifications
+  ADD CONSTRAINT query_clarifications_kind_check
+  CHECK (kind IN ('join_path', 'table', 'metric'));

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3624,7 +3624,7 @@ components:
           description: When true, generate and validate SQL without connecting to or executing against the source database.
         clarification_option_id:
           type: string
-          pattern: '^join_path_[a-f0-9]{12}$'
+          pattern: '^(join_path|table|metric)_[a-f0-9]{12}$'
           description: Opaque option ID returned by a prior 422 clarification response for this session.
         max_rows:
           type: integer
@@ -3682,7 +3682,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [join_path]
+          enum: [join_path, table, metric]
         message:
           type: string
         options:

--- a/frontend/src/components/Query/ClarificationPanel.tsx
+++ b/frontend/src/components/Query/ClarificationPanel.tsx
@@ -72,7 +72,7 @@ export function ClarificationPanel({
                             <span className="mt-0.5 shrink-0 text-xs font-semibold text-oxblood">
                                 {isResolving
                                     ? <Loader2 size={14} className="animate-spin" />
-                                    : isSelected ? 'Retry' : 'Use path'}
+                                    : isSelected ? 'Retry' : 'Select'}
                             </span>
                         </button>
                     );

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -5174,7 +5174,7 @@ export interface components {
         };
         QueryClarification: {
             /** @enum {string} */
-            kind: "join_path";
+            kind: "join_path" | "table" | "metric";
             message: string;
             options: components["schemas"]["QueryClarificationOption"][];
         };

--- a/frontend/src/pages/QueryWorkspace.tsx
+++ b/frontend/src/pages/QueryWorkspace.tsx
@@ -37,7 +37,9 @@ type QueryRunErrorPayload = {
 function parseClarification(value: unknown): QueryClarification | undefined {
     if (!value || typeof value !== 'object') return undefined;
     const candidate = value as Record<string, unknown>;
-    if (candidate.kind !== 'join_path' || typeof candidate.message !== 'string' || !Array.isArray(candidate.options)) {
+    if (!['join_path', 'table', 'metric'].includes(String(candidate.kind))
+        || typeof candidate.message !== 'string'
+        || !Array.isArray(candidate.options)) {
         return undefined;
     }
     const options = candidate.options.filter((option): option is QueryClarification['options'][number] => {
@@ -50,7 +52,7 @@ function parseClarification(value: unknown): QueryClarification | undefined {
             && item.table_refs.every((ref) => typeof ref === 'string');
     });
     if (options.length < 2 || options.length !== candidate.options.length) return undefined;
-    return { kind: 'join_path', message: candidate.message, options };
+    return { kind: candidate.kind as QueryClarification['kind'], message: candidate.message, options };
 }
 
 function parseRunErrorPayload(error: unknown): QueryRunErrorPayload | null {


### PR DESCRIPTION
## Summary

- detect duplicate unqualified table names across schemas
- detect exact business metric aliases mapped to multiple reporting objects
- avoid interruption when the question explicitly names a schema/table
- scope schema linking to the selected candidate while retaining complementary tables
- replay prior resolved choices so table/metric and join-path clarification can chain safely
- support all clarification kinds in persistence, OpenAPI, frontend parsing, and diagnostics

Closes #180

## Verification

- `npm run typecheck`
- focused clarification, store, migration, context, and orchestration tests (20 tests)
- `npm test` (274 tests)
- `npm --prefix frontend run lint`
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)