### PR TITLE
Add query connection loading and retry states

### DIFF
--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -13,6 +13,7 @@ import {
     Home,
     KeyRound,
     Plus,
+    RefreshCw,
     Settings as SettingsIcon,
     Star,
     Terminal,
@@ -92,7 +93,14 @@ function NavItem({ to, label, Icon, stub }: { to: string; label: string; Icon: t
 
 function HeaderInner() {
     const location = useLocation();
-    const { dataSources, selectedDataSourceId, setSelectedDataSourceId } = useDataSource();
+    const {
+        dataSources,
+        selectedDataSourceId,
+        setSelectedDataSourceId,
+        isLoadingDataSources,
+        dataSourceLoadError,
+        refreshDataSources,
+    } = useDataSource();
     const { actions } = useWorkspaceActions();
     const [showConnectionMenu, setShowConnectionMenu] = useState(false);
 
@@ -110,9 +118,14 @@ function HeaderInner() {
                         type="button"
                         onClick={() => setShowConnectionMenu((current) => !current)}
                         className="flex items-center gap-1.5 rounded font-medium text-slate-600 hover:text-slate-900"
+                        aria-haspopup="menu"
+                        aria-expanded={showConnectionMenu}
                     >
                         <Database size={14} className="text-oxblood" />
-                        <span>{selectedDataSource?.name || 'Select connection'}</span>
+                        <span>
+                            {selectedDataSource?.name
+                                || (isLoadingDataSources ? 'Loading connections…' : 'Select connection')}
+                        </span>
                         <ChevronDown size={14} />
                     </button>
                     {showConnectionMenu && (
@@ -139,7 +152,31 @@ function HeaderInner() {
                                         </div>
                                     </button>
                                 ))}
-                                {dataSources.length === 0 && (
+                                {isLoadingDataSources && dataSources.length === 0 && (
+                                    <div className="flex items-center gap-2 px-3 py-2 text-sm text-slate-500">
+                                        <RefreshCw size={14} className="animate-spin" aria-hidden="true" />
+                                        Loading connections…
+                                    </div>
+                                )}
+                                {dataSourceLoadError && (
+                                    <div className="border-t border-outline-variant px-3 py-2 text-sm" role="alert">
+                                        <p className="text-red-700">Connections unavailable.</p>
+                                        <button
+                                            type="button"
+                                            onClick={() => void refreshDataSources()}
+                                            disabled={isLoadingDataSources}
+                                            className="mt-1 inline-flex items-center gap-1 font-medium text-oxblood hover:underline disabled:opacity-60"
+                                        >
+                                            <RefreshCw
+                                                size={13}
+                                                className={isLoadingDataSources ? 'animate-spin' : ''}
+                                                aria-hidden="true"
+                                            />
+                                            Try again
+                                        </button>
+                                    </div>
+                                )}
+                                {!isLoadingDataSources && !dataSourceLoadError && dataSources.length === 0 && (
                                     <div className="px-3 py-2 text-sm italic text-slate-400">No connections available</div>
                                 )}
                             </div>

--- a/frontend/src/contexts/DataSourceContext.tsx
+++ b/frontend/src/contexts/DataSourceContext.tsx
@@ -9,39 +9,81 @@ export function DataSourceProvider({ children }: { children: ReactNode }) {
     const [selectedDataSourceId, setSelectedDataSourceIdRaw] = useState<string>(
         () => sessionStorage.getItem(SESSION_KEY) ?? ''
     );
+    const [isLoadingDataSources, setIsLoadingDataSources] = useState(true);
+    const [dataSourceLoadError, setDataSourceLoadError] = useState<string | null>(null);
 
     const setSelectedDataSourceId = useCallback((id: string) => {
         setSelectedDataSourceIdRaw(id);
         sessionStorage.setItem(SESSION_KEY, id);
     }, []);
 
-    useEffect(() => {
-        const fetchDataSources = async () => {
+    const refreshDataSources = useCallback(async () => {
+        setIsLoadingDataSources(true);
+        setDataSourceLoadError(null);
+        try {
             // AUTH-006: when nothing is in sessionStorage yet, prefer the
             // user's saved default before falling back to "first available".
-            const [dsResult, configResult] = await Promise.all([
+            // Preferences are optional here; a failure must not hide valid connections.
+            const [dsSettled, configSettled] = await Promise.allSettled([
                 client.GET('/v1/data-sources'),
                 client.GET('/v1/users/me/config'),
             ]);
-            if (!dsResult.data?.items) return;
+
+            if (dsSettled.status === 'rejected'
+                || dsSettled.value.error
+                || !dsSettled.value.data?.items) {
+                throw new Error('The data sources request failed');
+            }
+
+            const dsResult = dsSettled.value;
             setDataSources(dsResult.data.items);
+            if (configSettled.status === 'rejected' || configSettled.value.error) {
+                console.warn('Failed to load user preferences while selecting a data source');
+            }
             const stored = sessionStorage.getItem(SESSION_KEY);
             const validStored = stored && dsResult.data.items.some((ds) => ds.id === stored);
             if (validStored) return;
-            const preferred = configResult.data?.config?.default_data_source_id;
+
+            const preferred = configSettled.status === 'fulfilled'
+                ? configSettled.value.data?.config?.default_data_source_id
+                : undefined;
             const validPreferred = preferred && dsResult.data.items.some((ds) => ds.id === preferred);
             if (validPreferred) {
                 setSelectedDataSourceId(preferred as string);
             } else if (dsResult.data.items.length > 0) {
                 setSelectedDataSourceId(dsResult.data.items[0].id);
+            } else {
+                setSelectedDataSourceId('');
             }
-        };
-        void fetchDataSources();
+        } catch (error) {
+            console.error('Failed to load data sources', error);
+            setDataSourceLoadError('We could not load your database connections. Check your connection and try again.');
+        } finally {
+            setIsLoadingDataSources(false);
+        }
     }, [setSelectedDataSourceId]);
 
+    useEffect(() => {
+        void refreshDataSources();
+    }, [refreshDataSources]);
+
     const value = useMemo(
-        () => ({ dataSources, selectedDataSourceId, setSelectedDataSourceId }),
-        [dataSources, selectedDataSourceId, setSelectedDataSourceId],
+        () => ({
+            dataSources,
+            selectedDataSourceId,
+            setSelectedDataSourceId,
+            isLoadingDataSources,
+            dataSourceLoadError,
+            refreshDataSources,
+        }),
+        [
+            dataSources,
+            selectedDataSourceId,
+            setSelectedDataSourceId,
+            isLoadingDataSources,
+            dataSourceLoadError,
+            refreshDataSources,
+        ],
     );
 
     return <DataSourceContext.Provider value={value}>{children}</DataSourceContext.Provider>;

--- a/frontend/src/contexts/dataSourceContextValue.ts
+++ b/frontend/src/contexts/dataSourceContextValue.ts
@@ -7,6 +7,9 @@ export interface DataSourceContextValue {
     dataSources: DataSource[];
     selectedDataSourceId: string;
     setSelectedDataSourceId: (id: string) => void;
+    isLoadingDataSources: boolean;
+    dataSourceLoadError: string | null;
+    refreshDataSources: () => Promise<void>;
 }
 
 export const DataSourceContext = createContext<DataSourceContextValue | null>(null);

--- a/frontend/src/pages/QueryWorkspace.tsx
+++ b/frontend/src/pages/QueryWorkspace.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import type { editor } from 'monaco-editor';
 import type { OnMount } from '@monaco-editor/react';
-import { Calendar, Loader2, Play, Save, Share2, Timer } from 'lucide-react';
+import { Calendar, Database, Loader2, Play, Save, Share2, Timer } from 'lucide-react';
 import { format as formatSql } from 'sql-formatter';
 import { toast } from 'sonner';
 import { InspectorPanel } from '../components/Query/InspectorPanel';
@@ -12,6 +12,7 @@ import { ResultSection } from '../components/Query/ResultSection';
 import { SaveQueryDialog, type SaveQueryDialogValues } from '../components/Query/SaveQueryDialog';
 import { SavedQueryParamsPanel, type ParamValues } from '../components/Query/SavedQueryParamsPanel';
 import { SqlSection } from '../components/Query/SqlSection';
+import { AsyncErrorState } from '../components/Layout/AsyncErrorState';
 import type {
     LlmProvider,
     PromptHistoryItem,
@@ -74,7 +75,14 @@ function parseRunErrorPayload(error: unknown): QueryRunErrorPayload | null {
 
 export const QueryWorkspace = () => {
     const [searchParams, setSearchParams] = useSearchParams();
-    const { dataSources, selectedDataSourceId, setSelectedDataSourceId } = useDataSource();
+    const {
+        dataSources,
+        selectedDataSourceId,
+        setSelectedDataSourceId,
+        isLoadingDataSources,
+        dataSourceLoadError,
+        refreshDataSources,
+    } = useDataSource();
     const { savedQueries, createSavedQuery, updateSavedQuery } = useSavedQueries();
     const { setActions } = useWorkspaceActions();
 
@@ -597,6 +605,42 @@ export const QueryWorkspace = () => {
     };
 
     const lastDuration = queryResult && !queryResult.preview ? `${queryResult.duration_ms}ms` : '—';
+
+    if (isLoadingDataSources && dataSources.length === 0) {
+        return (
+            <div className="flex h-full flex-col items-center justify-center text-slate-500" role="status">
+                <Loader2 size={28} className="mb-3 animate-spin text-oxblood" aria-hidden="true" />
+                <p>Loading database connections…</p>
+            </div>
+        );
+    }
+
+    if (dataSourceLoadError && dataSources.length === 0) {
+        return (
+            <div className="h-full overflow-y-auto bg-surface-container-low p-6">
+                <div className="rounded-lg border border-outline-variant bg-white shadow-sm">
+                    <AsyncErrorState
+                        title="Database connections are unavailable"
+                        message={dataSourceLoadError}
+                        onRetry={() => void refreshDataSources()}
+                        isRetrying={isLoadingDataSources}
+                    />
+                </div>
+            </div>
+        );
+    }
+
+    if (dataSources.length === 0) {
+        return (
+            <div className="flex h-full flex-col items-center justify-center px-6 text-center text-slate-500">
+                <Database size={44} className="mb-4 text-slate-300" aria-hidden="true" />
+                <p className="text-lg font-medium text-slate-900">No database connections available</p>
+                <p className="mt-1 max-w-md text-sm">
+                    Add a data source or ask an administrator to grant access before creating a query.
+                </p>
+            </div>
+        );
+    }
 
     return (
         <div className="flex h-full overflow-hidden">


### PR DESCRIPTION
## Summary
- expose loading, failure, and retry state from the shared data-source context
- prevent optional user-preference failures from hiding valid database connections
- add loading, retryable error, and genuine-empty gates to the query workspace
- surface connection loading and retry status in the global selector

## Verification
- npm run typecheck
- npm --prefix frontend run lint
- npm run build
- npm test (281 passed)

Part of #18