### PR TITLE
Propagate OpenTelemetry trace context

### DIFF
--- a/app/src/lib/telemetry.ts
+++ b/app/src/lib/telemetry.ts
@@ -1,5 +1,8 @@
 import {
+  context,
   metrics,
+  propagation,
+  SpanKind,
   SpanStatusCode,
   trace,
   type Attributes,
@@ -7,6 +10,7 @@ import {
   type Counter,
   type Histogram
 } from "@opentelemetry/api";
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { resourceFromAttributes } from "@opentelemetry/resources";
@@ -36,10 +40,12 @@ export interface TelemetryDependencies {
 
 const SENSITIVE_ATTRIBUTE = /(prompt|question|sql|statement|connection|password|secret|token|api[_-]?key|parameter|request\.body|response\.body)/i;
 const MAX_ATTRIBUTE_LENGTH = 120;
-const tracer = trace.getTracer("report-pilot.pipeline", "0.1.0");
-const meter = metrics.getMeter("report-pilot.pipeline", "0.1.0");
 const counters = new Map<string, Counter>();
 const histograms = new Map<string, Histogram>();
+const headerGetter = {
+  keys: (carrier: IncomingHttpHeaders): string[] => Object.keys(carrier),
+  get: (carrier: IncomingHttpHeaders, key: string): string | string[] | undefined => carrier[key.toLowerCase()]
+};
 
 export async function initializeTelemetry(
   env: NodeJS.ProcessEnv = process.env,
@@ -52,6 +58,8 @@ export async function initializeTelemetry(
   try {
     const sdk = dependencies.createSdk(config);
     sdk.start();
+    counters.clear();
+    histograms.clear();
     console.log(`[telemetry] OTLP traces and metrics enabled for ${config.serviceName}`);
     return {
       enabled: true,
@@ -89,27 +97,103 @@ export async function withTelemetrySpan<T>(
 ): Promise<T> {
   const startedAt = performance.now();
   const safeAttributes = sanitizeTelemetryAttributes(attributes);
-  return tracer.startActiveSpan(name, { attributes: safeAttributes }, async (span) => {
-    let outcome = "success";
-    try {
-      return await operation();
-    } catch (error) {
-      outcome = "error";
-      span.setStatus({ code: SpanStatusCode.ERROR });
-      span.setAttribute("error.type", boundedErrorType(error));
-      throw error;
-    } finally {
-      span.end();
-      recordTelemetryHistogram("report_pilot.pipeline.stage.duration", performance.now() - startedAt, {
-        ...safeAttributes,
-        outcome
-      });
-      recordTelemetryCounter("report_pilot.pipeline.stage.calls", 1, {
-        ...safeAttributes,
-        outcome
-      });
+  try {
+    return pipelineTracer().startActiveSpan(name, { attributes: safeAttributes }, async (span) => {
+      let outcome = "success";
+      try {
+        return await operation();
+      } catch (error) {
+        outcome = "error";
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        span.setAttribute("error.type", boundedErrorType(error));
+        throw error;
+      } finally {
+        span.end();
+        recordTelemetryHistogram("report_pilot.pipeline.stage.duration", performance.now() - startedAt, {
+          ...safeAttributes,
+          outcome
+        });
+        recordTelemetryCounter("report_pilot.pipeline.stage.calls", 1, {
+          ...safeAttributes,
+          outcome
+        });
+      }
+    });
+  } catch {
+    return operation();
+  }
+}
+
+export async function withHttpServerTelemetry<T>(
+  request: IncomingMessage,
+  response: ServerResponse,
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    const method = String(request.method || "UNKNOWN").toUpperCase().slice(0, 16);
+    const route = normalizeHttpRoute(request.url);
+    const parentContext = propagation.extract(context.active(), request.headers, headerGetter);
+    const startedAt = performance.now();
+    return context.with(parentContext, () => pipelineTracer().startActiveSpan(
+    "http.request",
+    {
+      kind: SpanKind.SERVER,
+      attributes: sanitizeTelemetryAttributes({
+        "http.request.method": method,
+        "http.route": route
+      })
+    },
+    async (span) => {
+      let outcome = "success";
+      try {
+        return await operation();
+      } catch (error) {
+        outcome = "error";
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        span.setAttribute("error.type", boundedErrorType(error));
+        throw error;
+      } finally {
+        const responseStatus = Number(response.statusCode || 0);
+        const statusCode = outcome === "error" && responseStatus < 500 ? 500 : responseStatus;
+        span.setAttribute("http.response.status_code", statusCode);
+        if (statusCode >= 500) span.setStatus({ code: SpanStatusCode.ERROR });
+        span.end();
+        recordTelemetryHistogram("report_pilot.http.server.duration", performance.now() - startedAt, {
+          "http.request.method": method,
+          "http.route": route,
+          "http.response.status_code": statusCode,
+          outcome
+        });
+      }
     }
-  });
+    ));
+  } catch {
+    return operation();
+  }
+}
+
+export function bindTelemetryContext<Args extends unknown[], Result>(
+  callback: (...args: Args) => Result
+): (...args: Args) => Result {
+  try {
+    return context.bind(context.active(), callback);
+  } catch {
+    return callback;
+  }
+}
+
+export function normalizeHttpRoute(url: string | undefined): string {
+  const pathname = String(url || "/").split("?", 1)[0] || "/";
+  return pathname
+    .split("/")
+    .map((segment) => {
+      if (!segment) return segment;
+      if (/^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(segment)) return "{id}";
+      if (/^\d+$/.test(segment) || segment.length > 48) return "{id}";
+      return segment;
+    })
+    .join("/")
+    .slice(0, 255);
 }
 
 export function recordTelemetryCounter(
@@ -121,7 +205,7 @@ export function recordTelemetryCounter(
   try {
     let counter = counters.get(name);
     if (!counter) {
-      counter = meter.createCounter(name);
+      counter = pipelineMeter().createCounter(name);
       counters.set(name, counter);
     }
     counter.add(value, sanitizeTelemetryAttributes(attributes));
@@ -140,7 +224,7 @@ export function recordTelemetryHistogram(
   try {
     let histogram = histograms.get(name);
     if (!histogram) {
-      histogram = meter.createHistogram(name, { unit });
+      histogram = pipelineMeter().createHistogram(name, { unit });
       histograms.set(name, histogram);
     }
     histogram.record(value, sanitizeTelemetryAttributes(attributes));
@@ -182,6 +266,14 @@ function sanitizeAttributeValue(value: unknown): AttributeValue | undefined {
 function boundedErrorType(error: unknown): string {
   if (error instanceof Error && error.name) return error.name.slice(0, 80);
   return "Error";
+}
+
+function pipelineTracer() {
+  return trace.getTracer("report-pilot.pipeline", "0.1.0");
+}
+
+function pipelineMeter() {
+  return metrics.getMeter("report-pilot.pipeline", "0.1.0");
 }
 
 function noOpHandle(config: TelemetryConfig): TelemetryHandle {

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -1,6 +1,7 @@
 import * as http from "http";
 import type { IncomingMessage, ServerResponse } from "http";
 import { createRequestId, logEvent } from "./lib/observability";
+import { withHttpServerTelemetry } from "./lib/telemetry";
 import { json, notFound, badRequest, internalError, errorMessage } from "./lib/http";
 import { PORT } from "./lib/constants";
 import {
@@ -692,7 +693,7 @@ export function startServer(): Promise<http.Server> {
     });
 
     try {
-      await routeRequest(authedReq, res);
+      await withHttpServerTelemetry(req, res, () => routeRequest(authedReq, res));
     } catch (err) {
       if (statusCodeFromError(err) === 400) {
         return badRequest(res, (err as HttpishError).message);

--- a/app/src/services/ragService.ts
+++ b/app/src/services/ragService.ts
@@ -4,6 +4,7 @@ import appDb = require("../lib/appDb");
 import { embedTextsForIndexing } from "./embeddingRouter";
 import { buildRagDocuments } from "./ragDocumentBuilder";
 import { invalidateSchemaArtifacts } from "./schemaArtifactCache";
+import { bindTelemetryContext, withTelemetrySpan } from "../lib/telemetry";
 
 interface ReindexResult {
   data_source_id: string;
@@ -89,13 +90,15 @@ function triggerRagReindexAsync(dataSourceId: string | null | undefined): void {
 
   invalidateSchemaArtifacts(dataSourceId);
 
-  setImmediate(() => {
+  setImmediate(bindTelemetryContext(() => {
     // Read through the export object so test monkey-patches of
     // ragService.reindexRagDocuments are honored.
-    moduleExports.reindexRagDocuments(dataSourceId).catch((err: Error) => {
+    withTelemetrySpan("background.rag.reindex", {
+      "pipeline.stage": "rag_reindex"
+    }, () => moduleExports.reindexRagDocuments(dataSourceId)).catch((err: Error) => {
       console.error(`[rag] reindex failed for ${dataSourceId}: ${err.message}`);
     });
-  });
+  }));
 }
 
 function sha256(content: string): string {

--- a/app/src/services/scheduleDispatcher.ts
+++ b/app/src/services/scheduleDispatcher.ts
@@ -18,6 +18,7 @@
 
 import * as scheduleService from "./savedQueryScheduleService";
 import { logEvent } from "../lib/observability";
+import { withTelemetrySpan } from "../lib/telemetry";
 
 let intervalHandle: NodeJS.Timeout | null = null;
 let runningTick = false;
@@ -30,6 +31,12 @@ export interface TickResult {
 }
 
 export async function tickOnce(): Promise<TickResult> {
+  return withTelemetrySpan("background.schedule_dispatch", {
+    "pipeline.stage": "schedule_dispatch"
+  }, tickOnceInternal);
+}
+
+async function tickOnceInternal(): Promise<TickResult> {
   if (runningTick) return { skipped: true };
   runningTick = true;
   try {

--- a/app/test/telemetry.test.ts
+++ b/app/test/telemetry.test.ts
@@ -1,13 +1,22 @@
 import "./helpers/setupEnv";
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor
+} from "@opentelemetry/sdk-trace-base";
 
 import { loadTelemetryConfig } from "../src/lib/telemetryConfig";
 import {
   initializeTelemetry,
+  bindTelemetryContext,
+  normalizeHttpRoute,
   recordTelemetryCounter,
   recordTelemetryHistogram,
   withTelemetrySpan,
+  withHttpServerTelemetry,
   sanitizeTelemetryAttributes
 } from "../src/lib/telemetry";
 
@@ -113,4 +122,53 @@ test("no-op spans and metrics preserve application behavior", async () => {
     recordTelemetryHistogram("report_pilot.query.duration", 12, { outcome: "success" });
     recordTelemetryCounter("report_pilot.query.repairs", Number.NaN);
   });
+});
+
+test("HTTP trace context parents pipeline and queued background spans", async () => {
+  const exporter = new InMemorySpanExporter();
+  const processor = new SimpleSpanProcessor(exporter);
+  const sdk = new NodeSDK({
+    spanProcessors: [processor],
+    metricReaders: [],
+    logRecordProcessors: []
+  });
+  sdk.start();
+  const traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+  const incomingSpanId = "00f067aa0ba902b7";
+  const request = {
+    method: "POST",
+    url: "/v1/query/sessions/00000000-0000-4000-8000-000000000123/run?debug=true",
+    headers: { traceparent: `00-${traceId}-${incomingSpanId}-01` }
+  } as unknown as IncomingMessage;
+  const response = { statusCode: 200 } as unknown as ServerResponse;
+  const queuedWork: { run?: () => Promise<void> } = {};
+
+  await withHttpServerTelemetry(request, response, async () => {
+    await withTelemetrySpan("query.run", { "pipeline.stage": "end_to_end" }, async () => undefined);
+    queuedWork.run = bindTelemetryContext(() => withTelemetrySpan(
+      "background.rag.reindex",
+      { "pipeline.stage": "rag_reindex" },
+      async () => undefined
+    ));
+  });
+  assert.ok(queuedWork.run);
+  await queuedWork.run();
+  await processor.forceFlush();
+
+  const spans = exporter.getFinishedSpans();
+  const serverSpan = spans.find((span) => span.name === "http.request");
+  const querySpan = spans.find((span) => span.name === "query.run");
+  const backgroundSpan = spans.find((span) => span.name === "background.rag.reindex");
+  assert.ok(serverSpan);
+  assert.ok(querySpan);
+  assert.ok(backgroundSpan);
+  assert.equal(serverSpan.spanContext().traceId, traceId);
+  assert.equal(serverSpan.parentSpanContext?.spanId, incomingSpanId);
+  assert.equal(querySpan.parentSpanContext?.spanId, serverSpan.spanContext().spanId);
+  assert.equal(backgroundSpan.parentSpanContext?.spanId, serverSpan.spanContext().spanId);
+  assert.equal(serverSpan.attributes["http.route"], "/v1/query/sessions/{id}/run");
+  assert.equal(serverSpan.attributes["http.response.status_code"], 200);
+  assert.equal(normalizeHttpRoute("/v1/jobs/123?token=secret"), "/v1/jobs/{id}");
+
+  await sdk.shutdown();
 });

--- a/docs/observability/opentelemetry.md
+++ b/docs/observability/opentelemetry.md
@@ -56,6 +56,12 @@ fallbacks, repairs, token totals, and terminal errors. Provider and datasource
 type are included; model names, datasource IDs, user IDs, questions, prompts,
 SQL, parameters, connection details, and raw error messages are excluded.
 
+Incoming W3C `traceparent`/`tracestate` headers are extracted into the HTTP
+server span, so all query-pipeline spans share the caller's trace. Query strings
+and concrete resource IDs are removed from `http.route` attributes. Active
+context is explicitly bound to queued RAG reindex work, and scheduled-delivery
+ticks start their own background spans.
+
 ## Sensitive Data
 
 Report Pilot's telemetry attribute sanitizer drops prompt, question, SQL,


### PR DESCRIPTION
## Summary

- extract incoming W3C trace context into normalized HTTP server spans
- parent query-pipeline spans under the caller trace without exporting query strings or resource IDs
- bind active context to queued RAG reindex work
- add background spans for RAG reindex and scheduled-delivery ticks
- fall back to direct application execution if telemetry setup itself throws
- verify real trace IDs and HTTP/query/background parent relationships with an in-memory exporter

Closes #184

## Verification

- `npm run typecheck`
- focused telemetry, RAG, and schedule API tests (15 tests)
- `npm test` (281 tests)
- `npm --prefix frontend run lint`
- `npm run build`
- `npm run benchmark:large-schema` (all release gates passed)