### PR TITLE
Add query workspace browser smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,11 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: frontend
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend
+
+      - name: End-to-end smoke test
+        run: npm run test:e2e
+        working-directory: frontend

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ pnpm-debug.log*
 coverage/
 .nyc_output/
 .cache/
+frontend/playwright-report/
+frontend/test-results/
 
 # ---- Build artifacts ----
 dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Report Pilot is a local-first NL-to-SQL reporting runtime. This file is canonica
 - `npm run build` — builds frontend (`npm run build:fe`) and backend (`npm run build:be`); backend output goes to `dist/` (compiled by `tsc`)
 - `npm start` — runs the compiled backend via `node dist/src/start.js` (used by the Docker image)
 - `npm test` — runs `node --test` with the `tsx` loader against `app/test/**/*.test.ts`
+- `npm run test:e2e` — runs the Playwright Chromium smoke suite against a local Vite server
 - `npm run typecheck`
 - `npm run migrate`
 - `npm run types:openapi` — regenerate `app/src/types/openapi.ts` from `docs/api/openapi.yaml`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ This repository now includes a local Docker setup with:
 
 For local development, use Node.js 20 or newer and run `npm run setup`. The backend uses the native TypeScript 7 compiler; `npm run types:openapi` uses an isolated TypeScript 5.9 toolchain until `openapi-typescript` supports the TypeScript 7 compiler API. In the migration benchmark, the combined backend and scripts typecheck improved from 2.43 seconds on TypeScript 5.9 to a median 0.39 seconds on TypeScript 7 (6.2x); results vary by machine and workload.
 
