### PR TITLE
Enforce query workspace accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm --prefix frontend exec -- playwright install chromium
 npm run test:e2e
 ```
 
-The smoke suite starts the Vite frontend automatically and provides in-browser API fixtures, so it does not require PostgreSQL, a reporting database, or LLM credentials. Pull request CI runs the same test after the frontend lint and build gates.
+The smoke suite starts the Vite frontend automatically and provides in-browser API fixtures, so it does not require PostgreSQL, a reporting database, or LLM credentials. It also checks keyboard-only sign-in and query submission plus automated WCAG A/AA scans before and after execution. Pull request CI runs the same test after the frontend lint and build gates.
 
 ## Run
 

--- a/frontend/e2e/query-workspace.spec.ts
+++ b/frontend/e2e/query-workspace.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
 
 const DATA_SOURCE_ID = '00000000-0000-4000-8000-000000000101';
 const USER_ID = '00000000-0000-4000-8000-000000000201';
@@ -113,27 +114,48 @@ async function installApiFixture(page: Page) {
     };
 }
 
+async function expectNoWcagViolations(page: Page) {
+    const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .analyze();
+    expect(results.violations).toEqual([]);
+}
+
 test('signs in and completes the natural-language query flow', async ({ page }) => {
     const api = await installApiFixture(page);
 
     await page.goto('/query');
     await expect(page).toHaveURL(/\/login$/);
 
-    await page.getByLabel('Email').fill('analyst@example.com');
-    await page.getByLabel('Password').fill('Password123');
-    await page.getByRole('button', { name: 'Sign in' }).click();
+    const emailInput = page.getByLabel('Email');
+    const passwordInput = page.getByLabel('Password');
+    const signInButton = page.getByRole('button', { name: 'Sign in' });
+    await emailInput.focus();
+    await expect(emailInput).toBeFocused();
+    await emailInput.fill('analyst@example.com');
+    await page.keyboard.press('Tab');
+    await expect(passwordInput).toBeFocused();
+    await passwordInput.fill('Password123');
+    await page.keyboard.press('Tab');
+    await expect(signInButton).toBeFocused();
+    await page.keyboard.press('Enter');
 
     await expect(page).toHaveURL(/\/query$/);
     await expect(page.getByText('Sales Warehouse').first()).toBeVisible();
+    await expectNoWcagViolations(page);
 
     const question = 'Show total revenue by region';
-    await page.getByPlaceholder(/Adjust this query/).fill(question);
-    await page.getByRole('button', { name: 'Generate' }).click();
+    const questionInput = page.getByPlaceholder(/Adjust this query/);
+    await questionInput.focus();
+    await expect(questionInput).toBeFocused();
+    await questionInput.fill(question);
+    await page.keyboard.press('Enter');
 
     await expect(page.getByText('1 Rows')).toBeVisible();
     await expect(page.getByRole('cell', { name: 'North' })).toBeVisible();
     await expect(page.getByRole('cell', { name: '125000' })).toBeVisible();
     await expect(page.getByText('95.0%')).toBeVisible();
+    await expectNoWcagViolations(page);
     expect(api.getCreatedQuestion()).toBe(question);
     expect(api.getRunSessionId()).toBe(SESSION_ID);
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@eslint/js": "^9.39.1",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.1.18",
@@ -53,6 +54,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2441,6 +2455,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^9.39.1",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.1.18",

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -81,7 +81,7 @@ function NavItem({ to, label, Icon, stub }: { to: string; label: string; Icon: t
                 isActive
                     ? 'bg-white/10 text-white border-l-2 border-oxblood'
                     : 'text-slate-400 hover:bg-white/5 hover:text-white',
-                stub ? 'opacity-60' : '',
+                stub ? 'text-slate-400' : '',
             ].filter(Boolean).join(' ')}
             title={stub ? 'Coming soon' : undefined}
         >
@@ -252,7 +252,7 @@ function AppShellInner() {
                     </div>
                     <div>
                         <div className="text-base font-semibold leading-tight text-white">Workbench</div>
-                        <div className="text-[10px] font-medium text-slate-500">v2.4.0</div>
+                        <div className="text-[10px] font-medium text-slate-400">v2.4.0</div>
                     </div>
                 </div>
 
@@ -264,7 +264,7 @@ function AppShellInner() {
                     ))}
                     {adminNav.length > 0 && (
                         <div className="mt-4 space-y-1 border-t border-white/5 pt-3">
-                            <div className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-slate-500">Admin</div>
+                            <div className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-slate-400">Admin</div>
                             {adminNav.map((item) => (
                                 <NavItem key={item.path} to={item.path} label={item.label} Icon={item.icon} stub={item.stub} />
                             ))}

--- a/frontend/src/components/Query/InspectorPanel.tsx
+++ b/frontend/src/components/Query/InspectorPanel.tsx
@@ -22,7 +22,7 @@ function formatTimestamp(value: string) {
 function MetricRow({ label, value }: { label: string; value: string }) {
     return (
         <div className="flex items-center justify-between border-b border-outline-variant/60 py-1.5 last:border-0">
-            <span className="text-[11px] text-slate-500">{label}</span>
+            <span className="text-[11px] text-slate-600">{label}</span>
             <span className="font-mono text-[11px] font-medium text-on-surface">{value}</span>
         </div>
     );
@@ -31,7 +31,7 @@ function MetricRow({ label, value }: { label: string; value: string }) {
 function renderDependencies(citations: CitationCollection | undefined) {
     const schemaObjects = citations?.schema_objects ?? [];
     if (schemaObjects.length === 0) {
-        return <p className="text-[11px] text-slate-400">No dependencies tracked.</p>;
+        return <p className="text-[11px] text-slate-600">No dependencies tracked.</p>;
     }
     return (
         <div className="space-y-1">
@@ -43,7 +43,7 @@ function renderDependencies(citations: CitationCollection | undefined) {
                             {entry.schema_name}.{entry.object_name}
                         </p>
                     </div>
-                    <p className="line-clamp-1 pl-6 text-[10px] text-slate-500">{entry.object_type}</p>
+                    <p className="line-clamp-1 pl-6 text-[10px] text-slate-600">{entry.object_type}</p>
                 </div>
             ))}
         </div>
@@ -59,50 +59,54 @@ export function InspectorPanel({
     const tags = loadedSavedQuery?.tags ?? [];
 
     return (
-        <aside className="flex w-80 flex-col overflow-y-auto border-l border-outline-variant bg-white p-4">
+        <aside
+            className="flex w-80 flex-col overflow-y-auto border-l border-outline-variant bg-white p-4 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-oxblood"
+            aria-label="Query inspector"
+            tabIndex={0}
+        >
             <div className="mb-6">
-                <h2 className="mb-4 flex items-center justify-between border-b border-outline-variant pb-2 text-[10px] font-bold uppercase tracking-widest text-slate-500">
+                <h2 className="mb-4 flex items-center justify-between border-b border-outline-variant pb-2 text-[10px] font-bold uppercase tracking-widest text-slate-600">
                     Inspector
                     <Info size={14} />
                 </h2>
 
                 <div className="mb-4 rounded border border-outline-variant bg-white p-3">
                     <div className="mb-4 flex items-center justify-between">
-                        <span className="text-[10px] font-bold uppercase text-slate-500">Status</span>
-                        <span className="rounded border border-emerald-100 bg-emerald-50 px-2 py-0.5 text-[10px] font-bold uppercase text-emerald-600">
+                        <span className="text-[10px] font-bold uppercase text-slate-600">Status</span>
+                        <span className="rounded border border-emerald-100 bg-emerald-50 px-2 py-0.5 text-[10px] font-bold uppercase text-emerald-700">
                             {loadedSavedQuery ? 'Saved' : 'Draft'}
                         </span>
                     </div>
                     <div className="space-y-3">
                         {loadedSavedQuery && (
                             <div>
-                                <p className="mb-1 text-[10px] font-bold uppercase text-slate-500">Source</p>
+                                <p className="mb-1 text-[10px] font-bold uppercase text-slate-600">Source</p>
                                 <p className="flex items-start gap-1.5 text-[12px] font-semibold text-on-surface">
                                     <Bookmark size={14} className="mt-0.5 shrink-0 text-oxblood" />
                                     <span className="break-words">{loadedSavedQuery.name}</span>
                                 </p>
                                 {loadedSavedQuery.description && (
-                                    <p className="mt-1 line-clamp-3 pl-5 text-[11px] text-slate-500">
+                                    <p className="mt-1 line-clamp-3 pl-5 text-[11px] text-slate-600">
                                         {loadedSavedQuery.description}
                                     </p>
                                 )}
-                                <p className="mt-1.5 flex items-center gap-1 pl-5 text-[10px] text-slate-400">
+                                <p className="mt-1.5 flex items-center gap-1 pl-5 text-[10px] text-slate-600">
                                     <Clock size={10} />
                                     Updated {formatTimestamp(loadedSavedQuery.updated_at)}
                                 </p>
                             </div>
                         )}
                         <div>
-                            <p className="mb-1 text-[10px] font-bold uppercase text-slate-500">Data Source</p>
+                            <p className="mb-1 text-[10px] font-bold uppercase text-slate-600">Data Source</p>
                             <p className="flex items-center gap-1.5 text-[12px] font-semibold text-on-surface">
                                 <Database size={14} className="text-oxblood" />
                                 {selectedDataSource?.name || 'No data source selected'}
                             </p>
                         </div>
                         <div>
-                            <p className="mb-2 text-[10px] font-bold uppercase text-slate-500">Tags</p>
+                            <p className="mb-2 text-[10px] font-bold uppercase text-slate-600">Tags</p>
                             {tags.length === 0 ? (
-                                <p className="text-[11px] text-slate-400">No tags assigned.</p>
+                                <p className="text-[11px] text-slate-600">No tags assigned.</p>
                             ) : (
                                 <div className="flex flex-wrap gap-1.5">
                                     {tags.map((tag) => (
@@ -148,7 +152,7 @@ export function InspectorPanel({
                             <MetricRow label="Model" value={queryResult.provider?.model || 'N/A'} />
                         </div>
                     ) : (
-                        <p className="text-[11px] text-slate-400">
+                        <p className="text-[11px] text-slate-600">
                             {isDryRun ? 'Preview SQL to see metadata.' : 'Run the query to see metadata.'}
                         </p>
                     )}
@@ -171,25 +175,25 @@ export function InspectorPanel({
                             <div className="h-1 flex-1 overflow-hidden rounded-full bg-outline-variant">
                                 <div className="h-full w-1/4 bg-emerald-500" />
                             </div>
-                            <span className="font-mono text-[9px] text-slate-500">JOIN</span>
+                            <span className="font-mono text-[9px] text-slate-600">JOIN</span>
                         </div>
                         <div className="flex items-center gap-2">
                             <div className="h-1.5 w-1.5 rounded-full bg-amber-accent" />
                             <div className="h-1 flex-1 overflow-hidden rounded-full bg-outline-variant">
                                 <div className="h-full w-3/4 bg-amber-accent" />
                             </div>
-                            <span className="font-mono text-[9px] text-slate-500">SCAN</span>
+                            <span className="font-mono text-[9px] text-slate-600">SCAN</span>
                         </div>
                     </div>
                     <div className="mt-3 flex items-center justify-between border-t border-outline-variant pt-2">
-                        <span className="font-mono text-[9px] text-slate-500">PLACEHOLDER</span>
-                        <span className="text-[9px] uppercase text-slate-400">Coming soon</span>
+                        <span className="font-mono text-[9px] text-slate-600">PLACEHOLDER</span>
+                        <span className="text-[9px] uppercase text-slate-600">Coming soon</span>
                     </div>
                 </div>
             </div>
 
             <div className="mt-auto rounded border border-outline-variant bg-white p-4">
-                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-500 opacity-70">System Health</p>
+                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-slate-600">System Health</p>
                 <p className="mb-2 text-sm font-bold tracking-tight text-on-surface">Performance Optimal</p>
                 <svg viewBox="0 0 200 32" className="h-8 w-full text-amber-accent" preserveAspectRatio="none">
                     <polyline

--- a/frontend/src/components/Query/ResultSection.tsx
+++ b/frontend/src/components/Query/ResultSection.tsx
@@ -63,13 +63,13 @@ export function ResultSection({ queryResult, isRunning, isDryRun }: ResultSectio
                 )}
 
                 {!queryResult && !isRunning && (
-                    <div className="flex h-full flex-col items-center justify-center p-8 text-slate-400">
+                    <div className="flex h-full flex-col items-center justify-center p-8 text-slate-600">
                         <p>No results yet. {isDryRun ? 'Preview SQL to inspect the generated response.' : 'Run a query to see results.'}</p>
                     </div>
                 )}
 
                 {isRunning && (
-                    <div className="flex h-full items-center justify-center text-slate-400">
+                    <div className="flex h-full items-center justify-center text-slate-600">
                         <Loader2 className="mr-2 animate-spin" size={20} />
                         {isDryRun ? 'Generating preview…' : 'Executing query…'}
                     </div>
@@ -77,7 +77,7 @@ export function ResultSection({ queryResult, isRunning, isDryRun }: ResultSectio
 
                 {queryResult && !queryResult.preview && (
                     <table className="w-full border-collapse text-left">
-                        <thead className="sticky top-0 z-10 border-b border-outline-variant bg-surface-container-low text-slate-500">
+                        <thead className="sticky top-0 z-10 border-b border-outline-variant bg-surface-container-low text-slate-600">
                             <tr className="text-[11px] uppercase tracking-wider">
                                 <th className="border-r border-outline-variant/40 bg-surface-container px-4 py-2 font-bold">#</th>
                                 {queryResult.columns.map((column) => (
@@ -96,7 +96,7 @@ export function ResultSection({ queryResult, isRunning, isDryRun }: ResultSectio
                                     key={`${queryResult.attempt_id}-${rowIndex}`}
                                     className="border-b border-outline-variant/40 transition-colors hover:bg-surface-container-low"
                                 >
-                                    <td className="border-r border-outline-variant/40 bg-surface-container-low px-4 py-2 text-xs text-slate-400">
+                                    <td className="border-r border-outline-variant/40 bg-surface-container-low px-4 py-2 text-xs text-slate-600">
                                         {rowIndex + 1}
                                     </td>
                                     {queryResult.columns.map((column) => (

--- a/frontend/src/components/Query/SqlSection.tsx
+++ b/frontend/src/components/Query/SqlSection.tsx
@@ -23,7 +23,7 @@ export function SqlSection({
     return (
         <div className="flex flex-[0.45] flex-col overflow-hidden border-b border-outline-variant bg-white">
             <div className="flex h-9 shrink-0 items-center justify-between border-b border-outline-variant bg-surface-container-low px-4">
-                <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">
                     Generated SQL
                 </span>
                 <div className="flex items-center gap-1">
@@ -61,7 +61,7 @@ export function SqlSection({
             </div>
             <div className="min-h-0 flex-1 bg-white">
                 {isGenerating ? (
-                    <div className="flex h-full items-center justify-center text-sm text-slate-400">
+                    <div className="flex h-full items-center justify-center text-sm text-slate-600">
                         <Loader2 className="mr-2 animate-spin" size={16} />
                         Generating SQL…
                     </div>
@@ -83,7 +83,7 @@ export function SqlSection({
                         }}
                     />
                 ) : (
-                    <div className="flex h-full items-center justify-center p-4 text-center text-sm text-slate-400">
+                    <div className="flex h-full items-center justify-center p-4 text-center text-sm text-slate-600">
                         Generate a query or load a saved one to start editing SQL.
                     </div>
                 )}


### PR DESCRIPTION
## Summary
- add automated WCAG A/AA scans before and after query execution
- cover keyboard-only sign-in, focus progression, and Enter-to-submit behavior
- raise contrast for secondary query-workspace and navigation text
- make the scrollable query inspector keyboard-focusable with a visible focus ring

## Verification
- npm run test:e2e (1 passed; 2 axe scans with zero violations)
- npm --prefix frontend run lint
- npm --prefix frontend run build
- npm run typecheck
- npm test (281 passed)

Closes #18