### PR TITLE
Instrument the NL-to-SQL pipeline

### DIFF
--- a/app/src/lib/telemetry.ts
+++ b/app/src/lib/telemetry.ts
@@ -1,4 +1,12 @@
-import type { Attributes, AttributeValue } from "@opentelemetry/api";
+import {
+  metrics,
+  SpanStatusCode,
+  trace,
+  type Attributes,
+  type AttributeValue,
+  type Counter,
+  type Histogram
+} from "@opentelemetry/api";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { resourceFromAttributes } from "@opentelemetry/resources";
@@ -28,6 +36,10 @@ export interface TelemetryDependencies {
 
 const SENSITIVE_ATTRIBUTE = /(prompt|question|sql|statement|connection|password|secret|token|api[_-]?key|parameter|request\.body|response\.body)/i;
 const MAX_ATTRIBUTE_LENGTH = 120;
+const tracer = trace.getTracer("report-pilot.pipeline", "0.1.0");
+const meter = metrics.getMeter("report-pilot.pipeline", "0.1.0");
+const counters = new Map<string, Counter>();
+const histograms = new Map<string, Histogram>();
 
 export async function initializeTelemetry(
   env: NodeJS.ProcessEnv = process.env,
@@ -70,6 +82,73 @@ export function sanitizeTelemetryAttributes(
   return sanitized;
 }
 
+export async function withTelemetrySpan<T>(
+  name: string,
+  attributes: Record<string, unknown>,
+  operation: () => Promise<T>
+): Promise<T> {
+  const startedAt = performance.now();
+  const safeAttributes = sanitizeTelemetryAttributes(attributes);
+  return tracer.startActiveSpan(name, { attributes: safeAttributes }, async (span) => {
+    let outcome = "success";
+    try {
+      return await operation();
+    } catch (error) {
+      outcome = "error";
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.setAttribute("error.type", boundedErrorType(error));
+      throw error;
+    } finally {
+      span.end();
+      recordTelemetryHistogram("report_pilot.pipeline.stage.duration", performance.now() - startedAt, {
+        ...safeAttributes,
+        outcome
+      });
+      recordTelemetryCounter("report_pilot.pipeline.stage.calls", 1, {
+        ...safeAttributes,
+        outcome
+      });
+    }
+  });
+}
+
+export function recordTelemetryCounter(
+  name: string,
+  value: number,
+  attributes: Record<string, unknown> = {}
+): void {
+  if (!Number.isFinite(value) || value < 0) return;
+  try {
+    let counter = counters.get(name);
+    if (!counter) {
+      counter = meter.createCounter(name);
+      counters.set(name, counter);
+    }
+    counter.add(value, sanitizeTelemetryAttributes(attributes));
+  } catch {
+    // Telemetry must never affect the reporting path.
+  }
+}
+
+export function recordTelemetryHistogram(
+  name: string,
+  value: number,
+  attributes: Record<string, unknown> = {},
+  unit = "ms"
+): void {
+  if (!Number.isFinite(value) || value < 0) return;
+  try {
+    let histogram = histograms.get(name);
+    if (!histogram) {
+      histogram = meter.createHistogram(name, { unit });
+      histograms.set(name, histogram);
+    }
+    histogram.record(value, sanitizeTelemetryAttributes(attributes));
+  } catch {
+    // Telemetry must never affect the reporting path.
+  }
+}
+
 function createSdk(config: TelemetryConfig): NodeSDK {
   return new NodeSDK({
     resource: resourceFromAttributes({
@@ -98,6 +177,11 @@ function sanitizeAttributeValue(value: unknown): AttributeValue | undefined {
     return strings.length > 0 ? strings : undefined;
   }
   return undefined;
+}
+
+function boundedErrorType(error: unknown): string {
+  if (error instanceof Error && error.name) return error.name.slice(0, 80);
+  return "Error";
 }
 
 function noOpHandle(config: TelemetryConfig): TelemetryHandle {

--- a/app/src/services/queryDiagnosticsService.ts
+++ b/app/src/services/queryDiagnosticsService.ts
@@ -2,6 +2,10 @@ import { logEvent } from "../lib/observability";
 import type { ProviderAttempt } from "./llmSqlService";
 import type { SchemaLinkingDiagnostics } from "./queryGenerationContextService";
 import type { QueryClarification } from "./queryClarificationService";
+import {
+  recordTelemetryCounter,
+  recordTelemetryHistogram
+} from "../lib/telemetry";
 
 const MAX_TABLE_IDS = 20;
 const MAX_PROVIDER_ATTEMPTS = 8;
@@ -29,6 +33,7 @@ export interface QueryDiagnosticInput {
   executionDurationMs?: number | null;
   clarificationKind?: QueryClarification["kind"] | null;
   clarificationOptionCount?: number;
+  dataSourceType?: string | null;
 }
 
 export interface QueryDiagnosticPayload {
@@ -162,11 +167,54 @@ export function buildQueryDiagnostic(input: QueryDiagnosticInput): QueryDiagnost
 }
 
 export function emitQueryDiagnostic(input: QueryDiagnosticInput): void {
+  const payload = buildQueryDiagnostic(input);
+  recordQueryMetrics(input, payload);
   logEvent(
     "query_generation_diagnostics",
-    { ...buildQueryDiagnostic(input) },
+    { ...payload },
     input.outcome === "failed" ? "warn" : "info"
   );
+}
+
+function recordQueryMetrics(input: QueryDiagnosticInput, payload: QueryDiagnosticPayload): void {
+  const attributes = {
+    provider: payload.generation.provider,
+    "datasource.type": input.dataSourceType || "unknown",
+    outcome: payload.outcome
+  };
+  recordTelemetryHistogram("report_pilot.query.duration", payload.duration_ms, attributes);
+  recordTelemetryHistogram(
+    "report_pilot.query.retrieval.documents",
+    payload.retrieval.rag_document_count,
+    attributes,
+    "{document}"
+  );
+  recordTelemetryHistogram(
+    "report_pilot.query.retrieval.candidates",
+    payload.schema_linking?.candidate_count || 0,
+    attributes,
+    "{candidate}"
+  );
+  if (payload.generation.fallback_used || payload.schema_linking?.fallback_used) {
+    recordTelemetryCounter("report_pilot.query.fallbacks", 1, attributes);
+  }
+  if (payload.generation.repair_count > 0) {
+    recordTelemetryCounter("report_pilot.query.repairs", payload.generation.repair_count, attributes);
+  }
+  if (payload.generation.token_usage.total_tokens > 0) {
+    recordTelemetryCounter(
+      "report_pilot.query.tokens",
+      payload.generation.token_usage.total_tokens,
+      attributes
+    );
+  }
+  if (payload.outcome === "failed") {
+    recordTelemetryCounter("report_pilot.query.errors", 1, {
+      ...attributes,
+      "pipeline.stage": payload.terminal_stage,
+      "error.type": payload.error_code || "unknown"
+    });
+  }
 }
 
 function boundIds(ids: string[]): string[] {

--- a/app/src/services/queryGenerationContextService.ts
+++ b/app/src/services/queryGenerationContextService.ts
@@ -23,6 +23,7 @@ import {
   findJoinPathByOptionId,
   type QueryClarification
 } from "./queryClarificationService";
+import { withTelemetrySpan } from "../lib/telemetry";
 
 const { retrieveRagContext } = ragRetrieval;
 
@@ -90,8 +91,12 @@ export async function prepareQueryGenerationContext(
   const finalRagLimit = positiveInteger(input.finalRagLimit, 12);
   const retrievalLimit = Math.max(candidateLimit * 3, finalRagLimit);
   const [cards, retrievedDocuments] = await Promise.all([
-    dependencies.loadTableCards(input.dataSourceId),
-    dependencies.retrieveRagContext(input.dataSourceId, input.question, { limit: retrievalLimit })
+    withTelemetrySpan("query.schema.retrieve", {
+      "pipeline.stage": "schema_retrieval"
+    }, () => dependencies.loadTableCards(input.dataSourceId)),
+    withTelemetrySpan("query.rag.retrieve", {
+      "pipeline.stage": "rag_retrieval"
+    }, () => dependencies.retrieveRagContext(input.dataSourceId, input.question, { limit: retrievalLimit }))
   ]);
   const candidates = rankTableCards(input.question, cards, retrievedDocuments, candidateLimit);
   const diagnostics: SchemaLinkingDiagnostics = {
@@ -136,21 +141,25 @@ export async function prepareQueryGenerationContext(
     );
   }
 
-  const linker = await dependencies.linkTablesWithRouting({
+  const linker = await withTelemetrySpan("query.llm.schema_linker", {
+    "pipeline.stage": "schema_linking"
+  }, () => dependencies.linkTablesWithRouting({
     dataSourceId: input.dataSourceId,
     question: input.question,
     candidates: linkerCandidates,
     requestedProvider: input.requestedProvider,
     requestedModel: input.requestedModel,
     requestId: input.requestId
-  });
+  }));
   diagnostics.linker = linker;
 
-  let expanded = await dependencies.loadExpandedSchemaContext(
-    input.dataSourceId,
-    linker.selection.table_ids,
-    { maxIntermediateHops: 2, maxAlternativePaths: 4 }
-  );
+  let expanded = await withTelemetrySpan("query.schema.expand", {
+    "pipeline.stage": "schema_expansion"
+  }, () => dependencies.loadExpandedSchemaContext(
+      input.dataSourceId,
+      linker.selection.table_ids,
+      { maxIntermediateHops: 2, maxAlternativePaths: 4 }
+    ));
   diagnostics.expansion = expanded.expansion;
 
   const joinPathOptionIds = clarificationOptionIds(input).filter((optionId) => optionId.startsWith("join_path_"));

--- a/app/src/services/queryOrchestrationService.ts
+++ b/app/src/services/queryOrchestrationService.ts
@@ -33,6 +33,7 @@ import {
   loadResolvedClarificationOptionIds
 } from "./queryClarificationStore";
 import type { QueryClarification } from "./queryClarificationService";
+import { withTelemetrySpan } from "../lib/telemetry";
 
 const { extractForbiddenColumnsFromRagNotes, validateSqlAgainstForbiddenColumns } = columnPolicyService;
 const { retrieveRagContext } = ragRetrieval;
@@ -164,7 +165,18 @@ function buildValidationJson(input: BuildValidationJsonInput): Record<string, un
   };
 }
 
-export async function orchestrateQueryRun({
+export function orchestrateQueryRun(
+  input: OrchestrateInput,
+  dependencies: QueryOrchestrationDependencies = defaultDependencies
+): Promise<OrchestrateResult> {
+  return withTelemetrySpan("query.run", {
+    "pipeline.stage": "end_to_end",
+    provider: input.requestedProvider || "auto",
+    "datasource.type": input.dbType || "unknown"
+  }, () => orchestrateQueryRunInternal(input, dependencies));
+}
+
+async function orchestrateQueryRunInternal({
   sessionId,
   question,
   dataSourceId,
@@ -178,7 +190,7 @@ export async function orchestrateQueryRun({
   timeoutMs,
   noExecute,
   clarificationOptionId
-}: OrchestrateInput, dependencies: QueryOrchestrationDependencies = defaultDependencies): Promise<OrchestrateResult> {
+}: OrchestrateInput, dependencies: QueryOrchestrationDependencies): Promise<OrchestrateResult> {
   const providerIsValid = await validateRequestedProvider(requestedProvider);
   if (!providerIsValid) {
     return failure(400, { error: "bad_request", message: "Unsupported llm_provider" });
@@ -210,6 +222,10 @@ export async function orchestrateQueryRun({
   }
 
   const sqlDialect: "postgres" | "mssql" = session.db_type === "mssql" ? "mssql" : "postgres";
+  const telemetryAttributes = {
+    provider: requestedProvider || "auto",
+    "datasource.type": sqlDialect
+  };
   const generationStartedAt = Date.now();
   let context: QueryContext;
   let ragDocuments: RagRetrievalDoc[] = [];
@@ -259,7 +275,8 @@ export async function orchestrateQueryRun({
       tokenUsage: generationTokenUsage,
       executionDurationMs,
       clarificationKind: activeClarification?.kind || null,
-      clarificationOptionCount: activeClarification?.options.length
+      clarificationOptionCount: activeClarification?.options.length,
+      dataSourceType: sqlDialect
     });
   };
 
@@ -275,15 +292,18 @@ export async function orchestrateQueryRun({
       const resolvedClarificationOptionIds = clarificationOptionId
         ? await dependencies.loadResolvedClarificationOptionIds(sessionId)
         : [];
-      prepared = await dependencies.prepareQueryGenerationContext({
-        dataSourceId: session.data_source_id,
-        question: session.question,
-        requestedProvider,
-        requestedModel,
-        requestId,
-        clarificationOptionId,
-        resolvedClarificationOptionIds
-      });
+      prepared = await withTelemetrySpan("query.schema_linking", {
+        ...telemetryAttributes,
+        "pipeline.stage": "schema_linking"
+      }, () => dependencies.prepareQueryGenerationContext({
+          dataSourceId: session.data_source_id,
+          question: session.question,
+          requestedProvider,
+          requestedModel,
+          requestId,
+          clarificationOptionId,
+          resolvedClarificationOptionIds
+        }));
     } catch (err) {
       schemaLinkingDurationMs = Date.now() - schemaLinkingStartedAt;
       await markSessionStatus(sessionId, "failed");
@@ -335,7 +355,10 @@ export async function orchestrateQueryRun({
     promptVersion = "v2-cached-sql";
   } else {
     try {
-      const generation = await dependencies.generateSqlWithRouting({
+      const generation = await withTelemetrySpan("query.llm.generate", {
+        ...telemetryAttributes,
+        "pipeline.stage": "generation"
+      }, () => dependencies.generateSqlWithRouting({
         requestId: requestId || null,
         dataSourceId: session.data_source_id,
         dialect: sqlDialect,
@@ -349,7 +372,7 @@ export async function orchestrateQueryRun({
         metricDefinitions: context.metricDefinitions,
         joinPolicies: context.joinPolicies,
         ragDocuments
-      });
+      }));
 
       generatedSql = generation.sql;
       usedProvider = generation.provider;
@@ -371,21 +394,20 @@ export async function orchestrateQueryRun({
   let adapter: DbAdapter | null = null;
   try {
     let safeSql = generatedSql;
-    let safety = validateAndNormalizeSql(generatedSql, {
-      maxRows,
-      schemaObjects: context.schemaObjects,
-      dialect: sqlDialect
-    });
+    let safety: ReturnType<typeof validateAndNormalizeSql>;
     let validationJson: Record<string, unknown> = {};
 
     while (true) {
       let validationErrors: string[] = [];
       safeSql = generatedSql;
-      safety = validateAndNormalizeSql(generatedSql, {
-        maxRows,
-        schemaObjects: context.schemaObjects,
-        dialect: sqlDialect
-      });
+      safety = await withTelemetrySpan("query.sql.validate", {
+        ...telemetryAttributes,
+        "pipeline.stage": "validation"
+      }, async () => validateAndNormalizeSql(generatedSql, {
+          maxRows,
+          schemaObjects: context.schemaObjects,
+          dialect: sqlDialect
+        }));
 
       if (!safety.ok) {
         validationErrors = safety.errors;
@@ -410,7 +432,10 @@ export async function orchestrateQueryRun({
               return failure(400, { error: "bad_request", message: (err as Error).message });
             }
           }
-          const adapterValidation = await adapter.validateSql(safeSql);
+          const adapterValidation = await withTelemetrySpan("query.database.validate", {
+            ...telemetryAttributes,
+            "pipeline.stage": "validation"
+          }, () => adapter!.validateSql(safeSql));
           if (!adapterValidation.ok) {
             validationErrors = adapterValidation.errors;
           }
@@ -443,7 +468,10 @@ export async function orchestrateQueryRun({
           const previousSql = generatedSql;
           let repair;
           try {
-            repair = await dependencies.generateSqlWithRouting({
+            repair = await withTelemetrySpan("query.llm.repair", {
+              ...telemetryAttributes,
+              "pipeline.stage": "repair"
+            }, () => dependencies.generateSqlWithRouting({
               requestId: requestId || null,
               dataSourceId: session.data_source_id,
               dialect: sqlDialect,
@@ -459,7 +487,7 @@ export async function orchestrateQueryRun({
               ragDocuments,
               repair: { previousSql, errors: validationErrors },
               stage: "repair"
-            });
+            }));
           } catch (err) {
             await markSessionStatus(sessionId, "failed");
             emitTerminalDiagnostic("failed", "generation", "llm_repair_failed");
@@ -510,10 +538,15 @@ export async function orchestrateQueryRun({
       }
 
       if (!noExecute && EXPLAIN_BUDGET_ENABLED && sqlDialect === "postgres") {
-        const explainRows = await adapter!.explain(safeSql);
-        const budget = evaluateExplainBudget(explainRows, {
-          maxTotalCost: EXPLAIN_MAX_TOTAL_COST,
-          maxPlanRows: EXPLAIN_MAX_PLAN_ROWS
+        const budget = await withTelemetrySpan("query.budget.check", {
+          ...telemetryAttributes,
+          "pipeline.stage": "budget"
+        }, async () => {
+          const explainRows = await adapter!.explain(safeSql);
+          return evaluateExplainBudget(explainRows, {
+            maxTotalCost: EXPLAIN_MAX_TOTAL_COST,
+            maxPlanRows: EXPLAIN_MAX_PLAN_ROWS
+          });
         });
         validationJson.explain_budget = budget;
         if (!budget.ok) {
@@ -533,7 +566,10 @@ export async function orchestrateQueryRun({
             const previousSql = safeSql;
             let repair;
             try {
-              repair = await dependencies.generateSqlWithRouting({
+              repair = await withTelemetrySpan("query.llm.repair", {
+                ...telemetryAttributes,
+                "pipeline.stage": "repair"
+              }, () => dependencies.generateSqlWithRouting({
                 requestId: requestId || null,
                 dataSourceId: session.data_source_id,
                 dialect: sqlDialect,
@@ -549,7 +585,7 @@ export async function orchestrateQueryRun({
                 ragDocuments,
                 repair: { previousSql, errors: budget.errors },
                 stage: "repair"
-              });
+              }));
             } catch (err) {
               await markSessionStatus(sessionId, "failed");
               emitTerminalDiagnostic("failed", "generation", "llm_repair_failed");
@@ -660,7 +696,10 @@ export async function orchestrateQueryRun({
       });
     }
 
-    const execution = await adapter!.executeReadOnly(safeSql, { timeoutMs, maxRows });
+    const execution = await withTelemetrySpan("query.database.execute", {
+      ...telemetryAttributes,
+      "pipeline.stage": "execution"
+    }, () => adapter!.executeReadOnly(safeSql, { timeoutMs, maxRows }));
     executionDurationMs = execution.durationMs;
     await insertQueryResultMeta({
       attemptId: attemptId as string,

--- a/app/test/telemetry.test.ts
+++ b/app/test/telemetry.test.ts
@@ -5,6 +5,9 @@ import assert from "node:assert/strict";
 import { loadTelemetryConfig } from "../src/lib/telemetryConfig";
 import {
   initializeTelemetry,
+  recordTelemetryCounter,
+  recordTelemetryHistogram,
+  withTelemetrySpan,
   sanitizeTelemetryAttributes
 } from "../src/lib/telemetry";
 
@@ -88,4 +91,26 @@ test("telemetry shutdown failures are contained", async () => {
 
   assert.equal(handle.enabled, true);
   await handle.shutdown();
+});
+
+test("no-op spans and metrics preserve application behavior", async () => {
+  const value = await withTelemetrySpan("query.schema.retrieve", {
+    "pipeline.stage": "schema_retrieval",
+    question: "must not be exported"
+  }, async () => 42);
+  assert.equal(value, 42);
+
+  const failure = new Error("private provider response");
+  await assert.rejects(
+    withTelemetrySpan("query.llm.generate", { "pipeline.stage": "generation" }, async () => {
+      throw failure;
+    }),
+    (error) => error === failure
+  );
+
+  assert.doesNotThrow(() => {
+    recordTelemetryCounter("report_pilot.query.repairs", 1, { provider: "test" });
+    recordTelemetryHistogram("report_pilot.query.duration", 12, { outcome: "success" });
+    recordTelemetryCounter("report_pilot.query.repairs", Number.NaN);
+  });
 });

--- a/docs/observability/opentelemetry.md
+++ b/docs/observability/opentelemetry.md
@@ -43,6 +43,19 @@ The debug exporter prints received traces and metrics in the Collector output.
 Production deployments should pin the Collector image and replace the debug
 exporter with their observability backend.
 
+## Pipeline Signals
+
+Each query run creates an end-to-end span with child spans for schema and RAG
+retrieval, schema linking and graph expansion, LLM generation and repair, SQL
+and adapter validation, query-budget checks, and database execution. Stage
+metrics use bounded `pipeline.stage`, `outcome`, `provider`, and
+`datasource.type` attributes.
+
+The runtime also emits query duration, retrieval document/candidate counts,
+fallbacks, repairs, token totals, and terminal errors. Provider and datasource
+type are included; model names, datasource IDs, user IDs, questions, prompts,
+SQL, parameters, connection details, and raw error messages are excluded.
+
 ## Sensitive Data
 
 Report Pilot's telemetry attribute sanitizer drops prompt, question, SQL,


### PR DESCRIPTION
## Summary

- add no-op-safe active span and metric helpers
- trace end-to-end query orchestration and child schema/RAG retrieval, linking, expansion, generation, repair, validation, budget, and execution stages
- emit bounded latency, error, fallback, repair, token, and retrieval metrics
- distinguish provider, datasource type, stage, and outcome without high-cardinality identifiers
- avoid exporting raw exception messages or sensitive query data
- document the emitted pipeline signals

Part of #184

## Verification

- `npm run typecheck`
- focused telemetry, diagnostics, generation-context, and orchestration tests (18 tests)
- `npm test` (280 tests)
- `npm --prefix frontend run lint`
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)