+## Browser smoke test
+
+Install Chromium once, then run the deterministic sign-in and natural-language query smoke flow:
+
+```bash
+npm --prefix frontend exec -- playwright install chromium
+npm run test:e2e
+```
+
+The smoke suite starts the Vite frontend automatically and provides in-browser API fixtures, so it does not require PostgreSQL, a reporting database, or LLM credentials. Pull request CI runs the same test after the frontend lint and build gates.
+
 ## Run
 
 ```bash

--- a/frontend/e2e/query-workspace.spec.ts
+++ b/frontend/e2e/query-workspace.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const DATA_SOURCE_ID = '00000000-0000-4000-8000-000000000101';
+const USER_ID = '00000000-0000-4000-8000-000000000201';
+const SESSION_ID = '00000000-0000-4000-8000-000000000301';
+const ATTEMPT_ID = '00000000-0000-4000-8000-000000000401';
+
+const user = {
+    id: USER_ID,
+    email: 'analyst@example.com',
+    display_name: 'Test Analyst',
+    roles: ['admin'],
+    permissions: [
+        'query.run',
+        'saved_queries.read',
+        'saved_queries.write',
+        'data_sources.read',
+        'users.read_self',
+    ],
+};
+
+async function installApiFixture(page: Page) {
+    let authenticated = false;
+    let createdQuestion: string | null = null;
+    let runSessionId: string | null = null;
+
+    await page.route('**/v1/**', async (route) => {
+        const request = route.request();
+        const path = new URL(request.url()).pathname;
+        const method = request.method();
+        const json = (body: unknown, status = 200) => route.fulfill({
+            status,
+            contentType: 'application/json',
+            body: JSON.stringify(body),
+        });
+
+        if (path === '/v1/auth/me') {
+            return authenticated
+                ? json({ user, expires_at: '2099-01-01T00:00:00.000Z' })
+                : json({ message: 'Authentication required' }, 401);
+        }
+        if (path === '/v1/auth/oidc/providers') {
+            return json({ items: [] });
+        }
+        if (path === '/v1/auth/login' && method === 'POST') {
+            authenticated = true;
+            return json({ user, expires_at: '2099-01-01T00:00:00.000Z' });
+        }
+        if (path === '/v1/data-sources') {
+            return json({
+                items: [{
+                    id: DATA_SOURCE_ID,
+                    name: 'Sales Warehouse',
+                    db_type: 'postgres',
+                    connection_ref: 'fixture:sales',
+                    status: 'active',
+                    created_at: '2026-01-01T00:00:00.000Z',
+                }],
+            });
+        }
+        if (path === '/v1/users/me/config') {
+            return json({ config: { default_data_source_id: DATA_SOURCE_ID } });
+        }
+        if (path === '/v1/llm/providers') {
+            return json({
+                items: [{
+                    id: '00000000-0000-4000-8000-000000000501',
+                    provider: 'openai',
+                    display_name: 'OpenAI',
+                    default_model: 'gpt-4.1-mini',
+                    enabled: true,
+                }],
+            });
+        }
+        if (path === '/v1/saved-queries') {
+            return json({ items: [] });
+        }
+        if (path === '/v1/query/prompts/history') {
+            return json({ items: [] });
+        }
+        if (path === '/v1/query/sessions' && method === 'POST') {
+            createdQuestion = (request.postDataJSON() as { question?: string }).question ?? null;
+            return json({ session_id: SESSION_ID, status: 'created' });
+        }
+        if (path === `/v1/query/sessions/${SESSION_ID}/run` && method === 'POST') {
+            runSessionId = SESSION_ID;
+            return json({
+                attempt_id: ATTEMPT_ID,
+                sql: 'SELECT region, SUM(revenue) AS total_revenue FROM sales GROUP BY region',
+                columns: ['region', 'total_revenue'],
+                rows: [{ region: 'North', total_revenue: 125000 }],
+                row_count: 1,
+                duration_ms: 24,
+                confidence: 0.95,
+                preview: false,
+                diagnostics: {
+                    schema_linking: null,
+                    prompts: { linker_chars: 120, generation_chars: 480, repair_chars: 0, total_chars: 600 },
+                    retrieval: { rag_document_count: 2, example_count: 1 },
+                    repair_count: 0,
+                },
+                provider: { name: 'openai', model: 'gpt-4.1-mini' },
+                citations: { schema_objects: [] },
+            });
+        }
+
+        return json({ message: `Unhandled fixture request: ${method} ${path}` }, 501);
+    });
+
+    return {
+        getCreatedQuestion: () => createdQuestion,
+        getRunSessionId: () => runSessionId,
+    };
+}
+
+test('signs in and completes the natural-language query flow', async ({ page }) => {
+    const api = await installApiFixture(page);
+
+    await page.goto('/query');
+    await expect(page).toHaveURL(/\/login$/);
+
+    await page.getByLabel('Email').fill('analyst@example.com');
+    await page.getByLabel('Password').fill('Password123');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+
+    await expect(page).toHaveURL(/\/query$/);
+    await expect(page.getByText('Sales Warehouse').first()).toBeVisible();
+
+    const question = 'Show total revenue by region';
+    await page.getByPlaceholder(/Adjust this query/).fill(question);
+    await page.getByRole('button', { name: 'Generate' }).click();
+
+    await expect(page.getByText('1 Rows')).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'North' })).toBeVisible();
+    await expect(page.getByRole('cell', { name: '125000' })).toBeVisible();
+    await expect(page.getByText('95.0%')).toBeVisible();
+    expect(api.getCreatedQuestion()).toBe(question);
+    expect(api.getRunSessionId()).toBe(SESSION_ID);
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.1.18",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
@@ -1058,6 +1059,22 @@
         "monaco-editor": ">= 0.25.0 < 1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@redocly/ajv": {
@@ -4134,6 +4151,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test:e2e": "playwright test",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './e2e',
+    fullyParallel: true,
+    forbidOnly: Boolean(process.env.CI),
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: process.env.CI ? 'github' : 'list',
+    use: {
+        baseURL: 'http://127.0.0.1:4173',
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+    webServer: {
+        command: 'npm run dev -- --host 127.0.0.1 --port 4173 --strictPort',
+        url: 'http://127.0.0.1:4173',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+    },
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "benchmark:large-schema": "tsx app/src/benchmark/runLargeSchemaBenchmark.ts",
     "create-user": "tsx scripts/create-user.ts",
     "test": "node --import tsx --test app/test/**/*.test.ts",
+    "test:e2e": "npm --prefix frontend run test:e2e",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json && tsc --noEmit -p tsconfig.test.json",
     "types:openapi": "npm --prefix tools/openapi-typescript run generate"
   },


### PR DESCRIPTION
## Summary
- add a Playwright Chromium smoke harness with a Vite web server
- exercise auth redirect, sign-in, data-source initialization, NL prompt submission, and rendered query results
- use deterministic in-browser API fixtures so CI needs no database or LLM credentials
- run the smoke test in frontend CI and document the local command

## Verification
- npm run typecheck
- npm --prefix frontend run lint
- npm --prefix frontend run build
- npm run test:e2e (1 passed)
- npm test (281 passed)

Part of #18